### PR TITLE
fix: refuse a lockfile carrying importers git does not track

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "check": "tsc -p tsconfig.json --noEmit",
+    "lockfile:refresh": "node test/lockfile-refresh.mjs",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",

--- a/test/lockfile-refresh.mjs
+++ b/test/lockfile-refresh.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Write a lockfile the repository can commit.
+ *
+ * `pnpm-workspace.yaml` globs `projects/*​/packages/*` so that a project-local author package is one
+ * pnpm links — the authoring guide's convention depends on it. `.gitignore` excludes `projects/`,
+ * because a project is working material. Both are right, and together they mean a local install
+ * writes importers a clone will not have into a file the clone installs from.
+ *
+ * So the lockfile is written with that directory set aside, and put back afterwards. Dependencies
+ * declared inside `packages/` resolve identically either way; only the importers differ.
+ *
+ * Run this after changing any package's dependencies. `repository-hygiene.test.mjs` refuses a
+ * lockfile written without it.
+ */
+import { rename } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+const projects = fileURLToPath(new URL("../projects", import.meta.url));
+const aside = fileURLToPath(new URL("../.projects-aside-for-lockfile", import.meta.url));
+
+const moved = existsSync(projects);
+if (moved) {
+  if (existsSync(aside)) {
+    console.error(`${aside} already exists; a previous refresh did not finish. Move it back by hand.`);
+    process.exit(2);
+  }
+  await rename(projects, aside);
+}
+try {
+  const install = spawnSync("pnpm", ["install", "--lockfile-only"], {
+    cwd: root, stdio: "inherit", shell: process.platform === "win32", windowsHide: true,
+  });
+  if (install.status !== 0) process.exitCode = install.status ?? 1;
+} finally {
+  if (moved) await rename(aside, projects);
+}
+console.log(moved
+  ? "lockfile written with projects/ set aside; it is back where it was."
+  : "lockfile written.");

--- a/test/repository-hygiene.test.mjs
+++ b/test/repository-hygiene.test.mjs
@@ -324,3 +324,29 @@ test("every child process is started with its console window hidden", async () =
   }
   assert.deepEqual(failures, [], `child processes started with a visible console:\n${failures.join("\n")}`);
 });
+
+/**
+ * `pnpm-workspace.yaml` reaches into `projects/`, which `.gitignore` excludes, so a local install
+ * writes an importer for every project-local package into a file the repository commits. A clone has
+ * no such directory, so `pnpm install --frozen-lockfile` — what CI runs — refuses a lockfile carrying
+ * one.
+ *
+ * The failure that made this worth checking was not the importer itself. It was that the lockfile is
+ * dirty after every local install, so its diff stops being read, and a real dependency added to a
+ * package goes in without it. That shipped three times.
+ *
+ * `pnpm lockfile:refresh` writes a lockfile this accepts.
+ */
+test("the lockfile names no importer git does not track", async () => {
+  const lockfile = await readFile(new URL("./pnpm-lock.yaml", repositoryRoot), "utf8");
+  const ignored = (await readFile(new URL("./.gitignore", repositoryRoot), "utf8"))
+    .split("\n").map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#") && !line.startsWith("!"))
+    .map((line) => line.replace(/^\/+/u, "").replace(/\/+$/u, ""))
+    .filter((line) => !line.includes("*") && line.length > 0);
+  const importers = [...lockfile.matchAll(/^ {2}([^\s:][^:]*):$/gmu)].map((match) => match[1]);
+  const carried = importers.filter((importer) =>
+    ignored.some((entry) => importer === entry || importer.startsWith(`${entry}/`)));
+  assert.deepEqual(carried, [],
+    `the lockfile carries importers under a path git ignores:\n${carried.join("\n")}\n\nrun: pnpm lockfile:refresh`);
+});


### PR DESCRIPTION
## The root cause

Two correct decisions that collide:

- `pnpm-workspace.yaml` globs `projects/*/packages/*`, so a project-local author package is one pnpm links. The authoring convention depends on it — those packages declare eleven dependencies each and are dead without the link. I checked whether the glob could go; it cannot.
- `.gitignore` excludes `projects/`, because a project is working material.

Together: **every local install writes importers a clone will not have into the file that clone installs from.** pnpm offers no way to exclude a workspace member from the lockfile.

The damage was never the three importers. It was that the lockfile is dirty after every install, so its diff stops being read — and when seven real dependencies were added to `reference-video-tools`, the file went in without them and CI refused every run until someone looked.

## What this adds

**An invariant, where the eight others already live.** `repository-hygiene.test.mjs` reads `.gitignore` and refuses a lockfile naming an importer under any path it excludes. Two milliseconds, in a suite that already runs locally and in CI.

Verified by breaking it: with `projects/` present, `pnpm install`, then the check — it fails and names the three importers.

**A one-command way to satisfy it.** `pnpm lockfile:refresh` sets that directory aside, writes the lockfile, and puts it back. Run after changing any package's dependencies. Dependencies declared inside `packages/` resolve identically either way; only the importers differ.

## What this does not do

CI is unchanged. It is four steps — install, type check, test, hygiene — on two platforms, and the ubuntu leg spends 14s installing, 17s type checking, 54s on 524 tests and 6s on the invariants. It caught this failure three times; the gap was that nothing caught it before the push, which is what moves here.

Worth noting the eight existing invariants are not ceremony: no workstation paths or secret bytes in a public repository, version identity, import boundaries, a drawing Surface declaring a preview, that preview naming a file that exists, and every child process hiding its console window. That last one caught the refresh script added here starting `pnpm` without `windowsHide`, on its first run.

## Verification

- The new check fails on a dirty lockfile, naming each importer, and passes on a refreshed one.
- `pnpm lockfile:refresh` round-trips: 0 importers afterwards, `projects/` back where it was.
- `pnpm check` clean; `pnpm test` 524 tests, 0 failures; hygiene 9 tests, 0 failures.