### PR TITLE
perf(hypit): render only the window, and stop forcing software rasterization

### DIFF
--- a/.agents/skills/hypit/scripts/render-element.mjs
+++ b/.agents/skills/hypit/scripts/render-element.mjs
@@ -37,6 +37,7 @@ import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
+import { cpus } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -128,7 +129,15 @@ if (takeOutputs.size === 0) fail("the Source declares no whisperx:SemanticTake t
 const alreadySatisfied = new Set([...runSource.matchAll(/<satisfy\s+output="([^"]+)"/gu)].map(([, output]) => output));
 const carried = [...runSource.matchAll(/^[ \t]*<(?:file|value|satisfy)\b[^>]*\/>[ \t]*$/gmu)].map(([line]) => line.trim());
 
-const { takes, selections, frameCount: programFrames } = await standInTakes(svmlPath, frameRate);
+// The window is resolved before the stand-ins are built, so the program is only as long as the
+// stretch being looked at. Rendering the whole program to crop six seconds out of it is the
+// difference between a few seconds and a few minutes.
+const segmentArgument = flag("segment");
+const selectionArgument = flag("selection");
+const { takes, selections, frameCount: programFrames } = await standInTakes(svmlPath, frameRate, {
+  ...(segmentArgument === undefined ? {} : { segment: segmentArgument }),
+  ...(selectionArgument === undefined ? {} : { selection: selectionArgument }),
+});
 const framesBySegment = new Map(takes.map((item) => [item.segmentId, item.take.segment.endFrameExclusive]));
 // A Selection's window in frames, summed over the stand-in tokens it covers. This is the same word
 // span the Source binds to, carried into frames by the same estimate that sized the Segment.
@@ -198,13 +207,15 @@ for (const { segmentId, take } of takes) {
 // and nowhere else.
 const placeholderCli = new URL("../../../../packages/reference-video-tools/src/cli.ts", import.meta.url);
 for (const [id, { frames, picture }] of mockedMedia()) {
-  const seconds = Math.max(0.1, frames / frameRate);
+  // make-placeholder takes whole seconds, and a mock longer than its window costs nothing: the
+  // SynchronizedMedia declares the frame count, the file only has to reach it.
+  const seconds = Math.max(1, Math.ceil(frames / frameRate));
   const file = join(compareRoot, `${id}.mp4`);
   if (picture) {
     const made = spawnSync(process.execPath, [
       "--import", "tsx", fileURLToPath(placeholderCli), "make-placeholder",
       "--out", file, "--width", String(canvas.width), "--height", String(canvas.height),
-      "--video", "--seconds", seconds.toFixed(3), "--color", "mid",
+      "--video", "--seconds", String(seconds), "--color", "mid",
     ], { encoding: "utf8", windowsHide: true, timeout: 120_000 });
     if (made.status !== 0) fail(`make-placeholder failed for ${id}: ${made.stderr?.trim()}`);
   }
@@ -303,8 +314,6 @@ if (placed === undefined) {
 
 // The window to render, named in words. A shot of the reference is found by the words spoken over it
 // and those words are a Segment or a Selection here, so no reference timestamp is ever read across.
-const segmentArgument = flag("segment");
-const selectionArgument = flag("selection");
 let window = { startFrame: 0, endFrameExclusive: programFrames };
 if (selectionArgument !== undefined) {
   window = selections.get(selectionArgument)
@@ -343,7 +352,7 @@ const hyperframesCli = createRequire(join(packageRoot, "packages/provider-hyperf
 const drawn = spawnSync(process.execPath, [
   hyperframesCli, "render", stage,
   "--format", "png-sequence", "--output", frames, "--fps", String(frameRate),
-  "--workers", "1", "--no-browser-gpu", "--no-best-effort", "--quiet",
+  "--workers", String(Math.max(1, cpus().length - 2)), "--no-best-effort", "--quiet",
 ], { encoding: "utf8", windowsHide: true, timeout: 600_000 });
 if (drawn.status !== 0) fail(`the HyperFrames runtime refused: ${(drawn.stderr ?? "").trim().slice(-2000)}`, 1);
 

--- a/.agents/skills/hypit/scripts/stand-in-takes.mjs
+++ b/.agents/skills/hypit/scripts/stand-in-takes.mjs
@@ -83,12 +83,26 @@ const SILENT_AUDIO = { kind: "blob", digest: `sha256:${"0".repeat(64)}`, size: 1
  * @param frameRate the Program's frame rate, as a whole number of frames per second
  * @returns one `{ segmentId, take }` per Segment, in Script order
  */
-export async function standInTakes(svmlPath, frameRate) {
+export async function standInTakes(svmlPath, frameRate, focus = {}) {
   const svml = await readFile(svmlPath, "utf8");
   const body = scriptBody(svml);
   const parsed = parseScript(svmlPath, body.text, body.offset);
   const sheets = await recipeSheets(svml, svmlPath);
   const { policies, shared, policyCount } = policiesBySegment(svml, sheets);
+
+  // Which Segment the render is actually looking at. Every other Segment still has to exist — a
+  // Speech Track assembles one Take per Segment and an unsatisfied one refuses the whole projection —
+  // but nothing needs it at its estimated length. Held to one frame per word it stays legal, keeps
+  // its anchors, and stops the renderer drawing a minute of program to show six seconds of it.
+  let focused;
+  if (focus.segment !== undefined) focused = focus.segment;
+  else if (focus.selection !== undefined) {
+    const selection = parsed.selections.find((item) => item.id === focus.selection);
+    const token = selection?.occurrences[0]?.open.boundary.tokenIndex;
+    focused = token === undefined
+      ? undefined
+      : parsed.segments.find((segment) => token >= segment.tokenStart && token < segment.tokenEndExclusive)?.id;
+  }
 
   const takes = [];
   // Global frame span of every word, in Script order, so a Selection can be turned into a frame
@@ -104,7 +118,9 @@ export async function standInTakes(svmlPath, frameRate) {
     const tokens = parsed.tokens.slice(segment.tokenStart, segment.tokenEndExclusive);
     const text = tokens.map((token) => token.text).join(" ");
     const seconds = estimateSpeechDuration({ value: text }, policy);
-    const frameCount = Math.max(1, Math.round(seconds * frameRate));
+    const frameCount = focused !== undefined && segment.id !== focused
+      ? Math.max(1, tokens.length)
+      : Math.max(tokens.length, Math.round(seconds * frameRate));
 
     // Share the Segment's frames out by the estimator's own unit count, so the word order and the
     // relative widths both come from the same place the duration did.

--- a/packages/hyperframes/test/browser-visual.test.ts
+++ b/packages/hyperframes/test/browser-visual.test.ts
@@ -387,8 +387,7 @@ test("locked font and straight-alpha Surface survive one real Hyperframes browse
       "--output", output,
       "--fps", "30",
       "--workers", "1",
-      "--no-browser-gpu",
-      "--no-best-effort",
+            "--no-best-effort",
       "--quiet",
     ], { windowsHide: true, encoding: "utf8", timeout: 110_000 });
     assert.equal(render.status, 0, `${render.stdout}\n${render.stderr}`);
@@ -498,7 +497,7 @@ test("Fine Caption exact font, wrapping and all karaoke modes survive real brows
     const render = spawnSync(process.execPath, [
       hyperframesCli, "render", temp,
       "--format", "png-sequence", "--output", output, "--fps", "10", "--workers", "1",
-      "--no-browser-gpu", "--no-best-effort", "--quiet",
+      "--no-best-effort", "--quiet",
     ], { windowsHide: true, encoding: "utf8", timeout: 110_000 });
     assert.equal(render.status, 0, `${render.stdout}\n${render.stderr}`);
     const frames = await collectPngs(output);
@@ -578,7 +577,7 @@ test("Fine Caption joined trail Pill follows real wrapped browser line fragments
     const render = spawnSync(process.execPath, [
       hyperframesCli, "render", temp,
       "--format", "png-sequence", "--output", output, "--fps", "10", "--workers", "1",
-      "--no-browser-gpu", "--no-best-effort", "--quiet",
+      "--no-best-effort", "--quiet",
     ], { windowsHide: true, encoding: "utf8", timeout: 110_000 });
     assert.equal(render.status, 0, `${render.stdout}\n${render.stderr}`);
     const frames = await collectPngs(output);
@@ -685,7 +684,7 @@ test("installed open fonts render CJK, emoji and independent stroke, shadow and 
     const render = spawnSync(process.execPath, [
       hyperframesCli, "render", temp,
       "--format", "png-sequence", "--output", output, "--fps", "30", "--workers", "1",
-      "--no-browser-gpu", "--no-best-effort", "--quiet",
+      "--no-best-effort", "--quiet",
     ], { windowsHide: true, encoding: "utf8", timeout: 110_000 });
     assert.equal(render.status, 0, `${render.stdout}\n${render.stderr}`);
     const frames = await collectPngs(output);
@@ -921,7 +920,7 @@ test("complete Text flow, Path, local mask and motion stay exact under parallel 
       const result = spawnSync(process.execPath, [
         hyperframesCli, "render", temp,
         "--format", "png-sequence", "--output", output, "--fps", String(fps), "--workers", String(workers),
-        "--no-browser-gpu", "--no-best-effort", "--quiet",
+        "--no-best-effort", "--quiet",
       ], { windowsHide: true, encoding: "utf8", timeout: 170_000 });
       assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
       return await collectPngs(output);
@@ -1126,7 +1125,7 @@ test("Text box targets, rich runs and every sequence direction remain stable acr
       const result = spawnSync(process.execPath, [
         hyperframesCli, "render", temp,
         "--format", "png-sequence", "--output", output, "--fps", String(fps), "--workers", String(workers),
-        "--no-browser-gpu", "--no-best-effort", "--quiet",
+        "--no-best-effort", "--quiet",
       ], { windowsHide: true, encoding: "utf8", timeout: 170_000 });
       assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
       return collectPngs(output);
@@ -1235,7 +1234,7 @@ test("vertical Text paints in its authored direction and bounded shrink fails cl
     const verticalResult = spawnSync(process.execPath, [
       hyperframesCli, "render", temp,
       "--format", "png-sequence", "--output", verticalOutput, "--fps", String(fps), "--workers", "1",
-      "--no-browser-gpu", "--no-best-effort", "--quiet",
+      "--no-best-effort", "--quiet",
     ], { windowsHide: true, encoding: "utf8", timeout: 100_000 });
     assert.equal(verticalResult.status, 0, `${verticalResult.stdout}\n${verticalResult.stderr}`);
     const verticalFrames = await collectPngs(verticalOutput);
@@ -1255,7 +1254,7 @@ test("vertical Text paints in its authored direction and bounded shrink fails cl
     const shrinkResult = spawnSync(process.execPath, [
       hyperframesCli, "render", temp,
       "--format", "png-sequence", "--output", shrinkOutput, "--fps", String(fps), "--workers", "1",
-      "--no-browser-gpu", "--no-best-effort", "--quiet",
+      "--no-best-effort", "--quiet",
     ], { windowsHide: true, encoding: "utf8", timeout: 100_000 });
     assert.notEqual(shrinkResult.status, 0, "bounded Text shrink silently rendered below its authored minimum");
     assert.match(`${shrinkResult.stdout}\n${shrinkResult.stderr}`, /Text cannot fit at its authored minimum scale/u);
@@ -1378,7 +1377,7 @@ test("Media two-frame sampling, alpha, local motion and handoff survive partitio
       const result = spawnSync(process.execPath, [
         hyperframesCli, "render", temp,
         "--format", "png-sequence", "--output", output, "--fps", "12", "--workers", String(workers),
-        "--no-browser-gpu", "--no-best-effort", "--quiet",
+        "--no-best-effort", "--quiet",
       ], { windowsHide: true, encoding: "utf8", timeout: 110_000 });
       assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
       return Promise.all((await collectPngs(output)).map(async (file) => decodedRgba(file, width, height)));
@@ -1554,7 +1553,7 @@ test("DepthStack Deck reflow, exact labels and old-system layout survive partiti
       const result = spawnSync(process.execPath, [
         hyperframesCli, "render", temp,
         "--format", "png-sequence", "--output", output, "--fps", String(fps), "--workers", String(workers),
-        "--no-browser-gpu", "--no-best-effort", "--quiet",
+        "--no-best-effort", "--quiet",
       ], { windowsHide: true, encoding: "utf8", timeout: 110_000 });
       assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
       return Promise.all((await collectPngs(output)).map(async (file) => decodedRgba(file, width, height)));
@@ -1707,7 +1706,7 @@ test("both Ranking components paint frame-pure progressive states under partitio
       const result = spawnSync(process.execPath, [
         hyperframesCli, "render", temp,
         "--format", "png-sequence", "--output", output, "--fps", String(fps), "--workers", String(workers),
-        "--no-browser-gpu", "--no-best-effort", "--quiet",
+        "--no-best-effort", "--quiet",
       ], { windowsHide: true, encoding: "utf8", timeout: 110_000 });
       assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
       return Promise.all((await collectPngs(output)).map(async (file) => decodedRgba(file, width, height)));
@@ -1881,7 +1880,7 @@ test("all Spatial fit modes and equal-point alignments reach exact browser pixel
     const result = spawnSync(process.execPath, [
       hyperframesCli, "render", temp,
       "--format", "png-sequence", "--output", output, "--fps", "1", "--workers", "1",
-      "--no-browser-gpu", "--no-best-effort", "--quiet",
+      "--no-best-effort", "--quiet",
     ], { windowsHide: true, encoding: "utf8", timeout: 110_000 });
     assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
     const files = await collectPngs(output);
@@ -2005,7 +2004,7 @@ test("every official Screen Overlay survives real sequential and parallel browse
       const result = spawnSync(process.execPath, [
         hyperframesCli, "render", temp,
         "--format", "png-sequence", "--output", output, "--fps", "12", "--workers", String(workers),
-        "--no-browser-gpu", "--no-best-effort", "--quiet",
+        "--no-best-effort", "--quiet",
       ], { windowsHide: true, encoding: "utf8", timeout: 110_000 });
       assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
       return collectPngs(output);


### PR DESCRIPTION
You were right on all three counts.

## It drew the whole program

`render-element.mjs` rendered every frame of the program and cropped the window out of the PNG sequence. The stand-in track gave every Segment its full estimated length regardless of what was being looked at, so asking for six seconds of `takes-time` meant drawing sixty-four seconds of program first.

The window is now resolved before the stand-ins are built. Every Segment outside it is held to one frame per word — it still has to exist, because a Speech Track assembles one Take per Segment and an unsatisfied one refuses the whole projection, but nothing needs it at its estimated length. It keeps its anchors and stays legal.

| | before | after |
|---|---|---|
| program frames | 1920 | 338 |
| `--element captions --segment takes-time` | minutes | 30s |
| `render-previews.mjs packages/media-track` | 12s | 10s |

Output is unchanged: still 6.000s at 1080×1920, still showing `Scripts,` colliding with the line beneath.

## It was rasterizing in software

Both the script and `packages/hyperframes/test/browser-visual.test.ts` passed `--no-browser-gpu`, which forces Chrome through SwiftShader. The CLI's own default is `auto` — probe for a GPU, fall back to software only when there is none.

The script copied the flag from the test. The test never needed it: removed from all thirteen call sites, and **all twelve visual tests pass** with GPU rasterization (`HYPIT_BROWSER_TESTS=1`, 46s).

`packages/provider-hyperframes-local` is untouched. It only emits `--no-browser-gpu` when a Profile explicitly configures `browserGpu: "software"`, which is a choice a Profile is entitled to make.

I had also reached for `--gpu` in the script, which is GPU *encoding* — unrelated, and inert for a PNG sequence. Removed.

## It ran on one worker

`--workers 1`, copied from the same place. Now `cores - 2`.

## One fix that fell out

`make-placeholder` takes whole seconds and the compressed Segments were asking for fractions of one, so the mock is rounded up. That costs nothing: the `SynchronizedMedia` declares the frame count and the file only has to reach it.

## Verification

- `pnpm check` clean; `pnpm test` 524 tests, 0 failures.
- `HYPIT_BROWSER_TESTS=1` on `browser-visual.test.ts`: 12 passed, 0 failed, 0 skipped.
- Both render flows run and produce the same pictures as before.
