### PR TITLE
The skill follows Studio's semantic timeline

### DIFF
--- a/.agents/skills/hypit/references/local-author-package.md
+++ b/.agents/skills/hypit/references/local-author-package.md
@@ -80,6 +80,11 @@ The package is project-local even when the project is the Hypit checkout. Do not
 official package automatically. After the result is accepted, offer promotion as a separate
 contribution.
 
+Expect it to draw as a generic block in Studio until then. `packages/studio/src/studio-registry.ts`
+picks an adapter by the module that placed the Track, and no adapter names a `@hypit/local-…` module,
+so the component reaches the `visual-fallback` adapter: it renders, without its own family colour,
+icon or inspector. Registering it means editing a shared package, which is what promotion is for.
+
 ## Complete implementation
 
 The main agent writes all code. Gemini must not receive or produce TypeScript, `package.json`,
@@ -241,9 +246,12 @@ person to do it should correct what follows.
   `devDependencies`; in the package's own test harness; and in **both** package catalogs,
   `docs/guide/packages.md` and `docs/zh/guide/packages.md`. An English-only catalog entry is a half
   promotion.
-- **Studio keeps a hand-maintained list.** `packages/studio/src/adapters/generic.ts` enumerates the
-  modules that get the component adapter. A package missing from it still renders, through the visual
-  fallback — second-class in Studio, and invisible as itself in review.
+- **Studio keeps a hand-maintained registry.** `packages/studio/src/studio-registry.ts` composes the
+  adapter sets under `packages/studio/src/adapters/`, and each adapter names the modules it claims. A
+  family joins an existing set's `modules` list or brings its own adapter file, the way `deck.ts`
+  does. A package named by none of them still renders, through the `visual-fallback` and
+  `audio-fallback` adapters in `generic.ts` — second-class in Studio, and invisible as itself in
+  review.
 - **Its own chrome is untracked today.** Git ignores `projects/`, so the texture the package
   reads with `readFile(new URL("../assets/…"))` is not in git. Promotion is the first moment those
   bytes enter the repository, and **no package under `packages/` has a non-`preview/` asset

--- a/.agents/skills/hypit/references/preview.md
+++ b/.agents/skills/hypit/references/preview.md
@@ -68,10 +68,35 @@ pnpm studio -- --run path/to/build.svrun \
 
 Read the startup output for the chosen port. `--run` is required: Studio's unit of work is the Run
 Source, and it reads the Author SVML back out of it. Pass `--runtime` only when the Author Source
-reuses accepted Build records.
+reuses accepted Build records. `--workspace` selects the Source Workspace and defaults to the Run's
+own directory, so pass it when the Run's relative Sources resolve against a different root.
 
 Studio opens a Run whose material is satisfied. When a projection is missing it names the issue and
 stops, so a Run that opens is a Run whose Tracks all resolved.
+
+One Run in the repository is satisfied already, so Studio can be seen without spending anything:
+
+```bash
+pnpm studio -- --run examples/all-components-preview/studio.svrun --workspace .
+```
+
+It supplies its own Semantic Takes and caption plan from committed fixtures. Every other Run under
+`examples/` still names shots a Provider has to make, or footage that is not committed.
+
+## A timeline block is not the authored Selection
+
+Studio keeps three stages of an item's time apart, and reading one for another misreads the program:
+
+- the **semantic source** the author named — a Selection, Segment, Moment or Program, with its
+  occurrence identity and its anchors on the Semantic Track;
+- the **projection** of that source into frame space, after occurrence expansion, offset evaluation,
+  clipping and frame quantization. One authored binding can project to zero, one or several windows;
+- the **consumption** window the realized Track actually uses, which the projection does not have to
+  equal — a source-audio trim reads different samples than its target window, and a Ranking exposes
+  one outer window alongside its reveal phases.
+
+A projection line connects a source to its realized window, and the projection view is read-only.
+`docs/guide/studio-temporal-windows.md` is authoritative for what each stage carries.
 
 Studio is a browser preview **for a person to look at**. It is not a source of images for an
 automated comparison — that is what the local still render above is for.


### PR DESCRIPTION
PR #22 rebuilt Studio and changed three things the `/hypit` skill asserts. That branch did not touch `.agents/`, so this is the follow-up it named.

## Three windows, not one rectangle

`references/preview.md` gains a section on the distinction Studio now draws: the semantic source the author named, the projection of that source into frame space, and the window the realized Track consumes. None is assumed to equal another — a source-audio trim reads different samples than its target window, and a Ranking exposes one outer window alongside its reveal phases. An agent that reads a timeline block as the authored Selection misreads the program. `docs/guide/studio-temporal-windows.md` is cited as authoritative.

## Studio can be opened for free

`examples/all-components-preview/studio.svrun` supplies its own Semantic Takes and caption plan from committed fixtures, so it opens with no Provider work. `references/preview.md` gives that command and explains `--workspace`, which that Run needs because its Sources resolve against the repository root rather than the Run's own directory. Verified by booting it: `➜  Local:   http://localhost:5179/`.

## The adapter registry moved

`references/local-author-package.md`'s promotion checklist said `packages/studio/src/adapters/generic.ts` enumerates the modules that get the component adapter. It no longer does: `studio-registry.ts` composes six adapter sets, and each adapter names the modules it claims, so a family joins an existing set's `modules` or brings its own adapter file the way `deck.ts` does.

The package boundary section now also states the condition an author meets before any promotion question comes up. `matches()` requires `rule.modules.includes(placement.module.name)`, and no adapter names a `@hypit/local-…` module, so a project-local component reaches the module-less `visual-fallback` adapter: it renders, without its own family colour, icon or inspector. Registering it means editing a shared package, which is what promotion is for.

## Checked and left alone

`media-track:Track` gained a `program` output in #22. The skill never enumerates that Track's outputs, so nothing there was wrong and nothing was added — an author does not connect it.