### PR TITLE
feat(hypit): draw a package's catalogue preview from a Source it ships

### DIFF
--- a/.agents/skills/hypit/scripts/render-element.mjs
+++ b/.agents/skills/hypit/scripts/render-element.mjs
@@ -119,6 +119,12 @@ for (const [, attributes] of svml.matchAll(/<whisperx:SemanticTake\b([^>]*?)\/?>
 }
 if (takeOutputs.size === 0) fail("the Source declares no whisperx:SemanticTake to stand in for");
 
+// What the Run already brings. A project Run declares nothing and everything is mocked; a package's
+// preview Run ships its own sample pictures, and those are carried across untouched so the catalogue
+// picture shows the component holding something rather than a placeholder.
+const alreadySatisfied = new Set([...runSource.matchAll(/<satisfy\s+output="([^"]+)"/gu)].map(([, output]) => output));
+const carried = [...runSource.matchAll(/^[ \t]*<(?:file|value|satisfy)\b[^>]*\/>[ \t]*$/gmu)].map(([line]) => line.trim());
+
 const { takes, selections, frameCount: programFrames } = await standInTakes(svmlPath, frameRate);
 const framesBySegment = new Map(takes.map((item) => [item.segmentId, item.take.segment.endFrameExclusive]));
 // A Selection's window in frames, summed over the stand-in tokens it covers. This is the same word
@@ -153,6 +159,9 @@ function mockedMedia() {
     const id = /\bid="([^"]+)"/u.exec(attributes)?.[1];
     const video = /\bvideo="([^"]+)"/u.exec(attributes)?.[1];
     if (id === undefined || !windows.has(id)) continue;
+    // A Run that already satisfies this output brought its own material — a package's preview Source
+    // supplies sample pictures this way — and a mock over the top would hide what it came to show.
+    if (alreadySatisfied.has(`${id}.media`)) continue;
     carries.set(id, { frames: windows.get(id), picture: video !== "none" });
   }
   return carries;
