### PR TITLE
An intended change is made on the finished reconstruction

### DIFF
--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -21,9 +21,10 @@ the first command of any route.
   a video as Hypit source → read `references/reconstruction/index.md`. This is the route whatever
   the author calls it — reconstruct, reverse-engineer, recreate, replicate, clone, remake, copy,
   rebuild, or the same idea in any language — and **a path to a video file, with or without words
-  around it, is this route** even when no verb is given at all. The path is the whole request: the
-  working directory, the project location and the vocabulary are yours to decide rather than to ask
-  for.
+  around it, is this route** even when no verb is given at all. A video path with a change attached —
+  this one but with our presenter, our product, our brand — is this route too, and the change is made
+  on the finished reconstruction. The path is the whole request: the working directory, the project
+  location and the vocabulary are yours to decide rather than to ask for.
 - Making a video from a description, brief, topic, script or format name, with nothing to copy →
   read `references/original-authoring/index.md`. This is the route whatever shape the request takes —
   "make me a 45-second ranking video", "a talking-head explainer about X", an ad for a product, a

--- a/.agents/skills/hypit/references/reconstruction/index.md
+++ b/.agents/skills/hypit/references/reconstruction/index.md
@@ -42,6 +42,23 @@ supplied, not for material you generated a moment ago.
 
 Reference observation is part of the work and is expected to cost what it costs.
 
+## A requested change is made after the reconstruction is complete
+
+The author often wants the result to differ from the reference: their presenter rather than the one
+in the video, their product rather than the promoted one, their brand. Reconstruct the reference as
+it is anyway, all of it, and then read what you wrote and change it to what they asked for.
+
+The reason is that the reconstruction is checkable only while it claims to reproduce the video that
+was observed. The observations describe the reference and are cached, and `compare_reconstruction`
+judges a rendered element against a reference frame. Author the change into the sources early and the
+evidence describes one video while the sources describe another, which leaves the reconstruction with
+nothing to be checked against while it is still being written.
+
+Afterwards the sources are yours to change. You wrote every one of them, and the identity of each
+recurring person and product is already a single anchor in them, because
+`../playbooks/craft/persona-and-audio.md` and `../playbooks/craft/visual-continuity.md` required that
+while you were writing.
+
 ## A video path is the whole request
 
 The author gives one thing: the path to a video. Not a working directory, not a project name, not
@@ -57,7 +74,9 @@ discoverable:
   missing, say which one and stop — do not ask the author to describe their setup.
 
 Ask the author about the video and nothing else: what it is for, who is in it, what it should say.
-Never interrupt to ask which generator, which package, which directory, or whether to proceed.
+Those answers describe the result they want rather than the reconstruction; record them and apply
+them once the reconstruction is complete. Never interrupt to ask which generator, which package,
+which directory, or whether to proceed.
 
 ## Before the first command
 

--- a/.agents/skills/hypit/references/reconstruction/reconstruction-loop.md
+++ b/.agents/skills/hypit/references/reconstruction/reconstruction-loop.md
@@ -142,6 +142,12 @@ comparison to name what remains. Do not spend one to find out — a comparison t
 and exists only to report the gap is a paid step for a report nobody asked for. The element is what
 it is; move on to the next one.
 
-When there is no next element the route is over, except for one question. If a project-local package
-was built along the way, decide whether it should outlive this video and put that to the author:
-`../local-author-package.md` says how to judge it and what promoting it actually costs.
+When there is no next element the reconstruction is complete, and two things follow it.
+
+If the author wants the result to differ from the reference — their presenter, their product, their
+brand — read the sources you wrote and change them to what they asked for. `index.md` says why that
+happens here rather than earlier.
+
+If a project-local package was built along the way, decide whether it should outlive this video and
+put that to the author: `../local-author-package.md` says how to judge it and what promoting it
+actually costs.


### PR DESCRIPTION
## Why

The reconstruction route had nothing to say about the common case: the author wants the result to differ from the reference — their presenter, their product, their brand. `index.md` was already asking the author "who is in it" and then using the answer nowhere, and `SKILL.md`'s routing left a request that carries both a video path and a change ambiguous between the two routes.

## The rule

Reconstruct the reference as it is, all of it, then read the sources and change them to what the author asked for.

The reason is checkability. The observations are cached descriptions of the reference and `compare_reconstruction` judges a rendered element against a reference frame — both hold only while the sources claim to reproduce the video that was observed. Authoring the change in early leaves the reconstruction with nothing to be checked against while it is still being written.

What happens after the reconstruction is complete is not specified as a procedure. The main agent wrote every source and every component, and `persona-and-audio.md` and `visual-continuity.md` already required each recurring person and product to be a single anchor in them.

## Where it lands

| File | Change |
|---|---|
| `SKILL.md` | A video path with a change attached routes to reconstruction, and the change is made on the finished reconstruction |
| `references/reconstruction/index.md` | New section stating the rule and the reason; the "who is in it" answer now has a defined use |
| `references/reconstruction/reconstruction-loop.md` | The convergence loop's ending names the change as what follows it |