### PR TITLE
Draw what the playhead passes through without competing

### DIFF
--- a/packages/svml-playground/src/style.css
+++ b/packages/svml-playground/src/style.css
@@ -75,9 +75,13 @@ main { flex:1; min-height:0; display:grid; grid-template-columns:minmax(0,1fr) a
 .spoken { position:absolute; z-index:0; pointer-events:none; border-radius:3px; background:#ffd34d26; box-shadow:inset 0 0 0 1px #ffd34d66; transition:left .08s linear, width .08s linear; }
 .range { transition:opacity .08s linear; }
 .range-element { fill:#ffffff14; stroke:#ffffff; stroke-width:1.5; }
-/* Drawn at this frame, but not the thing chosen. Present without competing. */
-.range-binding { fill:color-mix(in srgb, var(--tone, var(--marker)) 12%, transparent);
-  stroke:var(--tone, var(--marker)); stroke-width:1.5; }
+/* Drawn at this frame, but not the thing chosen. Present without competing.
+   A solid outline of the same weight as the chosen one read as a second
+   selection, so what the playhead is merely passing through is dashed and
+   thinner: still legible as nesting, no longer a claim that it was picked. */
+.range-binding { fill:color-mix(in srgb, var(--tone, var(--marker)) 7%, transparent);
+  stroke:color-mix(in srgb, var(--tone, var(--marker)) 55%, transparent);
+  stroke-width:1; stroke-dasharray:3 3; }
 
 /* The picture takes the room that is left; the strip and the timeline are rows
    of the layout, so neither can ever cover the frame or the transport. */


### PR DESCRIPTION
## The report

After deselecting, the Source pane kept outlining Selections while the inspector read "nothing", the timeline cleared its clip, and the picture dropped its box. It read as a stale box that had failed to update — and it only happened *sometimes*.

## What is actually happening

Nothing was stale, and every pane was doing what it was told.

Those outlines follow the **playhead**, not the selection. `liveRanges` (`markers.ts:102`) filters Selections by frame alone and never looks at the selection. `clearSelection()` deliberately does not move the playhead, so a Selection the playhead still sits inside stays outlined — which `main.ts:167` documents as the point, since it is how nesting stays visible.

The intermittency has the same cause. Whether the outline disappears depends on whether the deselect happened to move the playhead:

| deselect via | playhead | outline |
|---|---|---|
| open timeline track | 145 → **290** (scrubbed out) | clears |
| Escape | 145 → **145** | stays |
| unmarked source line | 145 → **145** | stays |

Clearing from open track also scrubs, so the outline went away for a reason that had nothing to do with the Selection being let go. That is what made it look like a bug that struck at random.

## The actual defect

It was not the behaviour, it was the drawing. `style.css:78` already said what it wanted —

> Drawn at this frame, but not the thing chosen. Present without competing.

— and then gave binding a solid stroke at `stroke-width:1.5`, the same weight `.range-element` uses for the chosen element. Being passed through was drawn identically to being picked, so the two could not be told apart.

Binding is now dashed, thinner and dimmer. Verified computed styles with both present at once:

| | stroke | width | dash |
|---|---|---|---|
| `.range-binding` | tone at **0.55** alpha | 1px | `3px, 3px` |
| `.range-element` | solid **white** | 1.5px | none |

The nesting still reads; only what was chosen keeps a solid outline. No behaviour changed, so the documented design is left intact.

## Verification

Reproduced and confirmed by driving the running Playground with a headless browser against `examples/talking-film-broll-preview`, probing `.clip.selected`, the SVG outline classes, the stage overlay and the inspector across each deselect path. Captured the pane before and after the change, and read back computed styles to confirm the two treatments are distinguishable.

`tsc -p tsconfig.json --noEmit` clean, `pnpm test` 527 tests / 0 failures, `pnpm test:release` 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)