### PR TITLE
Draw a caption's shadows behind its outline

### DIFF
--- a/packages/caption-fine/src/render.ts
+++ b/packages/caption-fine/src/render.ts
@@ -72,6 +72,60 @@ function underlineStyle(underline: FineCaptionUnderline | FineCaptionActiveUnder
  * A caption with no outline keeps its plain fill, which is one element and one paint rather than
  * two, and is what most captions are.
  */
+/**
+ * CSS blur is a radius; a Gaussian blur is a deviation. The radius covers about two deviations, so
+ * the same number means twice the cloud when it moves from one to the other. Authors tuned these
+ * against the radius, and the outline is what moved, not the shadow.
+ */
+function deviationFromBlurRadius(radiusPx: number): number {
+  return radiusPx / 2;
+}
+
+/**
+ * The soft effects, ordered from the back forward.
+ *
+ * `text-shadow` paints its list front to back — the first shadow named is the one on top — while
+ * Paint layers are drawn in the order they are declared. So this reverses: the far end of a long
+ * shadow first, then the glow, then the drop shadow nearest the letter.
+ */
+function softPaints(paint: FineCaptionGlyphPaint): VisualTextPaintLayer[] {
+  const layers: VisualTextPaintLayer[] = [];
+  if (paint.longShadow.opacity > 0 && paint.longShadow.distancePx > 0) {
+    const steps = Math.min(32, Math.max(1, Math.ceil(paint.longShadow.distancePx)));
+    const radians = paint.longShadow.angleDeg * Math.PI / 180;
+    for (let step = steps; step >= 1; step -= 1) {
+      const distance = paint.longShadow.distancePx * step / steps;
+      layers.push({
+        kind: "shadow",
+        paint: { kind: "solid", color: alphaColor(paint.longShadow.color, paint.longShadow.opacity) },
+        offsetX: Math.cos(radians) * distance,
+        offsetY: Math.sin(radians) * distance,
+        blurPx: 0,
+        spreadPx: 0,
+      });
+    }
+  }
+  if (paint.glow.opacity > 0) {
+    layers.push({
+      kind: "glow",
+      paint: { kind: "solid", color: alphaColor(paint.glow.color, paint.glow.opacity) },
+      blurPx: deviationFromBlurRadius(paint.glow.blurPx),
+      spreadPx: 0,
+    });
+  }
+  if (paint.shadow.opacity > 0) {
+    layers.push({
+      kind: "shadow",
+      paint: { kind: "solid", color: alphaColor(paint.shadow.color, paint.shadow.opacity) },
+      offsetX: paint.shadow.offsetXPx,
+      offsetY: paint.shadow.offsetYPx,
+      blurPx: deviationFromBlurRadius(paint.shadow.blurPx),
+      spreadPx: 0,
+    });
+  }
+  return layers;
+}
+
 function glyphPaints(paint: FineCaptionGlyphPaint): VisualTextPaintLayer[] | undefined {
   if (paint.stroke.widthPx === 0) return undefined;
   const fill: VisualColorPaint = paint.gradient === undefined
@@ -84,9 +138,10 @@ function glyphPaints(paint: FineCaptionGlyphPaint): VisualTextPaintLayer[] | und
           { offset: 1, color: paint.gradient.to, opacity: 1 },
         ],
       };
-  // Outline first: the layers stack in the order they are declared, and the body sits over its own
-  // outline rather than the other way round.
+  // Back to front: the soft effects fall behind the outline they are cast from, the outline sits
+  // outside the letter, and the body sits over its own outline.
   return [
+    ...softPaints(paint),
     { kind: "stroke", placement: "outside", widthPx: paint.stroke.widthPx, paint: { kind: "solid", color: paint.stroke.color } },
     { kind: "fill", paint: fill },
   ];
