### PR TITLE
The skill finds its own checkout, and projects leave examples/

### DIFF
--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -11,6 +11,10 @@ that reference names required child references, read those completely in the sta
 Keep `.svml` Author Source, `.svs` Recipe Source, `.svrun` Run Source, and
 `hypit.runtime.json` Runtime Profile as separate languages and responsibilities.
 
+Every route runs against a Hypit checkout. `references/environment.md` finds one, clones it when this
+machine has none, and names the directory every path in these files is relative to. Read it before
+the first command of any route.
+
 ## Route
 
 - Reference-video reconstruction, reverse engineering, shot/B-roll/overlay analysis, or recreating

--- a/.agents/skills/hypit/references/environment.md
+++ b/.agents/skills/hypit/references/environment.md
@@ -2,10 +2,32 @@
 
 ## Where you are
 
-This skill lives inside the Hypit repository. Find the root from the skill's own location — the
-directory containing `package.json` and `packages/` — and work from there. Repository paths written in
-these files, `.agents/skills/hypit/scripts/…`, `packages/…`, `examples/…`, are relative to that root
-and to nothing else.
+Every route runs against a Hypit checkout: the `hypit` binary loads the repository's own sources and
+every `@hypit/…` package is unpublished, so the checkout is what supplies both. Find it before the
+first command of any route, from this skill's own directory — the one holding the `SKILL.md` you are
+reading:
+
+```text
+node scripts/locate-repository.mjs
+```
+
+It prints the checkout, and clones one into the home directory when this machine has none:
+
+```text
+repository	/Users/you/hypit
+source	cwd
+installed	yes
+```
+
+`source` says where that path came from: `cwd` for a working directory already inside a checkout,
+`skill` for a skill installed inside one, `home` for the clone it keeps, `cloned` when it made that
+clone just now, `env` for a `HYPIT_REPOSITORY` the author set. `installed no` means the workspace
+install below still has to run there.
+
+Every repository path written in these files — `.agents/skills/hypit/scripts/…`, `packages/…`,
+`docs/…`, `examples/…` — is relative to the printed `repository` and to nothing else. That includes
+the other scripts: run the checkout's copies. `preview-check.mjs` reaches Studio's sources through
+its own position in the checkout, so that copy is the one that resolves them.
 
 Several commands resolve against the **working directory** rather than against the Source they are
 given: `list_svml_packages` reads `node_modules/@hypit` from the cwd and refuses when it is empty, and
@@ -30,7 +52,7 @@ a compatible release from either shell:
 npm install --global corepack@0.34.5
 ```
 
-Then install and validate the workspace:
+Then install and validate the workspace, which is what `installed no` asks for:
 
 ```text
 corepack enable

--- a/.agents/skills/hypit/references/local-author-package.md
+++ b/.agents/skills/hypit/references/local-author-package.md
@@ -170,9 +170,9 @@ is expensive to read.
 
 ## Install and validate
 
-Reuse an existing workspace when it already includes `packages/*`; otherwise make only the minimal
-workspace/package changes required. Add the package as a normal `workspace:*` dependency and run
-`pnpm install`. Do not hide it under `.hypit/`, modify the package loader or invent a registry.
+The checkout's workspace already covers `projects/*/packages/*`, so a package placed there needs no
+glob of its own. Add it as a normal `workspace:*` dependency and run `pnpm install`. Do not hide it
+under `.hypit/`, modify the package loader or invent a registry.
 
 Repair in this order:
 
@@ -230,7 +230,7 @@ Say which it is either way. A local package nobody flagged is a local package no
 ### Promotion is not a move
 
 If the author wants it promoted, these are the parts. Say up front that this is a checklist rather
-than a path anyone has walked — no package under `packages/` began under `examples/`, so the first
+than a path anyone has walked — no package under `packages/` began inside a project, so the first
 person to do it should correct what follows.
 
 - **The name is load-bearing in six places.** `@hypit/local-<slug>` becomes `@hypit/<slug>` in
@@ -243,7 +243,7 @@ person to do it should correct what follows.
 - **Studio keeps a hand-maintained list.** `packages/studio/src/adapters/generic.ts` enumerates the
   modules that get the component adapter. A package missing from it still renders, through the visual
   fallback — second-class in Studio, and invisible as itself in review.
