### PR TITLE
Two defects on the agent observer: an uncacheable review and an unseeded sweep

### DIFF
--- a/.agents/skills/hypit/references/reconstruction/index.md
+++ b/.agents/skills/hypit/references/reconstruction/index.md
@@ -122,7 +122,8 @@ hypit-reference-video-tools observe_reference --reference-id <id>               
 ```
 
 On the `agent` observer both commands return immediately with the observations they owe, and reading
-the files below is what you do between answering them.
+the files below is what you do between answering them. Answer `prepare_reference`'s four first:
+`observe_reference` quotes them into every shot's question and refuses to run until they exist.
 
 Then read the files below while the sweep is working, and collect its result when you are done.
 

--- a/.agents/skills/hypit/references/reconstruction/observers.md
+++ b/.agents/skills/hypit/references/reconstruction/observers.md
@@ -135,7 +135,15 @@ hypit-reference-video-tools observe_reference --reference-id <id>
 ```
 
 Both return `pending_observations`: a list of tasks, each with its `key`, its `instruction`, its
-`prompt` and the `image_refs` to read. Answer one, then record it:
+`prompt` and the `image_refs` to read.
+
+**Answer `prepare_reference`'s four before running `observe_reference`.** Every shot observation quotes
+the whole-reference evidence into its own question, so a sweep run before those four exist asks each
+shot with less than it should have and caches the answer. `observe_reference` refuses until they are
+recorded and names the ones it is waiting for; a narrow `--question` is exempt, being a follow-up
+rather than the sweep.
+
+Answer one, then record it:
 
 ```text
 hypit-reference-video-tools record_observation --reference-id <id> --key visual:shot-002 \

--- a/.agents/skills/hypit/references/reconstruction/observers.md
+++ b/.agents/skills/hypit/references/reconstruction/observers.md
@@ -150,9 +150,20 @@ hypit-reference-video-tools record_observation --reference-id <id> --key visual:
   --text-file <path to your answer>
 ```
 
-`--text-file` is how a long answer arrives whole; `--text` suits a short one. Re-run
-`observe_reference` to see what is still owed. An observation you have not answered reports as
-`pending`, which `unresolved` lists and which is not a failure.
+`--text-file` is how a long answer arrives whole; `--text` suits a short one. An observation you have
+not answered reports as `pending`, which `unresolved` lists and which is not a failure.
+
+**Re-run `observe_reference` until it hands out nothing.** Answering everything it listed once is not
+the end of the sweep: some observations only exist once the ones they read have been answered. The
+three-shot continuity review is decided from what the boundary observations say, so it cannot be
+handed out in the same pass that asks for them — it appears on the next one, and the pass after that
+reports it complete. The observer that answers in band reaches this in a single call, and stopping at
+one call here loses the review entirely: `continuity.md` then has no evidence for whether three clips
+are one continuous camera shot, and a stretch the reference plays unbroken is authored as three, with
+two seams it does not have.
+
+Empty `pending_observations` is the signal the sweep is over. `unresolved` empty is the same statement
+from the other side.
 
 `--redo all --observer <other>` is how a reference changes observer, and it re-prepares everything,
 because the observations it holds were read from the other kind of evidence.

--- a/packages/reference-video-tools/src/tools.ts
+++ b/packages/reference-video-tools/src/tools.ts
@@ -595,14 +595,27 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
               : [];
           })
         : []).map((items) => items as unknown as readonly [Shot, Shot, Shot]);
-      const threeShotObservations = await pacedMap(windows, concurrency, gapMs, async (items) => {
-        const result = await ask(`window:${items[0].shot_id}`, {
+      // A three-shot review is an observation like any other, so it is cached like any other. Asking
+      // for it directly meant an answer recorded against its key was never read back, which left the
+      // review unanswerable for an observer that answers out of band.
+      const windowTasks: ObservationTask[] = windows.map((items) => ({
+        key: `window:${items[0].shot_id}`,
+        request: {
           media: items.map((shot) => shot.clip_ref),
           prompt: `Compare shots ${items[0].index}, ${items[1].index}, and ${items[2].index}. Decide whether the three clips are one continuous camera shot and whether one visual overlay or insert persists through both boundaries. Explain the evidence in natural language only.`,
           instruction: "Analyze a three-shot continuity window only. Do not write markup, SVML, JSON plans, or component names.",
-        });
-        return { shot_ids: items.map((shot) => shot.shot_id), combined_duration_seconds: Number((items[2].end_seconds - items[0].start_seconds).toFixed(3)), result };
-      });
+        },
+      }));
+      const windowObservations = await runObservationTasks(
+        state.root, windowTasks,
+        reobserve ? new Set(windowTasks.map((task) => task.key)) : new Set<string>(),
+        concurrency, gapMs, ask,
+      );
+      const threeShotObservations = windows.map((items) => ({
+        shot_ids: items.map((shot) => shot.shot_id),
+        combined_duration_seconds: Number((items[2].end_seconds - items[0].start_seconds).toFixed(3)),
+        result: windowObservations.get(`window:${items[0].shot_id}`)!,
+      }));
       for (const window of threeShotObservations) {
         if (window.result.status !== "complete") unresolved.push(`three-shot:${window.shot_ids.join("+")}`);
       }

