### PR TITLE
Place the caption outline outside the letter

### DIFF
--- a/packages/caption-fine/src/manifest.ts
+++ b/packages/caption-fine/src/manifest.ts
@@ -76,7 +76,7 @@ export const captionFineMarkupSurfaces = [
               { name: "stroke-color", required: false, fallback: "#000000",
                 summary: "Paints the outline drawn around each glyph." },
               { name: "stroke-width", required: false, fallback: "0",
-                summary: "Sets the glyph outline thickness in pixels. The outline is drawn behind the glyph body, so it grows outward and leaves the letterform whole. An outline that only has to separate the caption from the picture behind it is thin — around a twentieth of `size`, so roughly 2px at a `size` of 46. It grows quickly: past about a tenth of `size` neighbouring letters meet, the gaps between them close, and the caption reads as a slab rather than as words." },
+                summary: "Sets the glyph outline thickness in pixels. The outline is placed outside the letter, so the whole width shows and the letterform keeps its shape. An outline that only has to separate the caption from the picture behind it is thin — around a twentieth of `size`, so roughly 2px at a `size` of 46. It grows quickly: past about a tenth of `size` neighbouring letters meet, the gaps between them close, and the caption reads as a slab rather than as words." },
               { name: "shadow-color", required: false, fallback: "#000000",
                 summary: "Paints the soft drop shadow behind each glyph." },
               { name: "shadow-opacity", required: false, fallback: "0",

--- a/packages/caption-fine/src/render.ts
+++ b/packages/caption-fine/src/render.ts
@@ -4,10 +4,12 @@ import { assertVisualTrackIdentity, sealVisualTrack } from "@hypit/composition";
 import type {
   VisualAnimation,
   VisualBoxElement,
+  VisualColorPaint,
   VisualElement,
   VisualKeyframe,
   VisualStyleDeclaration,
   VisualTextElement,
+  VisualTextPaintLayer,
   VisualTrack,
 } from "@hypit/composition";
 import type { CaptionDisplayAtom, CaptionDisplaySequence } from "@hypit/narrative";
@@ -58,6 +60,44 @@ function underlineStyle(underline: FineCaptionUnderline | FineCaptionActiveUnder
   ];
 }
 
+/**
+ * The glyph body and its outline, as ordered Paint.
+ *
+ * An outline belongs outside the letter. `-webkit-text-stroke` cannot put it there: it centres the
+ * stroke on the glyph edge, so half the width is always inside, and the only choice left is which
+ * half gets painted over. Declaring the Paint hands the placement to the renderer, which builds the
+ * ring by dilating the glyph and subtracting it from itself — wholly outside, at the width asked
+ * for rather than half of it.
+ *
+ * A caption with no outline keeps its plain fill, which is one element and one paint rather than
+ * two, and is what most captions are.
+ */
+function glyphPaints(paint: FineCaptionGlyphPaint): VisualTextPaintLayer[] | undefined {
+  if (paint.stroke.widthPx === 0) return undefined;
+  const fill: VisualColorPaint = paint.gradient === undefined
+    ? { kind: "solid", color: paint.fill }
+    : {
+        kind: "linear-gradient",
+        angleDeg: paint.gradient.angleDeg,
+        stops: [
+          { offset: 0, color: paint.gradient.from, opacity: 1 },
+          { offset: 1, color: paint.gradient.to, opacity: 1 },
+        ],
+      };
+  // Outline first: the layers stack in the order they are declared, and the body sits over its own
+  // outline rather than the other way round.
+  return [
+    { kind: "stroke", placement: "outside", widthPx: paint.stroke.widthPx, paint: { kind: "solid", color: paint.stroke.color } },
+    { kind: "fill", paint: fill },
+  ];
+}
+
+/** The Paint fields of a text element, absent rather than empty when there is no outline. */
+function glyphPaintFields(paint: FineCaptionGlyphPaint): { paints?: readonly VisualTextPaintLayer[] } {
+  const paints = glyphPaints(paint);
+  return paints === undefined ? {} : { paints };
+}
+
 function glyphStyle(
   parameters: FineCaptionParameters,
   paint: FineCaptionGlyphPaint,
@@ -88,28 +128,19 @@ function glyphStyle(
       ].join(" "));
     }
   }