-- **Its own chrome is untracked today.** `examples/**/assets/` is ignored, so the texture the package
+- **Its own chrome is untracked today.** Git ignores `projects/`, so the texture the package
   reads with `readFile(new URL("../assets/…"))` is not in git. Promotion is the first moment those
   bytes enter the repository, and **no package under `packages/` has a non-`preview/` asset
   directory**. Promotion establishes that convention rather than following it; decide it deliberately.
@@ -251,11 +251,11 @@ person to do it should correct what follows.
   `test/render-preview.ts`, which is a harness, not a suite, so a promoted package contributes zero
   coverage where every peer has some. Writing one is part of promotion.
 - **It newly owes clean imports.** Repository hygiene requires that anything `src/` imports appears in
-  `dependencies`, not `devDependencies` — a rule examples are exempt from. A package carrying its
-  render-harness dependencies in `devDependencies` fails on the way in.
-- **The workspace already covers both locations.** `pnpm-workspace.yaml` lists `packages/*` and
-  `examples/*/packages/*`, and `tsconfig.json` includes both. No glob needs adding in either
-  direction; adding one is a change that does nothing.
+  `dependencies`, not `devDependencies` — a rule examples and projects are exempt from. A package
+  carrying its render-harness dependencies in `devDependencies` fails on the way in.
+- **The workspace already covers both locations.** `pnpm-workspace.yaml` lists `packages/*`,
+  `projects/*/packages/*` and `examples/*/packages/*`, and `tsconfig.json` includes them. No glob
+  needs adding in either direction; adding one is a change that does nothing.
 
 What promotion never means: merging the behaviour into the package it was modelled on. It installs
 beside that package as a sibling family, for the reasons the boundary section above gives.

--- a/.agents/skills/hypit/references/original-authoring/index.md
+++ b/.agents/skills/hypit/references/original-authoring/index.md
@@ -34,7 +34,8 @@ Everything else this route needs is discoverable:
 
 - **Where you are, and what is installed.** `../environment.md`.
 - **Credentials.** `../credentials.md` lists which variables each Provider needs.
-- **Where the project goes.** `../runtime.md` keeps the project and package boundaries distinct.
+- **Where the project goes.** Its own directory in the checkout: `projects/<name>/`, named after the
+  video. `../runtime.md` keeps the project and package boundaries distinct.
 
 ## Before deciding anything
 

--- a/.agents/skills/hypit/references/reconstruction/index.md
+++ b/.agents/skills/hypit/references/reconstruction/index.md
@@ -50,9 +50,9 @@ is asking the author to do your job. Everything this route needs beyond the vide
 discoverable:
 
 - **Where you are, and what is installed.** `../environment.md`.
-- **Where the project goes.** Its own directory: `examples/<something>-reverse/`, named after the
-  video, beside the other examples, which the workspace already covers. Use a directory the author
-  named only if they named one.
+- **Where the project goes.** Its own directory in the checkout: `projects/<something>-reverse/`,
+  named after the video — `../runtime.md` says what that directory is and what the workspace does
+  with it. Use a directory the author named only if they named one.
 - **Credentials.** The repository keeps them in `.env`; load it as shown below. If a variable is
   missing, say which one and stop — do not ask the author to describe their setup.
 

--- a/.agents/skills/hypit/references/runtime.md
+++ b/.agents/skills/hypit/references/runtime.md
@@ -82,8 +82,15 @@ Builds remain archived and neither command cancels remote Provider work.
 
 ## Keep project and package boundaries distinct
 
-Prefer production projects outside the Hypit checkout. Relative Author Sources and assets stay
-inside the independently resolved Source Workspace.
+A project lives at `projects/<name>/` in the checkout — its own directory, holding the four Sources,
+its assets and any project-local package. `pnpm-workspace.yaml` covers `projects/*/packages/*` and
+Git ignores `projects/`, so a project is installed and type-checked like the examples while staying
+out of the repository's history.
+
+`examples/` is the published example set. Read it for the nearest Runtime Profile and the closest
+source shape, and write under `projects/`.
+
+Relative Author Sources and assets stay inside the independently resolved Source Workspace.
 
 - `--workspace` explicitly selects the Source Workspace boundary.
 - `--package-root` only changes where the Host locates installed packages. It does not widen Source