@@ -220,7 +229,8 @@ for (const [id, { frames, picture }] of mockedMedia()) {
 
 // Still images the Source declares as generations. Same treatment, same tool, at the Canvas's size:
 // a picture slot that is empty in the render is black, and black is not what will be there.
-const imageIds = [...new Set([...svml.matchAll(/\{([a-z0-9-]+)\.image\}/gu)].map(([, id]) => id))];
+const imageIds = [...new Set([...svml.matchAll(/\{([a-z0-9-]+)\.image\}/gu)].map(([, id]) => id))]
+  .filter((id) => !alreadySatisfied.has(`${id}.image`));
 for (const id of imageIds) {
   const file = join(compareRoot, `${id}.png`);
   const made = spawnSync(process.execPath, [
@@ -238,6 +248,9 @@ await writeFile(derivedRun, [
   ``,
   `<svrun version="1">`,
   `  <author source="../../${authorMatch[1].replace(/^\.\//u, "")}"/>`,
+  // Whatever the Run brought, repointed: the derived Run sits two directories deeper than the one
+  // that declared these paths.
+  ...carried.map((line) => `  ${line.replace(/from="\.\//gu, 'from="../../')}`),
   // Targeting the element's own output rather than the Film prunes the closure to what this one
   // Track needs. Asking for the whole delivery would pull in every generation the Source declares
   // and report each as unresolved, which is true and useless: none of them is what is being looked at.
@@ -335,17 +348,24 @@ const written = (await readdir(frames)).filter((name) => name.endsWith(".png")).
 if (written.length === 0) fail("the HyperFrames runtime wrote no frames", 1);
 const first = Math.min(window.startFrame, written.length - 1);
 const last = Math.min(window.endFrameExclusive, written.length);
-if (clip) {
-  const encoded = spawnSync("ffmpeg", [
-    "-hide_banner", "-loglevel", "error", "-y", "-framerate", String(frameRate),
-    "-start_number", String(first), "-i", join(frames, "frame_%06d.png"),
-    "-frames:v", String(Math.max(1, last - first)),
-    "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "20", outPath,
-  ], { encoding: "utf8", windowsHide: true, timeout: 600_000 });
-  if (encoded.status !== 0) fail(`ffmpeg refused: ${(encoded.stderr ?? "").trim().slice(-2000)}`, 1);
-} else {
-  await writeFile(outPath, await readFile(join(frames, written[Math.min(first + Math.floor((last - first) / 2), written.length - 1)])));
-}
+// The runtime draws with an alpha channel and leaves unpainted area transparent. What a viewer is
+// under is the Film's own clear colour, so it is composited in here rather than left to whatever
+// opens the file: a reference clip is opaque, and an observer handed a transparent counterpart reads
+// the difference as design when it came from the encoding.
+const clear = built.canvas?.clearColor ?? "#000000";
+const background = `color=c=${clear.replace("#", "0x")}:s=${canvas.width}x${canvas.height}:r=${frameRate}`;
+const count = Math.max(1, clip ? last - first : 1);
+const encoded = spawnSync("ffmpeg", [
+  "-hide_banner", "-loglevel", "error", "-y",
+  "-f", "lavfi", "-i", background,
+  "-framerate", String(frameRate), "-start_number", String(clip ? first : Math.min(first + Math.floor((last - first) / 2), written.length - 1)),
+  "-i", join(frames, "frame_%06d.png"),
+  "-filter_complex", "[0][1]overlay=shortest=1[v]", "-map", "[v]",
+  "-frames:v", String(count),
+  ...(clip ? ["-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "20"] : []),
+  outPath,
+], { encoding: "utf8", windowsHide: true, timeout: 600_000 });
+if (encoded.status !== 0) fail(`ffmpeg refused: ${(encoded.stderr ?? "").trim().slice(-2000)}`, 1);
 
 console.log(JSON.stringify({
   element,

--- a/.agents/skills/hypit/scripts/render-previews.mjs
+++ b/.agents/skills/hypit/scripts/render-previews.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Draw a package's catalogue preview images from the package's own preview Source.
+ *
+ * A Manifest hands Studio and the README a picture per Surface, read off disk with `readFile`. Those
+ * pictures were made once and committed, and nothing could make them again: a Recipe could change, a
+ * Surface could gain a port, and the catalogue would go on showing what the package used to draw.
+ *
+ * So the sample lives in the package as a Source it can be drawn from. `preview/preview.svml`,
+ * `preview/recipes.svs` and `preview/build.svrun` hold the package's own copy, its own Recipe values
+ * and its own Canvas — nothing about any project — and `render-element.mjs` draws them through the
+ * real authoring path. A Surface that stopped working cannot produce a preview that looks fine.
+ *
+ * Which element draws which file comes from the Manifest's own naming: a Surface tagged `Track`
+ * declares `preview/Track.png`, so `Track.png` is drawn from whichever element in the preview Source
+ * carries that tag. No third file has to agree with the other two.
+ *
+ * Usage:  node --import tsx .agents/skills/hypit/scripts/render-previews.mjs <package-dir> [...]
+ * Exit:   0 having written each picture, naming it. 1 when a preview Source refuses to draw.
+ *         2 when a package has no preview Source, or its Manifest names a picture nothing draws.
+ */
+import { readFile, readdir } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { basename, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const renderElement = fileURLToPath(new URL("./render-element.mjs", import.meta.url));
+
+function fail(message, code = 2) {
+  console.error(`render-previews: ${message}`);
+  process.exit(code);
+}
+
+const directories = process.argv.slice(2).filter((value) => !value.startsWith("--"));
+if (directories.length === 0) fail("usage: render-previews.mjs <package-dir> [...]");
+
+const invokedFrom = process.env.INIT_CWD ?? process.cwd();
+let written = 0;
+for (const directory of directories) {
+  const packageDir = resolve(invokedFrom, directory);
+  const previewDir = join(packageDir, "preview");
+  const run = join(previewDir, "build.svrun");
+  const svml = await readFile(join(previewDir, "preview.svml"), "utf8").catch(() => undefined);
+  if (svml === undefined) {
+    fail(`${directory} has no preview/preview.svml. Write one: the package's own copy, its own Recipe values, its own Canvas.`);
+  }
+
+  // The alias the preview Source imports this package under. A preview Source places Tracks from
+  // several packages — it needs a semantic spine and a Film like any other — and `Track` is a common
+  // tag, so the tag alone would draw whichever one happened to be written first.
+  const specifier = JSON.parse(await readFile(join(packageDir, "package.json"), "utf8").catch(() => "{}")).name;
+  if (typeof specifier !== "string") fail(`${directory} has no package.json name`);
+  const imported = [...svml.matchAll(/<import\s+as="([^"]+)"\s+from="(@[^"]+)@\d+"/gu)];
+  const alias = imported.find(([, , from]) => from === specifier)?.[1];
+  if (alias === undefined) {
+    fail(`${directory}'s preview Source does not import ${specifier}, so nothing in it is this package's`);
+  }
+
+  // The pictures the Manifest promises, and the element tag each one is named for.
+  const manifest = await readFile(join(packageDir, "src", "manifest.ts"), "utf8").catch(() => "");
+  const promised = [...new Set([...manifest.matchAll(/previewImage\(\s*["']([^"']+)["']/gu)].map(([, file]) => file))];
+  const existing = (await readdir(previewDir).catch(() => []))
+    .filter((name) => /\.(png|jpe?g|svg)$/iu.test(name));
+  const pictures = promised.length > 0 ? promised : existing;
+  if (pictures.length === 0) fail(`${directory} promises no preview picture; nothing to draw`);
+
+  for (const picture of pictures) {
+    if (/\.svg$/iu.test(picture)) {
+      console.log(`  ${picture} is drawn by hand, not from a Source; left alone`);
+      continue;
+    }
+    const tag = basename(picture).replace(/\.[^.]+$/u, "");
+    const element = new RegExp(`<${alias}:${tag}\\b[^>]*?\\bid="([^"]+)"`, "su").exec(svml)?.[1];
+    if (element === undefined) {
+      fail(`${directory} promises ${picture} but its preview Source places no <${alias}:${tag}> to draw it from`);
+    }
+    const drawn = spawnSync(process.execPath, [
+      "--import", "tsx", renderElement, run, "--element", element, "--out", join(previewDir, picture),
+    ], { encoding: "utf8", windowsHide: true, timeout: 900_000 });
+    if (drawn.status !== 0) {
+      console.error((drawn.stderr ?? "").trim());
+      fail(`${directory} could not draw ${picture}`, 1);
+    }
+    console.log(`  ${directory}/preview/${picture} ← ${tag} id=${element}`);
+    written += 1;
+  }
+}
+console.log(`render-previews: drew ${written} picture${written === 1 ? "" : "s"}.`);

--- a/packages/media-track/preview/build.svrun
+++ b/packages/media-track/preview/build.svrun
@@ -1,0 +1,6 @@
+<?svml using="@hypit/run-markup@1"?>
+
+<svrun version="1">
+  <author source="./preview.svml"/>
+  <target output="final.video"/>
+</svrun>

--- a/packages/media-track/preview/preview.svml
+++ b/packages/media-track/preview/preview.svml
@@ -1,0 +1,85 @@
+<?svml using="@hypit/markup@1"?>
+
+<!-- The catalogue picture for this package's Surfaces, and the Source it is drawn from.
+
+     Everything here is the package's own sample: its copy, its Recipe values, its Canvas. Nothing
+     about a project reaches this file, and nothing in it reaches a project. It exists so a reader
+     can see the Surface's range in one picture, and so that picture can be made again.
+
+     The generations it declares are never performed. `scripts/render-previews.mjs` mocks each one
+     and draws the rest, so this stays free to run and free to re-run.
+
+     A placeholder shows the Frame treatment and nothing inside it. To show the component holding a
+     picture, commit a sample beside this file and satisfy the media output in `build.svrun`:
+
+       <file id="sample-a" type="@hypit/artifact@1#BlobArtifact" from="./sample-a.png" media-type="image/png"/>
+       <satisfy output="motion-a-media.media" candidate="sample-a"/>
+
+     Anything the Run satisfies is carried through untouched and never mocked over. -->
+<svml>
+  <import from="@hypit/script@1"/>
+  <import as="wording" from="@hypit/text@1"/>
+  <import as="seedance" from="@hypit/seedance@1"/>
+  <import as="pipeline" from="@hypit/media-pipeline@1"/>
+  <import as="speech" from="@hypit/speech-track@1"/>
+  <import as="whisperx" from="@hypit/whisperx@1"/>
+  <import as="estimate" from="@hypit/estimate@1"/>
+  <import as="media-track" from="@hypit/media-track@1"/>
+  <import as="space" from="@hypit/spatial@1"/>
+  <import as="program" from="@hypit/program-space@1"/>
+  <import as="film" from="@hypit/film@1"/>
+  <import as="render" from="@hypit/render-hyperframes@1"/>
+  <import as="recipes" source="./recipes.svs"/>
+
+  <!-- The copy is written so the two inserts are up at the same time in the middle of it: a
+       catalogue picture that shows one unit at a time says nothing about how two of them stack. -->
+  <script id="story">
+    <showcase><HOST>A Media Track lays @rounded pictures into Frames you place, @wide each one clipped
+      and painted the way its Recipe says@/wide@/rounded, and hands the rest of the Canvas back.</showcase>
+  </script>
+
+  <space:Canvas id="vertical" width="720" height="1280"/>
+  <program:Clock id="clock" frame-rate="30"/>
+  <space:Frame id="speech-frame" within={vertical}
+    left="0%" top="0%" right="100%" bottom="100%"/>
+  <space:Frame id="card-a" within={vertical}
+    left="8%" top="16%" right="92%" bottom="46%"/>
+  <space:Frame id="card-b" within={vertical}
+    left="12%" top="52%" right="88%" bottom="78%"/>
+
+  <wording:Value id="direction">Locked medium close-up in a quiet daylight studio. Spoken dialogue.</wording:Value>
+  <estimate:Speech id="showcase-duration" source={story.segment.showcase.speech} policy={recipes.speech.normal}/>
+  <seedance:TextVideo id="take" model="mini" prompt={direction} duration={showcase-duration.duration} generate-audio="true"/>
+  <seedance:TextVideo id="motion-a" model="mini" prompt={direction} duration="5"/>
+  <seedance:TextVideo id="motion-b" model="mini" prompt={direction} duration="5"/>
+
+  <pipeline:Normalize id="take-media" source={take.video}
+    recipe={recipes.media.aroll} clock={clock}/>
+  <pipeline:Normalize id="motion-a-media" source={motion-a.video}
+    recipe={recipes.media.broll} clock={clock}/>
+  <pipeline:Normalize id="motion-b-media" source={motion-b.video}
+    recipe={recipes.media.broll} clock={clock}/>
+  <whisperx:SemanticTake id="showcase-semantic" narrative={story}
+    segment={story.segment.showcase} media={take-media.media}/>
+
+  <speech:Track id="speech"
+    visual-frame={speech-frame} visual-appearance={recipes.speech.visual} visual-z="0">
+    <speech:Take source={showcase-semantic.take}/>
+  </speech:Track>
+
+  <!-- Rounded against square, padded against flush, sliding in against cutting: one Track showing
+       what the Recipe decides rather than what the component always does. -->
+  <media-track:Track id="showcase" semantic={speech.semantic} canvas={vertical}>
+    <media-track:Item id="rounded-card" media={motion-a-media.media} during={story.selection.rounded}
+      frame={card-a} appearance={recipes.media.card} motion={recipes.motion.card}/>
+    <media-track:Item id="flush-card" media={motion-b-media.media} during={story.selection.wide}
+      frame={card-b} appearance={recipes.media.wide} motion={recipes.motion.card}/>
+  </media-track:Track>
+
+  <film:Film id="main" canvas={vertical} semantic={speech.semantic} appearance={recipes.film.vertical}>
+    <film:Track source={speech.visual}/>
+    <film:Track source={speech.audio}/>
+    <film:Track source={showcase.visual}/>
+  </film:Film>
+  <render:Video id="final" composition={main.composition} semantic={speech.semantic}/>
+</svml>

--- a/packages/media-track/preview/recipes.svs
+++ b/packages/media-track/preview/recipes.svs
@@ -1,0 +1,27 @@
+<?svml using="@hypit/svs@1"?>
+
+<sheet version="1">
+  film.vertical { background: #09090B; }
+  speech.visual { fit: cover; }
+  speech.normal { language: en; pace: normal; min: 4; max: 30; rounding: round; }
+
+  media.aroll { video: primary-moving; audio: default; span-authority: video; }
+  media.broll { video: primary-moving; audio: none; span-authority: video; }
+
+  /* Rounded and padded, so the painted content box is visibly inset from the
+     Placement Frame Studio draws as a guide. */
+  media.card {
+    stack-order: 40; fit: cover; playback: hold-start;
+    frame-paint: #16161d; clip: rounded; radius: 24; padding: 12 12;
+  }
+  /* Square and flush, for contrast with media.card. */
+  media.wide {
+    stack-order: 41; fit: cover; playback: hold-start;
+    frame-paint: #1d1620; clip: frame;
+    border-width: 2; border-color: #ee7b6255;
+  }
+  motion.card {
+    enter: slide; enter-frames: 5; enter-direction: up; enter-easing: ease-out;
+    exit: fade; exit-frames: 5; exit-easing: ease-in;
+  }
+</sheet>


### PR DESCRIPTION
The catalogue preview images had no generator. The ten under `packages/*/preview/` are committed PNGs that each Manifest reads off disk with `readFile`; nothing in the repository produces them. They were made once, at 720×1280, and checked in. A Recipe can change, a Surface can gain a port, and the catalogue goes on showing what the package used to draw.

## The sample becomes a Source the package owns

```
packages/media-track/preview/
  preview.svml    the package's own copy, Recipe values and Canvas
  recipes.svs
  build.svrun
  Track.png       the picture
```

`render-previews.mjs` draws it, and it draws it by handing the Source to `render-element.mjs` — the renderer from #40, unchanged in what it does. So the catalogue picture goes through the same authoring path a project does: real Surface, real Producer, real projection. A Surface that stopped working cannot produce a preview that looks fine.

Which element draws which file comes from the Manifest's own naming. A Surface tagged `Track` declares `preview/Track.png`, so `Track.png` is drawn from the element carrying that tag **under the package's own import alias** — a preview Source places a `speech:Track` and a `film:Film` too, like any Source, so the tag alone would draw whichever was written first. No third file has to agree with the other two.

```
$ node --import tsx .agents/skills/hypit/scripts/render-previews.mjs packages/media-track
  packages/media-track/preview/Track.png ← Track id=showcase
render-previews: drew 1 picture.
```

`Column.svg` in `packages/ranking` is reported as hand-drawn and left alone.

## Two fixes to render-element.mjs that using it this way exposed

**The clear colour was not being composited.** The HyperFrames runtime draws with an alpha channel and leaves unpainted area transparent, so the output was RGBA with the Film's `background` nowhere in it. That matters more for the comparison loop than for the catalogue: a reference clip is opaque, and an observer handed a transparent counterpart reads the difference as design when it came from the encoding. Frames are now composited onto `composition.canvas.clearColor` and the output is RGB.

**Material the Run already brings is no longer mocked over.** `<file>`, `<value>` and `<satisfy>` from the original Run are carried into the derived Run with their paths repointed, and any output they satisfy is skipped when mocking. That is how a preview Source supplies real sample pictures rather than placeholders, and it leaves the project path unchanged — a project Run declares none of these, so all 27 media and 18 stills are still mocked there.

## Scope

This round builds the mechanism and takes one package through it. `media-track`'s committed `Track.png` is **unchanged**: the existing picture uses real sample media (a full-bleed sunset with an inset card), and the drawn one without sample media is two grey placeholders in the two Frames. That shows the Recipe treatment — rounded and padded against flush and bordered — but it is a worse catalogue image than what is there, so replacing it would be a downgrade. `preview.svml` documents the two lines that supply a sample and get the better picture.

The other seven packages keep their committed PNGs and have no preview Source yet.

## Verification

- `render-previews.mjs packages/media-track` draws `Track.png` at 720×1280, RGB, from `Track id=showcase`, with the Film's `#09090B` behind it.
- The project path is unaffected: `render-element.mjs projects/voice-clone-ad-reverse/build.svrun --element captions --segment takes-time` still produces its 1080×1920 clip with 27 media and 18 stills mocked.
- `pnpm check` clean, `pnpm test` 524 tests 0 failures.
