### PR TITLE
Say which observer is reading, and that the agent one reads less closely

### DIFF
--- a/.agents/skills/hypit/references/reconstruction/index.md
+++ b/.agents/skills/hypit/references/reconstruction/index.md
@@ -85,9 +85,14 @@ which directory, or whether to proceed.
 
 Ask the author which observer reads the reference, and ask it before anything runs. `gemini` uploads
 the video to Vertex and hears it; `agent` hands each observation to you as a picture to read and needs
-no credentials. Read `observers.md` first: it says what each one costs, how to report what this
-machine holds rather than asking the author to recall it, and what the `agent` observer can and cannot
-answer. The answer is passed once, as `--observer`, and the reference keeps it.
+no credentials. Read `observers.md` first: it says what each one costs in the terms the author needs
+to choose between them, how to report what this machine holds rather than asking them to recall it,
+and what the `agent` observer can and cannot answer. The answer is passed once, as `--observer`, and
+the reference keeps it.
+
+When the Vertex credentials are absent, `agent` is what can run — say that, say that it reads the
+reference a little less closely, and take the author's answer. Then say which observer is reading,
+before the evidence starts. Both are in `observers.md`.
 
 This is the only question this route asks about how it runs, and it is asked once, before the evidence
 starts.

--- a/.agents/skills/hypit/references/reconstruction/observers.md
+++ b/.agents/skills/hypit/references/reconstruction/observers.md
@@ -22,16 +22,31 @@ the other path's does.
 
 ## Choosing
 
-Ask the author once, before `prepare_reference`, and say what each one costs them. Report what this
-machine actually holds rather than asking them to recall it:
+Ask the author once, before `prepare_reference`. Report what this machine actually holds rather than
+asking them to recall it:
 
 ```text
 node .agents/skills/hypit/scripts/check-credentials.mjs GOOGLE_CLOUD_PROJECT GOOGLE_APPLICATION_CREDENTIALS_JSON
 ```
 
-Both variables `set` means `gemini` is available and the author chooses. Either one `missing` means
-`agent` is the path that can run today, and the author decides whether to run it or to configure
-Vertex first — `../credentials.md` says what those two variables are.
+Both variables `set` means `gemini` is available and the author chooses between the two. Either one
+`missing` means `agent` is the path that can run today; say so, say what it costs, and let the author
+decide whether to run it or to configure Vertex first. `../credentials.md` says what those two
+variables are.
+
+Say that `agent` reads the reference a little less closely — a shot arrives as sampled frames rather
+than continuous video, so continuity across it is read rather than watched, and there is no sound, so
+a voice is attributed rather than heard. The reconstruction it produces is a working one. Say it once,
+take the answer, and run.
+
+## Say which path is running
+
+Once the answer is in, tell the author which observer is reading the reference, before the evidence
+starts. One line is enough, and it names the observer and the reason: the credentials are there and
+they chose it, or the credentials are absent and this is the path that runs.
+
+The author reads the observations, the sources and eventually the video. Which observer produced the
+evidence changes what those are worth, and it is not visible in any of them.
 
 This is the one question this route asks about how it runs. Everything else it decides:
 `index.md` still owns the working directory, the project location, the vocabulary and the generators.


### PR DESCRIPTION
Follow-up to #25. The route asked the author which observer to use and then never mentioned it again.

## Two gaps

**The cost was never stated.** An author with no Vertex credentials was told `agent` is the path that can run, and left to guess what taking it means. `observers.md` now says it in a sentence:

> Say that `agent` reads the reference a little less closely — a shot arrives as sampled frames rather than continuous video, so continuity across it is read rather than watched, and there is no sound, so a voice is attributed rather than heard. The reconstruction it produces is a working one. Say it once, take the answer, and run.

**Which path ran was never announced.** The author reads the observations, the sources and eventually the video; which observer produced the evidence changes what all of those are worth and appears in none of them. Saying it is now required, once, before the evidence starts, naming the observer and why it is the one running.

`index.md` points at both rules at the moment the question is asked.