--- a/.agents/skills/hypit/scripts/locate-repository.mjs
+++ b/.agents/skills/hypit/scripts/locate-repository.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Report the Hypit checkout every route runs against, cloning one when this machine has none.
+ *
+ * Usage:  node scripts/locate-repository.mjs
+ *
+ * This is the one script that runs from the skill's own copy rather than from the checkout, so it
+ * depends on nothing but Node. It writes the report to stdout and leaves git's progress on stderr.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const remote = "https://github.com/hypit-ai/hypit.git";
+const target = join(homedir(), "hypit");
+
+const fail = (message) => { console.error(`locate-repository: ${message}`); process.exit(1); };
+
+function isCheckout(directory) {
+  try {
+    return JSON.parse(readFileSync(join(directory, "package.json"), "utf8")).name === "@hypit/repository";
+  } catch { return false; }
+}
+
+function nearestCheckout(start) {
+  let directory = resolve(start);
+  while (true) {
+    if (isCheckout(directory)) return directory;
+    const parent = dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
+function clone() {
+  if (existsSync(target)) fail(`${target} exists and is not a Hypit checkout; move it or set HYPIT_REPOSITORY`);
+  try {
+    execFileSync("git", ["clone", remote, target], { stdio: ["ignore", "inherit", "inherit"], windowsHide: true });
+  } catch (error) {
+    if (error?.code === "ENOENT") fail("git is not installed");
+    fail(`git clone ${remote} ${target} failed`);
+  }
+  if (!isCheckout(target)) fail(`git clone ${remote} ${target} produced no checkout`);
+  return target;
+}
+
+function locate() {
+  const override = process.env.HYPIT_REPOSITORY?.trim();
+  if (override) {
+    const directory = resolve(override);
+    if (!isCheckout(directory)) fail(`HYPIT_REPOSITORY is not a Hypit checkout: ${directory}`);
+    return ["env", directory];
+  }
+  const fromWorkingDirectory = nearestCheckout(process.cwd());
+  if (fromWorkingDirectory !== undefined) return ["cwd", fromWorkingDirectory];
+  const fromSkill = nearestCheckout(dirname(fileURLToPath(import.meta.url)));
+  if (fromSkill !== undefined) return ["skill", fromSkill];
+  if (isCheckout(target)) return ["home", target];
+  return ["cloned", clone()];
+}
+
+const [source, repository] = locate();
+console.log(`repository\t${repository}`);
+console.log(`source\t${source}`);
+console.log(`installed\t${existsSync(join(repository, "node_modules", "@hypit")) ? "yes" : "no"}`);

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ services/media-lambda/build/
 .DS_Store
 examples/**/.svml/
 
+# Authored projects: real output, but not the repository
+/projects/
+
 # Reverse-engineering scratch projects: real output, but not the repository
 /examples/*-reverse/
 /examples/reference-reconstruction/

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ Hypit gives AI agents (Claude Code, Codex...) a language and system to create vi
 
 **To be clear:** cloning a video is the fastest way in, not the only one. You can start from our templates, or just describe the video you want and your agent writes the workflow from scratch. Generation models are optional too: a workflow can compile captions, motion graphics and code-rendered visuals into a finished video without calling a single model, so a video can cost exactly $0.
 
-## Clone the repo
+## Install the Hypit skill
 
 ```bash
-git clone https://github.com/hypit-ai/hypit.git && cd hypit
+npx skills add hypit-ai/hypit
 ```
 
 ## Use the Hypit skill
 
-The `/hypit` skill is available to coding agents from the cloned repository. Ask your agent to set up the environment and create videos for you:
+The `/hypit` skill is available to coding agents. Your agent fetches the repository it needs on first use. Ask it to set up the environment and create videos for you:
 
 ```text
 /hypit Clone this viral video, show me a preview, and guide me through producing variants.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,15 +42,15 @@ Hypit 给 AI Agents (Claude Code、Codex……) 打造了一门做视频的语�
 
 **说明一点：** 复刻视频是最快的入口，但不是唯一的入口。你可以直接从我们的模板开始，也可以直接描述你想要的视频，让 Agent 从零写出一份 workflow。生成模型同样不是必需的：字幕、动效、代码渲染的画面，不调用任何模型也能编译成一条成片——一条视频的成本可以是 0 元。
 
-## 克隆仓库
+## 安装 Hypit skill
 
 ```bash
-git clone https://github.com/hypit-ai/hypit.git && cd hypit
+npx skills add hypit-ai/hypit
 ```
 
 ## 使用 Hypit skill
 
-克隆仓库后，编程 Agent 可以直接使用 `/hypit` skill。让 Agent 配置环境并为你创建视频：
+编程 Agent 可以直接使用 `/hypit` skill，首次使用时 Agent 会自行获取所需的仓库。让 Agent 配置环境并为你创建视频：
 
 ```text
 /hypit 把这条爆款视频复刻出来，展示预览，并带我批量生成多个变体。

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,8 @@
 packages:
   - packages/*
   - services/media-lambda
-  # A project-local author package lives at <project>/packages/local-<slug>, which for a project
-  # kept in this checkout means examples/<project>/packages/. Without this the convention the
+  # A project-local author package lives at <project>/packages/local-<slug>. Authored projects sit
+  # under projects/ and the shipped examples under examples/; without these globs the convention the
   # authoring guide documents produces a package pnpm never links.
+  - projects/*/packages/*
   - examples/*/packages/*

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,8 @@
   },
   "include": [
     "packages/**/*.ts",
+    "projects/*/packages/*/src/**/*.ts",
+    "projects/*/packages/*/test/**/*.ts",
     "examples/*/packages/*/src/**/*.ts",
     "examples/*/packages/*/test/**/*.ts",
     "services/media-lambda/src/**/*.ts"


### PR DESCRIPTION
## Why

The `hypit` skill assumed it was already inside a checkout: `references/environment.md` derived the repository root from the skill's own location, and both READMEs opened with `git clone … && cd hypit`. That made the clone a prerequisite for installing the skill at all, so `npx skills add hypit-ai/hypit` could not work.

Separately, both routes wrote the author's project into `examples/`, which is the published example set.

## What changed

**`scripts/locate-repository.mjs`** resolves the checkout: `HYPIT_REPOSITORY` → the working directory and its ancestors → the skill's own ancestors → `<home>/hypit`, cloning into `<home>/hypit` when the machine has none. Zero-dependency Node, because it is the one script that runs from the standalone copy of the skill. Paths come from `os.homedir()` and git is spawned without a shell, so no document carries a Windows path fork. It reports the checkout, where the path came from, and whether the workspace install has run:

```
repository	/Users/you/hypit
source	cwd | skill | home | cloned | env
installed	yes | no
```

**`SKILL.md` and `references/environment.md`** run that step before the first command of any route, and every repository path in the skill is relative to the reported checkout — including the other scripts, since `preview-check.mjs` reaches Studio's sources through its own position in the checkout.

**Projects move to `projects/<name>/`**, stated once in `references/runtime.md` and named by both route pages. `.gitignore` ignores `projects/`, `pnpm-workspace.yaml` covers `projects/*/packages/*` and `tsconfig.json` includes it, so a project-local author package links and type-checks exactly as one under `examples/` does. `examples/` is now read-only to the skill.

**Both READMEs** install with `npx skills add hypit-ai/hypit` in place of the clone step.

## Verification

| Check | Result |
|---|---|
| Script from the repository root | `source cwd`, no network access |
| `/tmp` with `HYPIT_REPOSITORY` | `source env`; a non-checkout path exits 1 naming that path |
| `/tmp` with no override | `source skill` |
| Sandboxed skill copy, empty `HOME`, git shim | first run `source cloned` / `installed no`; second run `source home` with no git call |
| `PATH` without git | `locate-repository: git is not installed`, exit 1 |
| `projects/probe/packages/local-x` | ignored by `.gitignore`; `tsc` reports its diagnostics; `pnpm m ls` lists it as a workspace member |
| `npx skills add ./ --list` | finds exactly one skill — the `.claude`/`.codex` links do not duplicate it |

`pnpm check` fails identically before and after this change (confirmed by stashing `tsconfig.json` alone); the errors come from untracked scratch projects under `examples/*-reverse/` on that machine.

The clone branch was exercised through a git shim, not a real clone of this private repository. The first real install has to be run once the repository is public, which also confirms `npx skills add hypit-ai/hypit` finds the skill through the registry path rather than the local one tested here.
