### PR TITLE
fix(hypit): close the gaps between the render scripts and the route

### DIFF
--- a/.agents/skills/hypit/references/preview.md
+++ b/.agents/skills/hypit/references/preview.md
@@ -66,7 +66,24 @@ collide — lines that overlap, type too large for the plate it sits on — whil
 drawn from different values, stays perfect. A route that compares the catalogue picture is answering
 a question about the catalogue.
 
-The comparison render has one command, shared by every package:
+Each has its own command, and both are shared by every package.
+
+**The catalogue preview** is drawn from a Source the package ships — `preview/preview.svml`,
+`preview/recipes.svs` and `preview/build.svrun`, holding its own copy, its own Recipe values and its
+own Canvas:
+
+```bash
+node --import tsx .agents/skills/hypit/scripts/render-previews.mjs packages/<name>
+```
+
+Which element draws which file comes from the Manifest's naming: a Surface tagged `Track` declares
+`preview/Track.png`, so that picture is drawn from the element carrying that tag under the package's
+own import alias. It **overwrites the picture in place**, so run it when the package's drawing has
+changed and look at what came out before committing it. Anything the preview Run satisfies with a
+`<file>` of its own is carried through and never mocked over, which is how a preview shows the
+component holding a picture rather than a placeholder.
+
+**The comparison render** has one command too:
 
 ```bash
 node --import tsx .agents/skills/hypit/scripts/render-element.mjs projects/<name>/build.svrun \

--- a/.agents/skills/hypit/references/reconstruction/reconstruction-loop.md
+++ b/.agents/skills/hypit/references/reconstruction/reconstruction-loop.md
@@ -45,11 +45,11 @@ card.
 
 The thing compared is the element **as this video places it**: the Recipe values the Source actually
 passes, the Script text the Source actually feeds it, and the windows the Source actually binds. A
-package's catalogue preview is a different picture with different inputs — the harness supplies its
-own sample copy and its own Recipe so a reader can see the Surface's range — and a Source can fill
+package's catalogue preview is a different picture drawn from different values — the package's own
+sample copy and sample Recipe, chosen to show a reader the Surface's range — and a Source can fill
 every one of those parameters with values that collide while the preview stays perfect. Comparing the
-preview answers a question nobody asked. `../preview.md` renders both, from the same harness, with
-different arguments; this loop uses the Source-configured one.
+preview answers a question nobody asked. `../preview.md` keeps the two apart and says which command
+draws which.
 
 One command produces it, and it is not written per package:
 
@@ -63,9 +63,17 @@ speech with the Source's own `estimate:Speech`, mocks every layer a Build has no
 the package's Producer. Nothing is transcribed by hand, so nothing is transcribed one line at a time
 — which is what made a caption system look correct while its lines collided.
 
-The window is named in words. `--segment` and `--selection` take a Script name, not a timestamp: a
-shot of the reference is found by the words spoken over it, and those words are where the Script
-says they are. No reference clock is read across.
+The window is named in words. `--segment` and `--selection` take a Script name, never a timestamp,
+and the way to find the right name for a given shot is:
+
+1. take the shot's `start_seconds` and `end_seconds` from the reference's `state.json`;
+2. read the words spoken over that stretch out of the reference's `transcript.json`, which carries
+   one entry per word with its own timings;
+3. find those words in the Script you wrote, and name the Selection or Segment that encloses them.
+
+The reference clock is read exactly once, at step 1, and only to index a table. Everything after it
+is words. The reconstruction's own frames come from estimated take lengths, so its clock and the
+reference's do not correspond and matching them would put the window in the wrong place.
 
 ### Mock the layers a Build has not made
 

--- a/.agents/skills/hypit/scripts/render-element.mjs
+++ b/.agents/skills/hypit/scripts/render-element.mjs
@@ -91,7 +91,10 @@ const out = flag("out") ?? fail("--out is required");
 
 const invokedFrom = process.env.INIT_CWD ?? process.cwd();
 const runPath = resolve(invokedFrom, runArgument);
-const packageRoot = resolve(invokedFrom);
+// The repository, found from this file rather than from wherever it was called. Deriving it from the
+// working directory means the command works from the root and crashes anywhere else, on a missing
+// module rather than on anything a reader could act on.
+const packageRoot = fileURLToPath(new URL("../../../../", import.meta.url));
 const projectRoot = dirname(runPath);
 const outPath = resolve(invokedFrom, out);
 


### PR DESCRIPTION
Running both render flows the way the route describes them, from a clean state, turned up three gaps. Two are documentation, one is a crash.

## The crash

`render-element.mjs` took the repository root from the working directory:

```js
const packageRoot = resolve(invokedFrom);
```

`loadStudioDomain` and the HyperFrames CLI both resolve against it, so the command worked from the repository root and died anywhere else:

```
$ cd projects && node --import tsx ../.agents/.../render-element.mjs voice-clone-ad-reverse/build.svrun ...
Error: Cannot find module 'hyperframes/bin/hyperframes.mjs'
```

A Node stack trace with nothing in it a reader could act on. The documented example passes `projects/<name>/build.svrun`, which implies the root without saying so. It now finds the repository from its own file location and runs from any directory — verified from `projects/`.

## `render-previews.mjs` was in no document

Zero mentions across `references/` and `SKILL.md`. An agent following the route would never learn the catalogue preview has a command. `preview.md` now carries it beside the comparison command, states that the element-to-file mapping comes from the Manifest's naming under the package's own import alias, and states that it **overwrites the picture in place** — worth knowing before running it, since the pictures are committed.

## The window had a principle but no procedure

`reconstruction-loop.md` said `--segment` and `--selection` take a Script name rather than a timestamp, and that a shot is found by the words spoken over it. It did not say how. It now gives the steps:

1. the shot's `start_seconds` / `end_seconds` from the reference's `state.json`;
2. the words over that stretch from `transcript.json`, which carries one entry per word with its own timings;
3. the Selection or Segment enclosing those words in the Script.

The reference clock is read exactly once, at step 1, to index a table. The reconstruction's frames come from estimated take lengths, so the two clocks do not correspond and matching them would put the window in the wrong place.

It also still said `preview.md` "renders both, from the same harness, with different arguments" — untrue since the catalogue preview moved to a Source the package ships.

## Verification

Both flows run clean, from the repository root and from `projects/`:

| | result |
|---|---|
| `render-previews.mjs packages/media-track` | `Track.png ← Track id=showcase`, 720×1280 rgb24, 12s |
| `--element captions --segment takes-time` | clip, 6.000s, 1080×1920 yuv420p, frames 240–420 |
| `--element captions --selection c-tt-3` | still, 1080×1920 rgb24, frames 287–294 |
| `--element paper --segment how` | clip, 14.000s, 1080×1920 |
| `--element player --selection reveal-stretch` | still, 1080×1920 |

Pixels checked, not just file headers: the `captions` clip draws its lines over the grey base mock, the `player` still draws its dashed oval ring and caption.

Failure paths exit with a message rather than a stack trace or an empty file:

| | exit | says |
|---|---|---|
| unknown `--element` | 1 | names it, then lists what the Source does place |
| unknown `--segment` | 2 | `the Script has no Segment nosuch` |
| unknown `--selection` | 2 | `the Script marks no Selection nosuch` |
| package with no preview Source | 2 | `packages/ranking has no preview/preview.svml. Write one: …` |

`pnpm check` clean, `pnpm test` 524 tests 0 failures. `media-track/preview/Track.png` is unchanged — it was regenerated during verification, inspected, and restored.
