### PR TITLE
The agent observer attributes speech instead of deferring it

### DIFF
--- a/.agents/skills/hypit/references/reconstruction/continuity.md
+++ b/.agents/skills/hypit/references/reconstruction/continuity.md
@@ -10,7 +10,9 @@ These invariants override superficial layer order and shot boundaries:
   move.
 - A shot with no visible person can carry continuing off-screen speech. Do not clear sound or base.
 - For alternating, overlapping or simultaneous speech, use audio evidence rather than visible-person
-  presence.
+  presence. The `agent` observer has no audio evidence and reads these from the frames and the word
+  timings instead, which `observers.md` describes: the transcript is what decides whether anyone is
+  speaking at all, so it is what keeps a moving mouth in B-roll from becoming a speaker.
 - One overlay that continues across a cut remains one visual track spanning its full observed
   lifetime. Do not recreate it once per shot.
 - Merge two or three incorrectly split clips only when continuity evidence confirms one camera shot

--- a/.agents/skills/hypit/references/reconstruction/observers.md
+++ b/.agents/skills/hypit/references/reconstruction/observers.md
@@ -45,21 +45,26 @@ the storyboard of representative frames. A task that carries a single picture ca
 The number of frames follows the shot's length, from four for a short one to nine for a long one, so
 a cell stays wide enough to read detail in.
 
-## What sound costs on the `agent` observer
+## How sound is answered on the `agent` observer
 
-You cannot hear the reference. Three things follow, and each is a condition to work inside rather than
-a step to skip:
+You cannot hear the reference, and there is no second source of sound to fall back to, so the sound
+observations are answered from the two things you do have. Answer them fully; do not leave them short
+and do not put the gap to the author.
 
-- `transcript` is unaffected. WhisperX measures every word locally on both paths, so the words and
-  their timings are exact, and `final-sources.md` takes Segment durations from `transcript_ref` as it
-  always does.
-- A task that needs sound says so in its own prompt. Answer it from what the pictures and the
-  transcript support — who is visibly speaking, what is on screen when a passage runs — and state
-  plainly which parts you could not determine. An observation that says what it could not see is
-  complete; one that infers a voice from an appearance is wrong, and
-  `continuity.md` depends on that distinction.
-- `voices` and the sound half of each `boundary` are the observations this affects. Read what they
-  return as what a viewer with the sound off would know.
+- **The transcript says when.** WhisperX measures every word locally on both paths, so the words and
+  their timings are exact whichever observer reads the pictures. That settles whether anyone is
+  speaking at a given moment, and `final-sources.md` still takes Segment durations from
+  `transcript_ref` as it always does.
+- **The pictures say who.** Attribute speech to the person the frames show speaking during the words
+  the transcript places there. A task that needs sound says so in its own prompt and asks for exactly
+  this reading.
+- **The two together are the evidence.** `continuity.md` asks for audio evidence over visible-person
+  presence because a mouth moving in silent B-roll misleads. On this observer the transcript is what
+  keeps that from happening: a person whose mouth moves during a stretch the transcript places no
+  words in is not the speaker, however much they look like one.
+
+`voices` and the sound half of each `boundary` are the observations this shapes. They are attributions
+read off pictures and word timings, and that is what a later reader should take them for.
 
 ## The comparison in the loop is yours too
 

--- a/packages/reference-video-tools/src/tools.ts
+++ b/packages/reference-video-tools/src/tools.ts
@@ -190,9 +190,14 @@ function asPictures(media: readonly string[], state: ReferenceState): readonly s
 const TILE_PREAMBLE = "Each supplied picture that shows a grid of frames is one shot, sampled evenly"
   + " across its duration and laid out in reading order: left to right, then top to bottom. Read the"
   + " grid as time passing. A single picture that is not a grid is one moment.";
-const NO_SOUND = "You are reading pictures and cannot hear this reference. Answer what the pictures and"
-  + " the measured transcript support, and say plainly which parts of the question need sound you do"
-  + " not have rather than inferring them from appearance.";
+// There is no second source of sound to fall back to, so this says how to answer from what there is
+// rather than leaving the observation short. The transcript settles when speech happens; the picture
+// settles who is on screen while it does. Read together they carry the question far enough to answer.
+const NO_SOUND = "You are reading pictures and cannot hear this reference. Answer from the pictures and"
+  + " the measured transcript together: the transcript says exactly when words are spoken, and the"
+  + " pictures say who is on screen and whose mouth is moving while they are. Attribute speech to the"
+  + " person the pictures show speaking during the words the transcript places there, and answer the"
+  + " question in full rather than deferring the parts that would be easier with sound.";
 
 /** Declares one observation: what it asks, and the evidence it asks over. The observer decides how. */
 type Request = {

--- a/packages/reference-video-tools/test/tools.test.ts
+++ b/packages/reference-video-tools/test/tools.test.ts
@@ -267,7 +267,9 @@ test("the agent observer hands every observation out as a task, with pictures, a
   assert.doesNotMatch(visual.prompt, /cannot hear/u, "a picture question carries no note about sound it never asked for");
 
   const audio = pending.find((task) => task.key === "audio:shot-002")!;
-  assert.match(audio.prompt, /cannot hear this reference/u, "a question that needs sound says the sound is missing rather than inviting a guess");
+  assert.match(audio.prompt, /cannot hear this reference/u, "a question that needs sound says so");
+  assert.match(audio.prompt, /transcript places there/u,
+    "and says how to answer it anyway, since there is no second source of sound to defer to");
   assert.equal(audio.image_refs.some((path) => path.endsWith(".wav")), false, "audio has no picture to become");
 
   const cached = JSON.parse(await readFile(join(stateRoot, "observations.json"), "utf8")) as Record<string, unknown>;


### PR DESCRIPTION
Follow-up to #25.

The sound questions on the `agent` observer told an observer that cannot hear to "say plainly which parts of the question need sound you do not have rather than inferring them from appearance." There is no second source of sound to defer to, so that only produced a shorter observation and left the gap open.

## What it says now

The prompt says how to answer from what there is:

> You are reading pictures and cannot hear this reference. Answer from the pictures and the measured transcript together: the transcript says exactly when words are spoken, and the pictures say who is on screen and whose mouth is moving while they are. Attribute speech to the person the pictures show speaking during the words the transcript places there, and answer the question in full rather than deferring the parts that would be easier with sound.

## The rule it has to live with

`continuity.md` asks for audio evidence over visible-person presence, because a mouth moving in silent B-roll misleads. That rule keeps its force on this observer through the transcript rather than through audio, and both files now say so: a person whose mouth moves during a stretch the transcript places no words in is not the speaker, however much they look like one. WhisperX measures those word timings locally and identically on both observers, so this is exact evidence rather than a substitute for it.

`observers.md`'s sound section is rewritten around the same three facts — the transcript says when, the pictures say who, and the two together are the evidence — and no longer describes the result as something to leave incomplete.

## Checks

11/11 package tests pass; the agent-path test now also asserts the prompt says how to answer, not only that it names the missing sound. `npx tsc -p tsconfig.json --noEmit` clean outside `examples/`. The rendered prompt was read back off a real `observe_reference` run with both Vertex variables unset.