### PR TITLE
Give each observation to its own subagent where the harness has them

### DIFF
--- a/.agents/skills/hypit/references/reconstruction/index.md
+++ b/.agents/skills/hypit/references/reconstruction/index.md
@@ -92,7 +92,9 @@ the reference keeps it.
 
 When the Vertex credentials are absent, `agent` is what can run — say that, say that it reads the
 reference a little less closely, and take the author's answer. Then say which observer is reading,
-before the evidence starts. Both are in `observers.md`.
+before the evidence starts. Both are in `observers.md`, which also says to give each observation to
+its own subagent where the harness has them: that is what makes the sweep parallel rather than serial,
+and what keeps the observations independent of one another.
 
 This is the only question this route asks about how it runs, and it is asked once, before the evidence
 starts.

--- a/.agents/skills/hypit/references/reconstruction/observers.md
+++ b/.agents/skills/hypit/references/reconstruction/observers.md
@@ -85,13 +85,35 @@ and do not put the gap to the author.
 `voices` and the sound half of each `boundary` are the observations this shapes. They are attributions
 read off pictures and word timings, and that is what a later reader should take them for.
 
-## The comparison in the loop is yours too
+## Answer each task in its own subagent when you can
 
-`compare_reconstruction` on the `agent` observer returns the two images and the same question rather
-than an answer. You look at the reference frame and your render and describe the differences yourself.
+Every task the tool returns is self-contained: a `key`, an `instruction`, a `prompt` that already
+carries the whole-reference context, and absolute `image_refs`. No task refers to another task's
+answer. So if the harness you are running in can spawn subagents — Claude Code and Codex can, and
+some cannot — give each task to its own, and run them together.
 
-That makes the report yours, and you know what you built, so the discipline that keeps it useful is
-explicit:
+Hand the subagent the `instruction`, the `prompt` verbatim and the `image_refs`, and nothing else.
+Not what you built, not which component drew anything, not what you expect it to find, and not another
+observation's answer. Take the returned text and write it with `record_observation` yourself, so one
+writer owns the cache.
+
+Two things follow from one task per subagent, and both of them are properties the `gemini` observer
+has for free:
+
+- **The observations are independent again.** Each one is answered by a reader that saw only its own
+  pictures and its own question, which is what a separate request to Gemini is. Two observations
+  agreeing is evidence again rather than one reader being consistent with itself.
+- **The comparison closes blind.** A subagent handed two unlabelled images and the comparison question
+  does not know which is the reference, what was built or what you hoped to see. That is the same
+  unlabelled pair the other observer gets.
+
+Answer the tasks in order yourself when the harness has no subagents. It is slower, and it is the
+fallback rather than the shape to aim for.
+
+## Comparing without subagents
+
+Answering the comparison yourself makes the report yours, and you know what you built, so the
+discipline that keeps it useful has to be explicit:
 
 - **Write the differences down before naming a cause.** List what is visibly different, in the words
   you would use if you had never seen the source. Deciding what went wrong first, then looking, finds
@@ -101,6 +123,9 @@ explicit:
 - **Measure rather than iterate.** A stroke that is too thick, a shape that is too tall, a margin that
   is too wide — read the number off the frame against the frame's own width and height, and change the
   value once. `reconstruction-loop.md` says why an attempt is for differences that have no number.
+
+The same three hold when a subagent compares, and they cost nothing there; what a subagent adds is
+that the comparer is not the builder.
 
 ## Running it
 

--- a/.agents/skills/hypit/references/reconstruction/reconstruction-loop.md
+++ b/.agents/skills/hypit/references/reconstruction/reconstruction-loop.md
@@ -62,11 +62,13 @@ very bias it claims to correct: it sees the reconstruction, knows what was built
 expects. This is why a font that is wrong is caught — the comparison names it, and the package is
 repaired, rather than a font being chosen because it resembles what you remember.
 
-**On the `agent` observer, that observer is you**, and the command returns the two images and the
-question instead of an answer. The bias above is then real and unavoidable, so `observers.md` states
-the discipline that replaces blindness: write the differences down before naming a cause, count only
-repairs aimed at a difference you wrote down, and read a quantity off the frame rather than spending
-an attempt guessing at it.
+**On the `agent` observer the command returns the two images and the question instead of an answer,
+and who looks at them is up to the harness.** Give them to a subagent when you can: one handed two
+unlabelled images and the question knows neither which is the reference nor what was built, which is
+the same blindness this section rests on. Answer it yourself only when there are no subagents, and
+then the bias above is real, so `observers.md` states the discipline that stands in for blindness —
+write the differences down before naming a cause, count only repairs aimed at a difference you wrote
+down, and read a quantity off the frame rather than spending an attempt guessing at it.
 
 Hypit Studio is a browser preview for a person to look at. It is not a source of the image this
 loop needs: that image is the local still render in `../preview.md`, which draws one element without


### PR DESCRIPTION
The `agent` observer answered every task in one context, in order. Testing showed that is slow on a reference of any length, and it was also paying for two properties the `gemini` observer has for free.

## What a subagent per task restores

**Speed.** The sweep runs together instead of one shot after another.

**Independence.** Each observation is answered by a reader that saw only its own pictures and its own question — which is exactly what a separate request to Gemini is. Two observations agreeing becomes evidence again, rather than one reader being consistent with itself.

**Blindness in the loop.** A subagent handed two unlabelled images and the comparison question knows neither which is the reference nor what was built. That is the same unlabelled pair `compare_reconstruction` sends on the other path, and it is the property `reconstruction-loop.md`'s whole convergence design rests on.

## No tool change

Each task the CLI already returns is self-contained, which I checked rather than assumed: `key`, `instruction`, a `prompt` that already carries the whole-reference context the Gemini path also seeds into per-shot requests, and absolute `image_refs`. No task refers to another task's answer. One task is exactly one subagent's work.

`observers.md` states what may be handed over — the instruction, the prompt verbatim, the images — and what may not: what was built, which component drew anything, what you expect to be found, or another observation's answer. The main agent records the returned text with `record_observation`, so one writer owns the cache.

## The fallback

Answering the tasks in order is still what a harness without subagents does, and it is now named as the fallback rather than the shape to aim for. The discipline that stands in for blindness moves into its own section and applies there.

## What still differs from the Gemini observer

Two things, and only two: it cannot hear the reference, and a shot reaches it as sampled frames rather than continuous video.