### PR TITLE
fix: record the reference-video-tools dependencies in the lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2048,27 +2048,48 @@ importers:
       '@hypit/driver-node':
         specifier: workspace:*
         version: link:../driver-node
+      '@hypit/estimate':
+        specifier: workspace:*
+        version: link:../estimate
+      '@hypit/hyperframes':
+        specifier: workspace:*
+        version: link:../hyperframes
       '@hypit/markup':
         specifier: workspace:*
         version: link:../markup
+      '@hypit/media':
+        specifier: workspace:*
+        version: link:../media
       '@hypit/model-kit':
         specifier: workspace:*
         version: link:../model-kit
       '@hypit/package-loader-node':
         specifier: workspace:*
         version: link:../package-loader-node
+      '@hypit/program-space':
+        specifier: workspace:*
+        version: link:../program-space
       '@hypit/protocol':
         specifier: workspace:*
         version: link:../protocol
       '@hypit/provider-whisperx-local':
         specifier: workspace:*
         version: link:../provider-whisperx-local
+      '@hypit/script':
+        specifier: workspace:*
+        version: link:../script
       '@hypit/speech':
         specifier: workspace:*
         version: link:../speech
       '@hypit/speech-evidence':
         specifier: workspace:*
         version: link:../speech-evidence
+      '@hypit/studio':
+        specifier: workspace:*
+        version: link:../studio
+      '@hypit/svs':
+        specifier: workspace:*
+        version: link:../svs
       '@hypit/whisperx':
         specifier: workspace:*
         version: link:../whisperx


### PR DESCRIPTION
CI has failed on every run since #44.

```
ERR_PNPM_OUTDATED_LOCKFILE  pnpm-lock.yaml is not up to date with packages/reference-video-tools/package.json
* 7 dependencies were added: @hypit/estimate, @hypit/hyperframes, @hypit/media,
  @hypit/program-space, @hypit/script, @hypit/studio, @hypit/svs
```

Moving the authoring tools into the package added those seven, and the lockfile went in without them.

It went in without them on purpose, and that was the mistake. Its diff also carried three `@hypit/local-*` importers under `projects/`, which is gitignored — a lockfile a fresh clone installs from cannot name workspace projects that clone does not have. I excluded the whole file rather than the three entries, twice, and reported it as the careful thing to do. It dropped the seven real dependencies with them.

The committed lockfile has never held a `projects/` importer; it is generated with that directory absent. This one is too: 21 added lines, all seven `workspace:*` links, no importers.

## Verification

- `pnpm install --frozen-lockfile` succeeds, which is the command CI runs.
- `pnpm check` clean; `pnpm test` 524 tests, 0 failures.