### PR TITLE
A whole-reference question sees every frame, not one per shot

### DIFF
--- a/.agents/skills/hypit/references/reconstruction/observers.md
+++ b/.agents/skills/hypit/references/reconstruction/observers.md
@@ -39,11 +39,15 @@ This is the one question this route asks about how it runs. Everything else it d
 ## What the `agent` observer reads
 
 Each shot arrives as one picture: its frames sampled evenly across its duration and tiled in reading
-order, left to right then top to bottom. Read the grid as time passing. The whole reference arrives as
-the storyboard of representative frames. A task that carries a single picture carries one moment.
+order, left to right then top to bottom. Read the grid as time passing. A task that carries a single
+picture carries one moment. The number of frames follows the shot's length, from four for a short one
+to nine for a long one, so a cell stays wide enough to read detail in.
 
-The number of frames follows the shot's length, from four for a short one to nine for a long one, so
-a cell stays wide enough to read detail in.
+A whole-reference task carries the storyboard — every shot's representative frame in one picture, for
+reading the video at a glance — followed by every shot's tile, so the question sees every frame the
+shot observations see. On a long reference that is a lot of pictures, and it is the whole evidence:
+answer from all of them rather than from the storyboard alone, which shows one moment per shot and
+therefore answers neither what moves nor what recurs.
 
 ## How sound is answered on the `agent` observer
 

--- a/packages/reference-video-tools/src/tools.ts
+++ b/packages/reference-video-tools/src/tools.ts
@@ -179,7 +179,11 @@ function asPictures(media: readonly string[], state: ReferenceState): readonly s
   for (const path of media) {
     const tile = tiles.get(path);
     if (tile !== undefined) pictures.push(tile);
-    else if (path === state.analysis_video_ref) pictures.push(state.storyboard_ref);
+    // A whole-reference question is asked over the whole reference. The storyboard puts every shot in
+    // one picture and is how the video is read at a glance, but one frame per shot answers neither
+    // what moves nor what recurs, so the shot tiles come with it and the question sees every frame
+    // the shot observations see.
+    else if (path === state.analysis_video_ref) pictures.push(state.storyboard_ref, ...state.shots.map((shot) => shot.frames_tile_ref));
     else if (!path.toLowerCase().endsWith(".wav")) pictures.push(path);
   }
   return [...new Set(pictures)];


### PR DESCRIPTION
Follow-up to #25, found by asking what actually differs between the two observers rather than assuming the answer.

## The defect

`asPictures` translated `analysis.mp4` — the whole video — into `storyboard.jpg` alone. The storyboard is a tile of **one representative frame per shot**. So on the `agent` observer:

- the per-shot observations saw every sampled frame of their shot, as intended;
- `people_and_product`, `voices`, `persistent_systems` and `places` saw one frame per shot for the entire reference.

`places` asks which camera positions appear and how each is lit and framed. `persistent_systems` asks whether a system's appearance ever changes and where. `people_and_product` asks what a recurring person looks like across the video. None of those is answerable from one frame per shot, and the `gemini` observer answers them from the whole video with its sound.

Verified before the fix on a two-shot reference: all four whole-reference tasks carried `['storyboard.jpg']` and nothing else.

## The fix

The translation now yields the storyboard followed by every shot's tile, so a whole-reference question sees every frame the shot observations see. After the fix, the same reference reports `['storyboard.jpg', '001-frames.jpg', '002-frames.jpg']` for each of the four.

On a long reference that is many pictures. `observers.md` says so, and says to answer from all of them rather than from the storyboard alone — the alternative was a silent cap that would read as full coverage while not being it.

## Checks

11/11 package tests pass. `npx tsc -p tsconfig.json --noEmit` clean outside `examples/`. Before and after both read off real `prepare_reference --observer agent` runs with the Vertex variables unset.