### PR TITLE
Build a frame tile only for the observer that reads it

### DIFF
--- a/packages/reference-video-tools/src/media.ts
+++ b/packages/reference-video-tools/src/media.ts
@@ -127,7 +127,7 @@ async function shotTile(clip: string, duration: number, target: string): Promise
   return target;
 }
 
-export async function prepareMedia(videoPath: string, root: string, duration: number): Promise<{
+export async function prepareMedia(videoPath: string, root: string, duration: number, tiles: boolean): Promise<{
   readonly bounds: readonly Bounds[];
   readonly storyboard: string;
   readonly analysisVideo: string;
@@ -146,7 +146,9 @@ export async function prepareMedia(videoPath: string, root: string, duration: nu
     await extract(videoPath, ["-i", videoPath, "-ss", String(bound.start), "-t", String(Math.max(0.1, bound.end - bound.start)), "-c:v", "libx264", "-preset", "veryfast", "-crf", "23", "-c:a", "aac", "-b:a", "96k", "-movflags", "+faststart"], clip);
     await extract(videoPath, ["-i", videoPath, "-ss", String(bound.start + (bound.end - bound.start) / 2), "-frames:v", "1", "-vf", "scale='min(720,iw)':-2", "-q:v", "3"], join(shotDir, `${id}-representative.jpg`));
     await extract(videoPath, ["-sseof", "-0.1", "-i", clip, "-update", "1", "-frames:v", "1", "-vf", "scale='min(720,iw)':-2", "-q:v", "3"], join(shotDir, `${id}-tail.jpg`));
-    await shotTile(clip, bound.end - bound.start, join(shotDir, `${id}-frames.jpg`));
+    // Only the observer that reads pictures has anything to read them from, and building a tile per
+    // shot is a decode per shot. The other observer is handed the clip itself.
+    if (tiles) await shotTile(clip, bound.end - bound.start, join(shotDir, `${id}-frames.jpg`));
     if (await hasAudio(clip)) await extract(videoPath, ["-sseof", "-3", "-i", clip, "-map", "0:a:0", "-vn", "-ac", "1", "-ar", "16000", "-c:a", "pcm_s16le"], join(shotDir, `${id}-audio.wav`));
   }));
   const inputs = bounds.map((_, index) => `[${index}:v]`).join("");

--- a/packages/reference-video-tools/src/tools.ts
+++ b/packages/reference-video-tools/src/tools.ts
@@ -178,12 +178,17 @@ function asPictures(media: readonly string[], state: ReferenceState): readonly s
   const pictures: string[] = [];
   for (const path of media) {
     const tile = tiles.get(path);
-    if (tile !== undefined) pictures.push(tile);
+    if (tile !== undefined) {
+      // Every shot of a reference prepared for this observer has a tile. One without means the media
+      // was prepared for the observer that reads video, which `prepare_reference` refuses to mix.
+      assert(tile !== null, `shot media for ${path} has no frame tile; re-prepare the reference with --redo all --observer agent`);
+      pictures.push(tile);
+    }
     // A whole-reference question is asked over the whole reference. The storyboard puts every shot in
     // one picture and is how the video is read at a glance, but one frame per shot answers neither
     // what moves nor what recurs, so the shot tiles come with it and the question sees every frame
     // the shot observations see.
-    else if (path === state.analysis_video_ref) pictures.push(state.storyboard_ref, ...state.shots.map((shot) => shot.frames_tile_ref));
+    else if (path === state.analysis_video_ref) pictures.push(state.storyboard_ref, ...state.shots.flatMap((shot) => shot.frames_tile_ref === null ? [] : [shot.frames_tile_ref]));
     else if (!path.toLowerCase().endsWith(".wav")) pictures.push(path);
   }
   return [...new Set(pictures)];
@@ -259,7 +264,7 @@ async function runObservationTasks(
   return new Map(tasks.map((task) => [task.key, cache[task.key] ?? answers.get(task.key) ?? observation("failed", "not observed")]));
 }
 
-async function shotFromBound(root: string, index: number, bound: { start: number; end: number; group: number; part: number; parts: number }): Promise<Shot> {
+async function shotFromBound(root: string, index: number, bound: { start: number; end: number; group: number; part: number; parts: number }, tiles: boolean): Promise<Shot> {
   const id = String(index + 1).padStart(3, "0");
   const dir = join(root, "shots");
   const audioPath = join(dir, `${id}-audio.wav`);
@@ -277,7 +282,7 @@ async function shotFromBound(root: string, index: number, bound: { start: number
     clip_ref: join(dir, `${id}.mp4`),
     representative_frame_ref: join(dir, `${id}-representative.jpg`),
     tail_frame_ref: join(dir, `${id}-tail.jpg`),
-    frames_tile_ref: join(dir, `${id}-frames.jpg`),
+    frames_tile_ref: tiles ? join(dir, `${id}-frames.jpg`) : null,
     audio_tail_ref,
   };
 }
@@ -438,8 +443,8 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
         state = existing;
         analysisVideo = existing.analysis_video_ref;
       } else {
-        const media = await prepareMedia(videoPath, root, info.duration);
-        const shots = await Promise.all(media.bounds.map((bound, index) => shotFromBound(root, index, bound)));
+        const media = await prepareMedia(videoPath, root, info.duration, observer === "agent");
+        const shots = await Promise.all(media.bounds.map((bound, index) => shotFromBound(root, index, bound, observer === "agent")));
         state = {
           reference_id: reference,
           video_path: videoPath,

--- a/packages/reference-video-tools/src/types.ts
+++ b/packages/reference-video-tools/src/types.ts
@@ -45,8 +45,11 @@ export type Shot = {
   readonly clip_ref: string;
   readonly representative_frame_ref: string;
   readonly tail_frame_ref: string;
-  /** The shot's frames sampled evenly and tiled into one picture, in reading order. */
-  readonly frames_tile_ref: string;
+  /**
+    * The shot's frames sampled evenly and tiled into one picture, in reading order. Built for the
+    * `agent` observer, which reads it in place of the clip, and null for the observer that reads video.
+    */
+  readonly frames_tile_ref: string | null;
   readonly audio_tail_ref: string | null;
 };
 


### PR DESCRIPTION
`prepare_reference` built one tile per shot whatever the observer, so the Gemini path paid an ffmpeg decode per shot, and wrote a file per shot, for pictures it never opens.

The reason I gave for that in #25 was that either observer could then be chosen later without re-preparing. That is not true: `prepare_reference` refuses to change the observer of a reference without `--redo all`, which re-prepares the media anyway. So the flexibility the unconditional build was buying did not exist, and what remained was the work.

## What changed

`prepareMedia` takes whether tiles are wanted, and `frames_tile_ref` is `null` when they are not — the same shape `audio_tail_ref` already uses for a silent shot. `asPictures` names the fix rather than handing an mp4 to an image reader if it ever meets a shot without one.

## Checks

| Observer | `-frames.jpg` on disk | `frames_tile_ref` |
|---|---|---|
| `gemini` (default) | 0 | `null` |
| `agent` | one per shot | the tile |

Read off two real `prepare_reference` runs on the same two-shot video. 11/11 package tests pass; `npx tsc -p tsconfig.json --noEmit` clean outside `examples/`.

The Gemini path's model calls were already proven byte-for-byte unchanged against the pre-refactor commit — 13 calls, same order, media, instructions and prompts. This restores its disk layout too. What it still gains over the pre-refactor state is `observer` in the state file and result, `pending_observations: []` in the result, and a `frames_tile_ref: null` per shot.