@@ -142,7 +197,9 @@ function glyphStyle(
       { name: "-webkit-background-clip", value: "text" },
       { name: "-webkit-text-fill-color", value: "transparent" },
     ] as const),
-    ...(shadows.length === 0 ? [] : [{ name: "text-shadow", value: shadows.join(",") }] as const),
+    // An outlined caption casts its shadows as Paint, behind the outline. Left here as well they
+    // would be cast by the body alone, and so land on top of the ring they are supposed to be under.
+    ...(painted || shadows.length === 0 ? [] : [{ name: "text-shadow", value: shadows.join(",") }] as const),
     ...(underline === undefined ? [] : underlineStyle(underline)),
   ];
 }

--- a/packages/caption-fine/test/caption-fine.test.ts
+++ b/packages/caption-fine/test/caption-fine.test.ts
@@ -461,25 +461,35 @@ test("full Fine Paint and layered motion lower to terminal Visual IR without cha
   assert.equal(base?.kind, "text");
   assert.ok(base?.style.some(({ name, value }) => name === "text-transform" && value === "uppercase"));
   assert.ok(base?.style.some(({ name }) => name === "text-decoration-thickness"));
-  assert.ok(base?.style.some(({ name, value }) => name === "text-shadow" && String(value).split(",").length >= 8));
   // The outline is declared as Paint placed outside the letter, not as a centred stroke that would
   // spend half its width inside. A centred stroke is what the style vocabulary can say, so the
   // absence of one here is as much the point as the presence of the Paint.
-  assert.deepEqual(base?.paints, [
-    { kind: "stroke", placement: "outside", widthPx: 3, paint: { kind: "solid", color: "#101010" } },
-    { kind: "fill", paint: { kind: "linear-gradient", angleDeg: 120, stops: [
+  const paints = base?.paints ?? [];
+  assert.deepEqual(paints.at(-2), {
+    kind: "stroke", placement: "outside", widthPx: 3, paint: { kind: "solid", color: "#101010" },
+  });
+  assert.deepEqual(paints.at(-1), {
+    kind: "fill", paint: { kind: "linear-gradient", angleDeg: 120, stops: [
       { offset: 0, color: "#FFFFFF", opacity: 1 },
       { offset: 1, color: "#60A5FA", opacity: 1 },
-    ] } },
-  ]);
+    ] },
+  });
+  // The soft effects are declared before the outline, so they are drawn beneath it rather than
+  // cast by the body alone and landing on top of the ring they belong under. The long shadow is
+  // its own discrete steps, which is what a long shadow is.
+  const soft = paints.slice(0, -2);
+  assert.ok(soft.length >= 8, `expected the long shadow steps, found ${soft.length}`);
+  assert.ok(soft.every((paint) => paint.kind === "shadow" || paint.kind === "glow"));
   assert.ok(!base?.style.some(({ name }) => name.startsWith("-webkit-text-stroke")));
-  // The body is spelled once, in the Paint, so the style does not also colour it.
-  assert.ok(!base?.style.some(({ name }) => name === "color" || name === "background-clip"));
+  // Each of these is now spelled once, in the Paint, so the style does not also draw it.
+  assert.ok(!base?.style.some(({ name }) =>
+    name === "color" || name === "background-clip" || name === "text-shadow"));
   const activeGlyph = elements.find((element) => element.id === "atom-1-active-1");
   assert.equal(activeGlyph?.kind, "text");
-  // The spoken Word carries its own gradient and its own outline, in the same vocabulary.
-  assert.equal(activeGlyph?.paints?.[0]?.kind, "stroke");
-  const activeFill = activeGlyph?.paints?.[1];
+  // The spoken Word carries its own gradient and its own outline, in the same vocabulary and the
+  // same order: whatever it casts behind it, then the outline, then the body.
+  assert.equal(activeGlyph?.paints?.at(-2)?.kind, "stroke");
+  const activeFill = activeGlyph?.paints?.at(-1);
   assert.equal(activeFill?.kind, "fill");
   assert.equal(activeFill?.kind === "fill" ? activeFill.paint.kind : undefined, "linear-gradient");
   const joined = elements.filter((element) => element.attributes?.some((attribute) =>

--- a/packages/hyperframes/src/document.ts
+++ b/packages/hyperframes/src/document.ts
@@ -247,6 +247,7 @@ function renderElement(
     readonly programNumerator: number;
     readonly programDenominator: number;
     readonly stackIndex: number;
+    readonly emittedFilterIds: Set<string>;
   },
 ): string {
   const id = stableDomId([context.trackId, context.presentId, element.id]);
@@ -346,6 +347,7 @@ function renderElement(
     exactFontFamily,
     baseStyle: inlineStyle,
     commonAttributes,
+    emittedFilterIds: context.emittedFilterIds,
   };
   if (element.kind === "text") {
     const body = element.paints === undefined
@@ -425,6 +427,7 @@ function renderVisualPresent(
   stackIndex: number,
   numerator: number,
   denominator: number,
+  emittedFilterIds: Set<string>,
 ): string {
   const start = frameSeconds(present.span.startFrame, numerator, denominator);
   const duration = frameSeconds(present.span.endFrameExclusive - present.span.startFrame, numerator, denominator);
@@ -447,6 +450,7 @@ function renderVisualPresent(
     programNumerator: numerator,
     programDenominator: denominator,
     stackIndex,
+    emittedFilterIds,
   });
   return `<div class="clip hypit-visual-present" data-hypit-track-id="${escapeHtml(track.id)}" data-hypit-present-id="${escapeHtml(present.id)}" data-hypit-stack-order="${present.stacking.order}" data-hypit-stack-tie="${escapeHtml(present.stacking.tieBreak)}" data-track-index="${stackIndex}" data-start="${start}" data-duration="${duration}" style="position:absolute;inset:0;z-index:${stackIndex};overflow:hidden;pointer-events:none">${contents}</div>`;
 }
@@ -638,7 +642,10 @@ function frameAnimationRuntime(numerator: number, denominator: number): string {
 function emitHtml(composition: Composition, programSpace: ProgramSpace): string {
   const { numerator, denominator } = programSpace.frameRate;
   const visuals = orderedVisualPresents(composition.tracks);
-  const visualHtml = visuals.map(({ track, present }, index) => renderVisualPresent(track, present, index, numerator, denominator)).join("\n    ");
+  // One document, one set of glyph filter definitions: every Present writes only what is not
+  // already there, and references resolve across the document regardless of where they landed.
+  const emittedFilterIds = new Set<string>();
+  const visualHtml = visuals.map(({ track, present }, index) => renderVisualPresent(track, present, index, numerator, denominator, emittedFilterIds)).join("\n    ");
   const animationCss = visuals.flatMap(({ track, present }) => renderAnimationRules(track, present)).join("\n    ");
   const fontCss = renderFontFaces(composition);
   const duration = frameSeconds(programSpaceFrameCount(programSpace), numerator, denominator);

--- a/packages/hyperframes/src/text.ts
+++ b/packages/hyperframes/src/text.ts
@@ -27,6 +27,13 @@ export type TextRenderContext = {
   readonly exactFontFamily: (font: FontArtifactRef) => string;
   readonly baseStyle: string;
   readonly commonAttributes: string;
+  /**
+   * Filter identifiers already written into this document.
+   *
+   * A caption is one element per word, and every word carries the same Paint, so without somewhere
+   * to remember that, each word writes the whole set again.
+   */
+  readonly emittedFilterIds?: Set<string>;
 };
 
 function number(value: number): string {
@@ -167,11 +174,20 @@ function inheritedGlyphColor(paints: readonly VisualTextPaintLayer[]): string[] 
   return fills.length === 1 && fills[0]!.paint.kind === "solid" ? [`color:${fills[0]!.paint.color}`] : [];
 }
 
+/**
+ * Name a filter after the Paint it draws, and after nothing else.
+ *
+ * What the filter contains is decided by the Paint alone, so two Paints that are equal want one
+ * definition between them. Naming the Track and the Present as well made every element that shared
+ * a Paint carry its own copy: a five-word caption with an outline, a glow and a long shadow emitted
+ * eighty definitions of sixteen distinct filters, thirty-six kilobytes of which thirty were the
+ * same bytes repeated. Identifiers are resolved across the document, so one copy answers for all.
+ */
 function glyphFilterId(
   paint: Extract<GlyphPaintLayer, { kind: "stroke" | "shadow" | "glow" }>,
   context: TextRenderContext,
 ): string {
-  return context.stableId([context.trackId, context.presentId, "text-glyph-filter", canonicalStringify(paint)]);
+  return context.stableId(["text-glyph-filter", canonicalStringify(paint)]);
 }
 
 function glyphFilterDefinition(
@@ -282,7 +298,15 @@ export function renderGlyphPaintedString(
   if (layers.length === 0) return context.escape(value);
   const shaped = layers.filter((paint): paint is Extract<GlyphPaintLayer, { kind: "stroke" | "shadow" | "glow" }> =>
     paint.kind !== "fill");
+  const written = context.emittedFilterIds;
   const definitions = [...new Map(shaped.map((paint) => [canonicalStringify(paint), paint])).values()]
+    .filter((paint) => {
+      const id = glyphFilterId(paint, context);
+      if (written === undefined) return true;
+      if (written.has(id)) return false;
+      written.add(id);
+      return true;
+    })
     .map((paint) => glyphFilterDefinition(paint, context)).join("");
   const defs = definitions.length === 0
     ? ""


### PR DESCRIPTION
The outline moved to Paint in #14; shadow, glow and long shadow stayed as CSS `text-shadow` on the word element. A shadow is cast by whatever carries it, and what carried it was the glyph body — so the shadow landed on top of the ring instead of underneath it. Every recipe in the repository pairs a dark outline with a dark shadow, which is the only reason it did not show.

They are Paint now as well, declared before the stroke, since layers draw in the order they are named.

## Two things that needed care

**Order reverses on the way across.** `text-shadow` paints its list front to back — the first shadow named is the one on top — while Paint layers draw back to front. So the far end of the long shadow is declared first, then the glow, then the drop shadow nearest the letter. The long shadow was already computed as discrete steps and each step becomes one shadow layer, which is what a long shadow is.

**Blur is converted, not copied.** CSS blur is a radius and covers roughly two standard deviations; `feGaussianBlur` takes the deviation. Passing the authored number straight through would have doubled every shadow and glow in the repository.

## Measured

Rendered through the real pipeline with an unblurred blue shadow offset ten pixels beneath a red outline:

- visible shadow pixels: **1184** — only the crescent the ring does not cover
- of the 351 columns carrying ink, the number whose topmost pixel is shadow: **0**

In front of the ring the shadow would have shown its whole silhouette, on the order of nine thousand pixels, and would have capped columns.

## Filter definitions were being repeated

Naming a filter after the Track and Present as well as the Paint meant every word carried its own copy of byte-identical definitions. A five-word caption with an outline, a glow and a long shadow emitted 80 definitions of 16 distinct filters — 36 KiB, of which 7 were not repetition. A filter's content depends on its Paint alone, so its name now does too, and the document writes each one once.

| | definitions | distinct | bytes |
|---|---|---|---|
| before | 80 | 16 | 36 KiB |
| after | 16 | 16 | 7 KiB |
| ordinary caption (outline + shadow) | 2 | 2 | 907 B |

## Verification

`pnpm check`, `pnpm test` (544, 0 failures), `pnpm test:release` (8) and `pnpm test:browser-visual` (12 against a real browser) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)