+  // An outlined caption carries its body and outline as Paint instead, so the fill is spelled once
+  // — there, not here — and the two cannot disagree.
+  const painted = glyphPaints(paint) !== undefined;
   return [
-    { name: "color", value: paint.fill },
+    ...(painted ? [] : [{ name: "color", value: paint.fill }] as const),
     ...typographyStyle(parameters),
     { name: "opacity", value: paint.opacity },
     { name: "white-space", value: "nowrap" },
-    ...(paint.gradient === undefined ? [] : [
+    ...(painted || paint.gradient === undefined ? [] : [
       { name: "background-image", value: `linear-gradient(${compactNumber(paint.gradient.angleDeg)}deg,${paint.gradient.from},${paint.gradient.to})` },
       { name: "background-clip", value: "text" },
       { name: "-webkit-background-clip", value: "text" },
       { name: "-webkit-text-fill-color", value: "transparent" },
-    ] as const),
-    ...(paint.stroke.widthPx === 0 ? [] : [
-      { name: "-webkit-text-stroke-color", value: paint.stroke.color },
-      { name: "-webkit-text-stroke-width", value: `${compactNumber(paint.stroke.widthPx)}px` },
-      // A text stroke is centred on the glyph outline, so half of it falls inside the letter. Left
-      // in the default order the browser fills first and strokes over the top, and that inner half
-      // is painted away: every stroke of every letter is separately narrowed, the counters of a, e
-      // and o close, and where two letters kern tightly one letter's outline crosses its
-      // neighbour's face. Putting the stroke first spends the same width the other way — the fill
-      // lands on top of it, and what is left showing is one contour around the outside of the
-      // word, which is what an outline is for.
-      { name: "paint-order", value: "stroke fill" },
     ] as const),
     ...(shadows.length === 0 ? [] : [{ name: "text-shadow", value: shadows.join(",") }] as const),
     ...(underline === undefined ? [] : underlineStyle(underline)),
@@ -670,6 +701,7 @@ function cueElements(
         kind: "text",
         text,
         style: glyphStyle(parameters, parameters.basePaint, parameters.underline),
+        ...glyphPaintFields(parameters.basePaint),
         fonts,
         attributes: [{ name: "data-caption-word", value: wordId }],
       });
@@ -707,6 +739,8 @@ function cueElements(
           style: kind === "glyph"
             ? glyphStyle(parameters, parameters.activePaint)
             : transparentGlyphStyle(parameters, parameters.activeUnderline),
+          // The underline layer paints no glyph at all, so it declares no glyph Paint either.
+          ...(kind === "glyph" ? glyphPaintFields(parameters.activePaint) : {}),
           fonts,
           attributes: [{ name: kind === "glyph" ? "data-caption-active-word" : "data-caption-underlined-word", value: wordId }],
         });

--- a/packages/caption-fine/test/caption-fine.test.ts
+++ b/packages/caption-fine/test/caption-fine.test.ts
@@ -459,17 +459,29 @@ test("full Fine Paint and layered motion lower to terminal Visual IR without cha
   const elements = renderFineCaption(projection, program, display, space).presents[0]!.elements;
   const base = elements.find((element) => element.id === "atom-1-base-1");
   assert.equal(base?.kind, "text");
-  assert.ok(base?.style.some(({ name }) => name === "background-image"));
   assert.ok(base?.style.some(({ name, value }) => name === "text-transform" && value === "uppercase"));
   assert.ok(base?.style.some(({ name }) => name === "text-decoration-thickness"));
   assert.ok(base?.style.some(({ name, value }) => name === "text-shadow" && String(value).split(",").length >= 8));
-  // The outline is only an outline when it is painted behind the body it outlines; the other way
-  // round it eats the letterform it was meant to separate from the picture.
-  assert.ok(base?.style.some(({ name }) => name === "-webkit-text-stroke-width"));
-  assert.ok(base?.style.some(({ name, value }) => name === "paint-order" && value === "stroke fill"));
+  // The outline is declared as Paint placed outside the letter, not as a centred stroke that would
+  // spend half its width inside. A centred stroke is what the style vocabulary can say, so the
+  // absence of one here is as much the point as the presence of the Paint.
+  assert.deepEqual(base?.paints, [
+    { kind: "stroke", placement: "outside", widthPx: 3, paint: { kind: "solid", color: "#101010" } },
+    { kind: "fill", paint: { kind: "linear-gradient", angleDeg: 120, stops: [
+      { offset: 0, color: "#FFFFFF", opacity: 1 },
+      { offset: 1, color: "#60A5FA", opacity: 1 },
+    ] } },
+  ]);
+  assert.ok(!base?.style.some(({ name }) => name.startsWith("-webkit-text-stroke")));
+  // The body is spelled once, in the Paint, so the style does not also colour it.
+  assert.ok(!base?.style.some(({ name }) => name === "color" || name === "background-clip"));
   const activeGlyph = elements.find((element) => element.id === "atom-1-active-1");
   assert.equal(activeGlyph?.kind, "text");
-  assert.ok(activeGlyph?.style.some(({ name }) => name === "background-image"));
+  // The spoken Word carries its own gradient and its own outline, in the same vocabulary.
+  assert.equal(activeGlyph?.paints?.[0]?.kind, "stroke");
+  const activeFill = activeGlyph?.paints?.[1];
+  assert.equal(activeFill?.kind, "fill");
+  assert.equal(activeFill?.kind === "fill" ? activeFill.paint.kind : undefined, "linear-gradient");
   const joined = elements.filter((element) => element.attributes?.some((attribute) =>
     attribute.name === "data-caption-active-box" && attribute.value === "joined"));
   assert.equal(joined.length, display.atoms.length);

--- a/packages/composition/src/track.ts
+++ b/packages/composition/src/track.ts
@@ -73,6 +73,15 @@ export type VisualTextElement = VisualElementBase & {
   readonly text: string;
   /** Exact ordered fallback faces. Terminal Visual IR never depends on environment fonts. */
   readonly fonts: readonly FontArtifactRef[];
+  /**
+   * Ordered glyph Paint, in the same vocabulary Text Flow uses.
+   *
+   * Style alone can only say `-webkit-text-stroke`, which centres an outline on the glyph edge and
+   * therefore spends half its width inside the letter. An outline that is asked to sit outside the
+   * letter cannot be expressed that way at all. Declaring the Paint instead lets the renderer build
+   * the placement that was asked for, and `stroke` before `fill` orders them.
+   */
+  readonly paints?: readonly VisualTextPaintLayer[];
 };
 
 export type VisualTextDirection = "auto" | "ltr" | "rtl";
@@ -942,10 +951,22 @@ function assertPresent(present: VisualPresent, programSpace: ProgramSpace | unde
       }
     }
     if (element.kind === "text") {
-      assertExactFonts(element.fonts, `${trackId}.${present.id}.${element.id}.fonts`);
+      const label = `${trackId}.${present.id}.${element.id}`;
+      assertExactFonts(element.fonts, `${label}.fonts`);
       const ownedFontStyles = new Set(["font", "font-family", "font-style", "font-synthesis", "font-weight"]);
       if (element.style.some((declaration) => ownedFontStyles.has(declaration.name))) {
-        throw new Error(`${trackId}.${present.id}.${element.id} exact fonts conflict with a raw font style.`);
+        throw new Error(`${label} exact fonts conflict with a raw font style.`);
+      }
+      for (const [index, paint] of (element.paints ?? []).entries()) {
+        assertTextPaint(paint, `${label}.paints.${index}`);
+        // Box Paint decorates a laid-out run, and this element has no layout to decorate.
+        if (paint.kind === "box") throw new Error(`${label}.paints.${index} is Box Paint on a plain text element.`);
+      }
+      // Two ways to say the same thing render twice: the declared Paint draws the glyph, and the
+      // style would draw it again underneath.
+      const paintedStyles = new Set(["-webkit-text-stroke", "-webkit-text-stroke-color", "-webkit-text-stroke-width", "paint-order"]);
+      if (element.paints !== undefined && element.style.some((declaration) => paintedStyles.has(declaration.name))) {
+        throw new Error(`${label} declares glyph Paint beside a raw stroke style.`);
       }
     }
     if (element.kind === "text-flow" || element.kind === "path-text") {
@@ -1110,6 +1131,7 @@ function normalizeElement(element: VisualElement): VisualElement {
           weight: font.weight,
           style: font.style,
         })),
