### PR TITLE
The Studio adapter is registered after the author agrees to promote

### DIFF
--- a/.agents/skills/hypit/references/local-author-package.md
+++ b/.agents/skills/hypit/references/local-author-package.md
@@ -80,10 +80,13 @@ The package is project-local even when the project is the Hypit checkout. Do not
 official package automatically. After the result is accepted, offer promotion as a separate
 contribution.
 
-Expect it to draw as a generic block in Studio until then. `packages/studio/src/studio-registry.ts`
-picks an adapter by the module that placed the Track, and no adapter names a `@hypit/local-…` module,
-so the component reaches the `visual-fallback` adapter: it renders, without its own family colour,
-icon or inspector. Registering it means editing a shared package, which is what promotion is for.
+Expect it to draw as a generic block in Studio until then, and leave it that way.
+`packages/studio/src/studio-registry.ts` picks an adapter by the module that placed the Track, and no
+adapter names a `@hypit/local-…` module, so the component reaches the `visual-fallback` adapter: it
+renders, without its own family colour, icon or inspector. That is the correct state for a package
+one project owns. Registering it edits `packages/studio`, which every project shares, so it happens
+only after the author has agreed the package moves into `packages/`. It is one item of the promotion
+checklist below, not a repair for what Studio shows during the work.
 
 ## Complete implementation
 


### PR DESCRIPTION
Follow-up to #23.

A project-local component reaches the module-less `visual-fallback` adapter, because `packages/studio/src/studio-registry.ts` matches by the module that placed the Track and no adapter names a `@hypit/local-…` module. #23 stated that and said registering it "is what promotion is for" — true, but it left the generic-looking block reading as a defect an agent might go and fix.

Registering an adapter edits `packages/studio`, which every project shares. The sequence is the one the surrounding section already sets out for promotion as a whole: finish the work, get the result accepted, judge whether a second unrelated video would want the vocabulary, put that to the author, and only once the author has agreed the package moves into `packages/` does any shared file change — the adapter included.

So the boundary section now says the fallback rendering is the correct state for a package one project owns, and names the gate.