### PR TITLE
Keep the repository boundary tests in test

### DIFF
--- a/docs/guide/develop.md
+++ b/docs/guide/develop.md
@@ -42,7 +42,7 @@ narratage/
 ├── docs/                  VitePress documentation site
 ├── examples/              runnable example sources
 ├── services/              Python services (whisperx, image-opencv)
-├── tools/                 boundary tests and build scripts
+├── test/                  repository boundary tests and shared fixtures
 ├── package.json           root workspace manifest
 ├── pnpm-workspace.yaml    workspace: [packages/*]
 └── tsconfig.json          TypeScript config

--- a/docs/zh/guide/develop.md
+++ b/docs/zh/guide/develop.md
@@ -42,7 +42,7 @@ narratage/
 ├── docs/                  VitePress documentation site
 ├── examples/              runnable example sources
 ├── services/              Python 服务 (whisperx, image-opencv)
-├── tools/                 boundary tests and build scripts
+├── test/                  repository boundary tests and shared fixtures
 ├── package.json           root workspace manifest
 ├── pnpm-workspace.yaml    workspace: [packages/*]
 └── tsconfig.json          TypeScript config

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
     "test": "node --import tsx --test 'packages/*/test/**/*.test.ts' 'services/*/test/**/*.test.ts' 'test/**/*.test.ts'",
-    "test:release": "node --import tsx --test tools/repository-hygiene.test.mjs",
+    "test:release": "node --import tsx --test test/repository-hygiene.test.mjs",
     "test:whisperx-service": "uv run --project services/whisperx --frozen python -m unittest discover -s services/whisperx/tests -p 'test_*.py'",
     "test:browser-visual": "NARRATAGE_BROWSER_TESTS=1 node --import tsx --test packages/hyperframes/test/browser-visual.test.ts",
     "test:image-opencv": "NARRATAGE_OPENCV_TESTS=1 NARRATAGE_OPENCV_PYTHON=services/image-opencv/.venv/bin/python node --import tsx --test packages/provider-image-opencv-local/test/provider.test.ts",

--- a/test/repository-hygiene.test.mjs
+++ b/test/repository-hygiene.test.mjs
@@ -5,7 +5,7 @@ import test from "node:test";
 import ts from "typescript";
 
 const repositoryRoot = new URL("../", import.meta.url);
-const scanRoots = ["docs", "examples", "packages", "services", "test", "tools"];
+const scanRoots = ["docs", "examples", "packages", "services", "test"];
 const rootTextFiles = ["README.md", "package.json", "pnpm-workspace.yaml", "tsconfig.json"];
 const ignoredDirectories = new Set(["node_modules", "dist", "output", ".narratage", ".svml", ".vitepress"]);
 const textExtensions = new Set([


### PR DESCRIPTION
## Why

Once the Playgrounds moved to `packages/`, `tools/` held exactly one file — and that file is a test. A directory named for tools that contains no tool only invites the question of what belongs there.

`test/` already owns repository-level material: it holds `fixture-digest.ts` and `support/video-domain.ts`, the shared fixtures these boundary tests read. The test belongs beside them.

## What changed

- `tools/repository-hygiene.test.mjs` → `test/repository-hygiene.test.mjs`, and `tools/` is gone
- `test:release` points at the new path
- `scanRoots` drops `"tools"`
- The layout guide named `tools/` but never named `test/`, so the entry is replaced rather than removed

`repositoryRoot` resolves through `../`, which reaches the repository root from `test/` exactly as it did from `tools/`, so no path arithmetic changed.

## The one thing that would have broken

`scanRoots` had to lose `"tools"` in the same commit that removes the directory. The scan reads each root directly, and `readdir` on a missing directory throws — leaving the name behind would have failed all four tests with ENOENT instead of a boundary report. Verified that `readdir` throws before relying on it.

`pnpm test` globs `test/**/*.test.ts`, and this file is `.mjs`, so it is not swept into the main suite. It stays independently run by `test:release`, which is what both CI workflows call.

## Verification

- `pnpm test:release` — 4/4 from the new location, with `tools/` genuinely absent rather than merely empty
- Detection confirmed still live, not vacuous: planting a workstation path in a scanned root failed the test with `packages/protocol/src/__probe.ts:1 (workstation path)`, and it went green again once removed
- `pnpm install --frozen-lockfile`, `tsc -p tsconfig.json --noEmit` clean, `pnpm test` 527 tests / 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)