### PR TITLE
fix(reconstruction): always estimate take durations; close the anchoring gate

### DIFF
--- a/.agents/skills/hypit/references/playbooks/craft/sfx.md
+++ b/.agents/skills/hypit/references/playbooks/craft/sfx.md
@@ -31,7 +31,10 @@ Declare the source, normalize it to audio-only `SynchronizedMedia`, and place it
 ```
 
 - Use `during={story.selection.NAME}` for a range, a Script Moment plus `for` for a point event, or
-  explicit `start`/`end` timing in the SemanticTrack frame domain.
+  explicit `start`/`end` timing in the SemanticTrack frame domain — the last only for a program
+  with no speech to anchor to, the same gate `overlays.md` and `screen-demo.md` put on absolute
+  placement. Copying the reference's own seconds into an `start=`/`end=` is the same defect
+  `continuity.md` names for covering content.
 - Use `playback="once"` for a discrete effect, loop only for a genuinely repeating texture, and
   bounded pitch-preserving stretch only when the occupancy must fill an authored range.
 - Use explicit trim, gain, fade-in, and fade-out. The Audio Track preserves source level and does not

--- a/.agents/skills/hypit/references/reconstruction/final-sources.md
+++ b/.agents/skills/hypit/references/reconstruction/final-sources.md
@@ -27,20 +27,23 @@ consecutive Segments carrying one unbroken voiceover are one Segment with Select
 `../playbooks/craft/generated-dependencies.md` says why — a Segment is a generation boundary, and
 splitting a stretch the reference delivers unbroken invents a seam it does not have.
 
-## A take's duration is measured, not estimated
+## A take's duration is estimated, not read off the reference
 
-`estimate:Speech` predicts how long a line will take to say. In this route that prediction is the
-wrong input, because the reference already contains the answer: `prepare_reference` measured every
-word of it, so each Segment's real duration is the span from its first word's start to its last
-word's end in `transcript_ref`. Write that number on the take.
+Every take is generated, and the generated speech plays at its own pace, not the reference's. So
+each take's duration comes from `estimate:Speech` — the prediction of how long the generated line
+will be. Write that estimate on the take.
 
-An estimate is not close enough to skip this. A reconstruction whose Segments are each estimated a
-second long finishes several seconds longer than the reference, and every reveal, cut and overlay
-lands late against a program that no longer matches the thing it reconstructs. The estimate is for
-original authoring, where nobody has said the words yet.
+The reference's measured word timings describe how the original speaker delivered the line; the
+reconstruction re-speaks it, and the generated take will not match that recording second for
+second. Reading the reference's span onto the take fixes a length that has nothing to do with how
+the generator speaks.
 
-Keep the estimate only where the reference cannot answer: a line the reconstruction adds, or a
-Segment whose speech the reference never contains.
+Nothing depends on the estimate being exact. Script Selections bind every placed element to the
+words, and the SemanticTrack places the words where the generated audio actually has them, so a
+take that comes back a little long or short moves the words, not the bindings. This is also what
+lets a reconstruction survive the author changing the lines: the estimate recomputes from the new
+words, where a literal read off the old reference would not. `estimate:Speech` takes
+`story.segment.NAME.speech`, so the duration follows the script it is asked to predict.
 
 Then check and wire, in that order. `../authoring.md` holds the check set — all four commands, not
 only the Author Source — and `../preview.md` holds the graph check that comes after it. A Source that

--- a/.agents/skills/hypit/references/reconstruction/observers.md
+++ b/.agents/skills/hypit/references/reconstruction/observers.md
@@ -111,8 +111,8 @@ and do not put the gap to the author.
 
 - **The transcript says when.** WhisperX measures every word locally on both paths, so the words and
   their timings are exact whichever observer reads the pictures. That settles whether anyone is
-  speaking at a given moment, and `final-sources.md` still takes Segment durations from
-  `transcript_ref` as it always does.
+  speaking at a given moment, and where a word sits. It does not set a take's duration: the take is
+  generated and its length comes from `estimate:Speech`, as `final-sources.md` requires.
 - **The pictures say who.** Attribute speech to the person the frames show speaking during the words
   the transcript places there. A task that needs sound says so in its own prompt and asks for exactly
   this reading.

--- a/.agents/skills/hypit/references/reconstruction/workflow.md
+++ b/.agents/skills/hypit/references/reconstruction/workflow.md
@@ -60,8 +60,9 @@ word, measured locally by WhisperX. It is not an observation: no model wrote it,
 reaches an observer, and it does not go in the observation cache. It is identical on both observers,
 and on the `agent` observer it is the only exact record of the sound. Read it whenever a decision depends on
 when a word is said — placing each on-screen text reveal against the line that triggers it, timing a
-caption, checking that a voice observation matches what was actually spoken, or setting how long a
-take runs, which `final-sources.md` measures from these words rather than estimating. Do not run WhisperX
+caption, checking that a voice observation matches what was actually spoken, or judging a Segment's
+natural boundary. It does not set a take's duration: the take is generated and its length comes from
+`estimate:Speech`, as `final-sources.md` requires. Do not run WhisperX
 by hand and do not ask a model to transcribe: the transcript is already there.
 
 `transcript` reports `status`, `transcript_ref` and `word_count`. Read the words from


### PR DESCRIPTION
修复核对工作流发现的两处问题。

## 估时规则（用户方向）

复刻路由此前从原片转录读 take 时长。改为**始终用 `estimate:Speech`**：
- take 是生成的，生成语音按自己的节奏说话，不是按原片录音；
- 估时跟随脚本（`source={story.segment.NAME.speech}`），改稿后自动重算——字面量不会。

改动：
- `final-sources.md`：改为主规则（estimated, not read off the reference）
- `workflow.md`：转录不再设 take 时长，只定词的位置与 Segment 边界
- `observers.md`：修掉验证扫出的矛盾（"still takes Segment durations from transcript_ref"）

## 锚定门

核对发现 `sfx.md` 是唯一把显式 `start/end` 列为无条件选项的文件（b-roll/overlays/screen-demo 都带无语音限定）。已补同样的门：只有"无语音可锚定"的节目用绝对时间，抄参考秒数即 continuity.md 点名的缺陷。

## 验证

- 三路扫描确认：重建路由 7 文件全部词锚定，所有绝对定位都是条件性例外
- 无其他残留矛盾

🤖 Generated with [Claude Code](https://claude.com/claude-code)