### PR TITLE
docs(vocabulary): author from the declared contract, not package source

### DIFF
--- a/.agents/skills/hypit/references/authoring.md
+++ b/.agents/skills/hypit/references/authoring.md
@@ -4,11 +4,15 @@ Read `quickstart.md`, then the authoritative page it selects under `docs/quickst
 Keep Author Source, Recipe Source and Run Source complete and internally consistent rather than
 assembling independent per-shot source fragments.
 
-Before writing an element, read the owning package README and inspect what its Surface actually
-declares — `vocabulary.md` names the command and decides which package owns an element in the first
-place. For `@hypit/<name>@1`, the repository README is `packages/<name>/README.md`. Never invent a
-component, attribute, child, port, Recipe property or literal value. Do not infer one package's
-syntax from a neighboring package.
+Before writing an element, inspect what its Surface actually declares and read the owning package
+README as its example — `vocabulary.md` names the command and decides which package owns an element
+in the first place. The inspect output lists every attribute and every Recipe property with its
+description and admitted values; that is the parameter reference. The README is the example, not the
+reference — a thin README is a thin example next to a complete declaration. For `@hypit/<name>@1`,
+the repository README is `packages/<name>/README.md`. Never invent a component, attribute, child,
+port, Recipe property or literal value, and do not read a package's source code to learn its
+syntax: the source is implementation, the declaration is the contract the loader checks against. Do
+not infer one package's syntax from a neighboring package.
 
 Install dependencies after package selections change. Validate with the existing commands, run from
 the repository root:

--- a/.agents/skills/hypit/references/vocabulary.md
+++ b/.agents/skills/hypit/references/vocabulary.md
@@ -54,6 +54,15 @@ each Surface carries `tag`, `mode`, `outputs`, `vocabulary` (its `attributes`, `
 is the declared Type an element must satisfy, and a property with nowhere to land in those lists is
 the finding that makes a gap.
 
+**That output is the complete authoring contract. Author from it, and do not read a package's source
+code to learn an element's syntax.** Every recipe property carries its own `summary` and its admitted
+`values` — the parameter reference is in the inspect output, not in the package. The README is the
+example, and it is not a parameter reference: some READMEs are a single illustrative recipe, and a
+thin one is not missing documentation, it is a thin example next to a complete declaration. The
+source is implementation, and the loader refuses a mistaken attribute against the declaration, not
+against the source — so reading it neither teaches the contract nor matches how the element is
+validated.
+
 ## Reuse, compose, or declare a gap
 
 Use this decision order:


### PR DESCRIPTION
修复另一个复刻会话滑向读包源码的问题。

## 问题

skill 指示"run inspect + 读 README"。caption-fine 的 README 只有 64 行、一个示例配方，没有逐参数参考。模型按指示读 README 发现不够，就滑向读包的 TypeScript 源码。

## 事实

`inspect_svml_vocabulary` 的输出已经声明了全部 95 个 recipe 参数，每个带 summary 和 admitted values——参数参考是齐的，在声明里不在源码里。

## 改动

- `vocabulary.md`：明确 inspect 输出即完整作者契约，据此写，不要读包源码学语法；薄 README 是薄示例，不是缺文档；loader 按声明拒绝误写属性，不是按源码。
- `authoring.md`："读 README"改为"inspect 声明 + README 当示例"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)