+      ...(element.paints === undefined ? {} : { paints: structuredClone(element.paints) as VisualTextPaintLayer[] }),
     };
   }
   if (element.kind === "text-flow" || element.kind === "path-text") {

--- a/packages/hyperframes/src/document.ts
+++ b/packages/hyperframes/src/document.ts
@@ -28,6 +28,7 @@ import type {
 } from "./types.js";
 import {
   collectTerminalTextFonts,
+  renderGlyphPaintedString,
   renderTerminalTextElement,
   terminalTextLayoutScript,
 } from "./text.js";
@@ -332,22 +333,28 @@ function renderElement(
     .map((child) => renderElement(child, children, context))
     .join("");
   if (element.kind === "box") return `<div ${common}>${descendants}</div>`;
-  if (element.kind === "text") return `<div ${common}>${escapeHtml(element.text)}${descendants}</div>`;
+  const textContext = {
+    trackId: context.trackId,
+    presentId: context.presentId,
+    durationFrames: context.presentDurationFrames,
+    durationSeconds: context.presentDuration,
+    presentStartFrame: context.presentStartFrame,
+    programNumerator: context.programNumerator,
+    programDenominator: context.programDenominator,
+    escape: escapeHtml,
+    stableId: stableDomId,
+    exactFontFamily,
+    baseStyle: inlineStyle,
+    commonAttributes,
+  };
+  if (element.kind === "text") {
+    const body = element.paints === undefined
+      ? escapeHtml(element.text)
+      : renderGlyphPaintedString(element.text, element.paints, textContext);
+    return `<div ${common}>${body}${descendants}</div>`;
+  }
   if (element.kind === "text-flow" || element.kind === "path-text") {
-    return renderTerminalTextElement(element, {
-      trackId: context.trackId,
-      presentId: context.presentId,
-      durationFrames: context.presentDurationFrames,
-      durationSeconds: context.presentDuration,
-      presentStartFrame: context.presentStartFrame,
-      programNumerator: context.programNumerator,
-      programDenominator: context.programDenominator,
-      escape: escapeHtml,
-      stableId: stableDomId,
-      exactFontFamily,
-      baseStyle: inlineStyle,
-      commonAttributes,
-    });
+    return renderTerminalTextElement(element, textContext);
   }
   if ((element.kind === "video" || element.kind === "surface") && element.sampling !== undefined) {
     const artifact = element.kind === "surface" ? element.surface.artifact : element.artifact;

--- a/packages/hyperframes/src/text.ts
+++ b/packages/hyperframes/src/text.ts
@@ -247,6 +247,9 @@ function glyphLayerCss(
     ...common,
     "color:#ffffff",
     "-webkit-text-fill-color:#ffffff",
+    // The filter builds its shape out of this layer's own alpha, so anything inherited that also
+    // marks the glyph — a shadow from the element around it — would be dilated along with it.
+    "text-shadow:none",
     `filter:url(#${glyphFilterId(paint, context)})`,
   ];
 }
@@ -260,6 +263,32 @@ function renderGlyphPaint(
   if (layers.length === 0) return context.escape(value);
   const singleSolidFill = layers.length === 1 && layers[0]?.kind === "fill" && layers[0].paint.kind === "solid";
   return layers.map((paint, index) => `<span aria-hidden="${index === layers.length - 1 ? "false" : "true"}" data-hypit-text-paint-layer="${index}"${styleAttribute(glyphLayerCss(paint, singleSolidFill, context), context.escape)}>${context.escape(value)}</span>`).join("");
+}
+
+/**
+ * Render one plain string as ordered glyph Paint, with the filter definitions it needs.
+ *
+ * Text Flow reaches these layers through its document structure, a run at a time. A plain text
+ * element has no structure to walk — its whole content is one string — so it arrives here instead.
+ * Both end up in the same layers, drawn by the same filters, which is the point: an outline placed
+ * outside the letter is one thing, not one thing per element kind.
+ */
+export function renderGlyphPaintedString(
+  value: string,
+  paints: readonly VisualTextPaintLayer[],
+  context: TextRenderContext,
+): string {
+  const layers = glyphPaintLayers(paints);
+  if (layers.length === 0) return context.escape(value);
+  const shaped = layers.filter((paint): paint is Extract<GlyphPaintLayer, { kind: "stroke" | "shadow" | "glow" }> =>
+    paint.kind !== "fill");
+  const definitions = [...new Map(shaped.map((paint) => [canonicalStringify(paint), paint])).values()]
+    .map((paint) => glyphFilterDefinition(paint, context)).join("");
+  const defs = definitions.length === 0
+    ? ""
+    : `<svg aria-hidden="true" width="0" height="0" style="position:absolute;overflow:hidden"><defs>${definitions}</defs></svg>`;
+  // The layers occupy one grid cell each so they stack in the order they were declared.
+  return `${defs}<span style="position:relative;display:inline-grid">${renderGlyphPaint(value, paints, context)}</span>`;
 }
 
 function boxLayers(


### PR DESCRIPTION
The previous change put the caption's centred stroke behind the fill, which stopped it eating the letterform but left it showing at half the authored width — and did nothing at all when the fill is a gradient, because a gradient fill is a `background-clip: text` background and `paint-order` only orders the text's own fill and stroke. Both are symptoms of the same thing: a text stroke is centred on the glyph edge, so half its width is inside the letter no matter what, and the only remaining choice is which half gets painted over.

Placing an outline needs Paint rather than style. Text Flow already has that vocabulary — a stroke layer carries `placement`, and the renderer builds the ring by dilating the glyph alpha and compositing the glyph out of it, so nothing of the letter is spent. Caption Fine could not reach it because it emits the plain text element, which had no Paint. That element now carries the same `paints` field Text Flow does: the same `VisualTextPaintLayer` type, the same `assertTextPaint` validation, the same filters. Caption Fine keeps its per-word elements, karaoke layers and Pill unchanged.

## Measured

Rendered through the real pipeline at size 64, outline 8px, and counted from the framebuffer:

| | letter body | outline ring | total ink |
|---|---|---|---|
| no outline | 2957 | 0 | 3678 |
| outside outline (this change) | **2957** | 9345 | 13024 |
| centred stroke behind fill (before) | 2957 | 3044 | 8558 |

The body is identical to the no-outline baseline to the pixel — the outline takes nothing from the letter — and the ring is three times what a centred stroke could show at the same width.

The emitted document contains `feMorphology operator="dilate" radius="8"` and the `out` composite, and no `-webkit-text-stroke` anywhere.

## Also

- A filter layer sets `text-shadow:none`. It shapes itself from its own alpha, so a shadow inherited from the element around it would be dilated into the outline. This applies to Text Flow too, where it was latent.
- A plain text element may not declare Paint beside a raw stroke style — two ways to say one thing, and both would draw.
- The manifest said an outline past a tenth of `size` closes the counters of a, e and o. That was describing the centred stroke; the outline now grows outward and what a heavy one closes is the gap between letters.

## Known limit

Shadow, glow and long shadow stay as CSS `text-shadow`. Long shadow is up to 32 stacked shadows and the IR shadow Paint is a single offset, so they cannot move across without losing it. They therefore paint above the ring rather than beneath it. Every recipe in the repository uses a dark outline with a dark shadow, so it does not show; a light shadow over a dark outline would.

## Verification

`pnpm check`, `pnpm test` (544, 0 failures), `pnpm test:release` (8), and `pnpm test:browser-visual` (12 against a real browser) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)