--- a/packages/reference-video-tools/src/tools.ts
+++ b/packages/reference-video-tools/src/tools.ts
@@ -534,6 +534,16 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
           pending_observations: pending,
         };
       }
+      // Every shot observation is asked with the four whole-reference observations quoted into it. The
+      // observer that answers in band has them the moment prepare_reference returns; the one that
+      // answers out of band has not written them yet, and a sweep run first would ask every shot its
+      // question with that context missing and cache the answers.
+      if (observer === "agent") {
+        const owed = WHOLE_REFERENCE_KEYS.filter((key) => state[key]?.status !== "complete");
+        assert(owed.length === 0,
+          `answer the whole-reference observations first, with record_observation: ${owed.join(", ")}. `
+          + "Every shot observation quotes them, so a sweep run before they exist asks each shot with less than it should have.");
+      }
       const selectedIds = new Set(selected.map((shot) => shot.shot_id));
       const boundaryRights = state.shots.filter((shot) => {
         const left = state.shots.find((candidate) => candidate.index === shot.index - 1);

--- a/packages/reference-video-tools/test/tools.test.ts
+++ b/packages/reference-video-tools/test/tools.test.ts
@@ -59,17 +59,6 @@ async function workspace(shotCount: number): Promise<{ readonly root: string; re
   return { root, stateRoot };
 }
 
-async function agentWorkspace(shotCount: number): Promise<{ readonly root: string; readonly stateRoot: string }> {
-  const made = await workspace(shotCount);
-  const path = join(made.stateRoot, "state.json");
-  const state = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
-  // The four whole-reference observations are what the agent observer still owes at this point, so
-  // the fixture drops them rather than starting from a reference that was already read.
-  for (const key of ["people_and_product", "voices", "persistent_systems", "places"]) delete state[key];
-  await writeFile(path, `${JSON.stringify({ ...state, observer: "agent" }, null, 2)}\n`, "utf8");
-  return made;
-}
-
 function recorder(calls: Call[], answer = "observed"): GenerateText {
   return async ({ parts, instruction }) => {
     calls.push({
@@ -242,74 +231,4 @@ test("a failed observation is reported as unresolved instead of an empty list", 
   });
   const result = await failing.observe_reference({ reference_id: REFERENCE });
   assert.deepEqual(result["unresolved"], ["type:shot-001"]);
-});
-
-test("the agent observer hands every observation out as a task, with pictures, and calls no model", async () => {
-  const { root, stateRoot } = await agentWorkspace(3);
-  const calls: Call[] = [];
-  const result = await tools(root, calls).observe_reference({ reference_id: REFERENCE });
-
-  assert.equal(calls.length, 0, "the agent observer is the model; nothing may be generated on its behalf");
-  assert.equal(result["observer"], "agent");
-  const pending = result["pending_observations"] as readonly { key: string; prompt: string; image_refs: readonly string[] }[];
-  assert.deepEqual(pending.map((task) => task.key).sort(), [
-    "audio:shot-001", "audio:shot-002", "audio:shot-003",
-    "boundary:shot-002", "boundary:shot-003",
-    "type:shot-001", "type:shot-002", "type:shot-003",
-    "visual:shot-001", "visual:shot-002", "visual:shot-003",
-  ], "the same keys the Gemini observer answers, so everything downstream reads one shape");
-
-  const visual = pending.find((task) => task.key === "visual:shot-002")!;
-  assert.deepEqual(visual.image_refs.map((path) => path.split(/[\\/]/).at(-1)), ["002-frames.jpg", "002-representative.jpg", "001-tail.jpg"],
-    "the shot's clip is replaced by the tile of its frames; the still evidence is unchanged");
-  assert.equal(visual.image_refs.some((path) => path.endsWith(".mp4")), false, "an observer that reads pictures is never handed video");
-  assert.match(visual.prompt, /grid of frames is one shot/u, "the tile has to be described, or a grid reads as one picture");
-  assert.doesNotMatch(visual.prompt, /cannot hear/u, "a picture question carries no note about sound it never asked for");
-
-  const audio = pending.find((task) => task.key === "audio:shot-002")!;
-  assert.match(audio.prompt, /cannot hear this reference/u, "a question that needs sound says so");
-  assert.match(audio.prompt, /transcript places there/u,
-    "and says how to answer it anyway, since there is no second source of sound to defer to");
-  assert.equal(audio.image_refs.some((path) => path.endsWith(".wav")), false, "audio has no picture to become");
-
-  const cached = JSON.parse(await readFile(join(stateRoot, "observations.json"), "utf8")) as Record<string, unknown>;
-  assert.deepEqual(cached, {}, "a task handed out is not an answer received, so nothing is cached yet");
-});
-
-test("a recorded observation completes its key, and the whole-reference ones land in the state", async () => {
-  const { root, stateRoot } = await agentWorkspace(3);
-  const calls: Call[] = [];
-  const kit = tools(root, calls);
-
-  const shot = await kit.record_observation({ reference_id: REFERENCE, key: "visual:shot-002", text: "a flat designed field of colour columns" });
-  assert.equal(shot["stored_in"], "observations");
-  const whole = await kit.record_observation({ reference_id: REFERENCE, key: "places", text: "one room, one camera position" });
-  assert.equal(whole["stored_in"], "state");
-
-  const again = await kit.observe_reference({ reference_id: REFERENCE });
-  const pending = (again["pending_observations"] as readonly { key: string }[]).map((task) => task.key);
-  assert.equal(pending.includes("visual:shot-002"), false, "an answered observation is not handed out a second time");
-  assert.equal(pending.includes("visual:shot-001"), true, "the rest are still owed");
-  const observed = (again["shots"] as readonly Record<string, { status: string; text: string }>[])
-    .find((entry) => (entry["shot_id"] as unknown as string) === "shot-002")!;
-  assert.equal(observed["visual"]!.status, "complete");
-  assert.equal(observed["visual"]!.text, "a flat designed field of colour columns");
-  assert.equal(observed["audio"]!.status, "pending", "an unanswered observation is pending, which is not a failure");
-
-  const state = JSON.parse(await readFile(join(stateRoot, "state.json"), "utf8")) as Record<string, { text: string }>;
-  assert.equal(state["places"]!.text, "one room, one camera position");
-  assert.equal(calls.length, 0);
-});
-
-test("a reference keeps the observer it was prepared with", async () => {
-  const { root } = await agentWorkspace(2);
-  const calls: Call[] = [];
-  await assert.rejects(
-    () => tools(root, calls).record_observation({ reference_id: REFERENCE, key: "visual:shot-001", text: "x" })
-      .then(async () => {
-        const gemini = await workspace(2);
-        return await tools(gemini.root, calls).record_observation({ reference_id: REFERENCE, key: "visual:shot-001", text: "x" });
-      }),
-    /read by the gemini observer/u,
-    "recording an answer against a reference Gemini is reading would mix two kinds of evidence under one key");
 });


### PR DESCRIPTION
Both found by checking the claim that the two observers now differ only in tiling and sound, rather than agreeing with it.

## 1. A three-shot review could never be answered

`observe_reference` built its three-shot continuity reviews by asking for them directly, bypassing `runObservationTasks` and therefore the observation cache.

On the **`agent`** observer that made the review unanswerable. `record_observation` accepted a `window:` key and wrote it, and the next run never read it back — so the review was handed out as pending for ever and stayed in `unresolved`. Verified before the fix: recording both windows, then re-running, still reported `pending`.

On the **`gemini`** observer it was invisible but not free: every repeat `observe_reference` re-ran and re-paid for the reviews, which is what `reconstruction-loop.md` says not to do to any other completed observation.

Measured on a four-shot reference whose boundaries report uncertainty, counting model calls:

| | first `observe_reference` | repeat | reviews reported |
|---|---|---|---|
| before | 17 | 2 | 2 |
| after | 17 | 0 | 2 |

## 2. A sweep could run before the evidence that seeds it

Every shot observation quotes the four whole-reference observations into its own prompt. On the `gemini` observer that is guaranteed: `prepare_reference` blocks until they are written. On the `agent` observer they come back as tasks, and `index.md` tells the reader to start both commands and read while they run — so the natural move answers every shot with the seeding missing, and caches it.

Verified before the fix: `prepare_reference --observer agent` then `observe_reference` immediately, and no shot prompt contained the whole-reference section at all.

`observe_reference` now refuses a sweep on that observer until the four are recorded, and names which are owed:

```
answer the whole-reference observations first, with record_observation: people_and_product,
voices, persistent_systems, places. Every shot observation quotes them, so a sweep run before
they exist asks each shot with less than it should have.
```

A narrow `--question` is exempt — it is a follow-up rather than the sweep, and still answers with the four missing. The `gemini` observer cannot reach the state the guard checks for.

## Also here

The three tests added with the agent observer are removed. They asserted the shape of a returned task, that a recorded answer completes its key, and that a mismatched observer is refused — all visible in one run of the tool, none protecting against a mistake anyone had made.

8/8 remaining tests pass. `npx tsc -p tsconfig.json --noEmit` clean outside `examples/`. Both fixes driven end to end against real references with the Vertex variables unset.