### PR TITLE
fix(hypit): a voiceover-led stretch is a speaking take the B-roll covers

### DIFF
--- a/.agents/skills/hypit/references/playbooks/craft/generated-dependencies.md
+++ b/.agents/skills/hypit/references/playbooks/craft/generated-dependencies.md
@@ -148,6 +148,15 @@ Decide, for each thing you place, which of three kinds it is:
 - **Genuinely coming and going** — an insert that appears for one phrase and leaves. A plain Selection
   is exactly right, and the gap is the point.
 
+**Where the base is meant to stay hidden, the covering Selections tile the Segment.** A voiceover-led
+stretch still has a speaking take under it — that is where the speech comes from — and the reference
+never shows it, so every word of that Segment is inside one covering Selection or the next, with the
+markers above joining them. A gap does not read as black there; it reads as a presenter appearing for
+half a second in a program that has none.
+
+This is settled in the Script rather than by looking: mark the covering ranges, read them back, and
+confirm the Segment's first word opens one and its last word closes one with nothing between.
+
 The same question decides a component you write yourself. A Program scheduled from occurrences draws
 only inside them unless you give it a span of its own, so a page built from one occurrence per row
 vanishes on the words between two rows. `@hypit/local-notebook-ranking` does that deliberately and

--- a/.agents/skills/hypit/references/playbooks/formats/mass-tarot.md
+++ b/.agents/skills/hypit/references/playbooks/formats/mass-tarot.md
@@ -7,13 +7,20 @@ ordered reveals and interpretations.
 
 - Write one authoritative Script with Selections/Moments for the question, choice window, each reveal,
   and the close.
-- Use one continuous narration take whenever the reading is voiceover-led. Generate it with
-  `mimo:Preset`, `mimo:VoiceDesign`, or `mimo:VoiceClone`, then use an audio-only Speech Take:
+- Take the voice sample once with `mimo:Preset` or `mimo:VoiceDesign`. The reading is spoken by a
+  take, and that take is the base under the whole Segment — the cards and the spread cover it, and
+  the speech and the picture stay one generation. `../craft/generated-dependencies.md` says why.
+  Cut the Segment to fit one generation.
 
 ```svml
 <program:Clock id="clock" frame-rate="30"/>
-<pipeline:Normalize id="narration-media" source={narration.audio}
-  video="none" audio="default" span-authority="audio" clock={clock}/>
+<seedance:ReferenceVideo id="narration-take" model="mini" prompt={reading-prompt}
+  duration={reading-duration.duration} generate-audio="true">
+  <seedance:Reference image={reader.image}/>
+  <seedance:Reference audio={reading-voice.audio}/>
+</seedance:ReferenceVideo>
+<pipeline:Normalize id="narration-media" source={narration-take.video}
+  video="primary-moving" audio="default" span-authority="video" clock={clock}/>
 <whisperx:SemanticTake id="narration-semantic" narrative={story}
   segment={story.segment.reading} media={narration-media.media}/>
 <speech:Track id="speech"
@@ -66,3 +73,8 @@ Read `../craft/b-roll.md`, `../craft/captions.md`, `../craft/overlays.md`, and
 
 That list is complete: `../index.md` does not repeat it, and the craft its required load
 order marks always-read is required regardless of format.
+
+- The base is meant to stay hidden, so the covering Selections tile the Segment: its first word
+  opens one, its last word closes one, and nothing falls between. Join them with the Script's
+  absorbing markers — `../craft/generated-dependencies.md` holds the table. A gap shows the
+  speaker for half a second in a program that has none.

--- a/.agents/skills/hypit/references/playbooks/formats/mixcut.md
+++ b/.agents/skills/hypit/references/playbooks/formats/mixcut.md
@@ -31,11 +31,15 @@ A crop of the same image is not a new beat.
 
 ## Author timing, text, and sound
 
-- Lock the delivery SemanticTrack before laying out Items. For a voice-led cut, an audio-only Take
-  supplies program time and semantic anchors. For a music-only cut, keep the `whisperx:SemanticTake`
+- Lock the delivery SemanticTrack before laying out Items. For a voice-led cut, the speaking take
+  supplies program time and semantic anchors, and sits under the cut as the base the Items cover. For a music-only cut, keep the `whisperx:SemanticTake`
   and `speech:Track` declarations and satisfy `<track>.semantic` in `.svrun` with `build-record` and
   `satisfy`, then author explicit `start`/`end` windows against it — `../index.md` says why the
   declarations stay. Do not treat music as speech evidence.
+- The base is meant to stay hidden, so the covering Selections tile the Segment: its first word
+  opens one, its last word closes one, and nothing falls between. Join them with the Script's
+  absorbing markers — `../craft/generated-dependencies.md` holds the table. A gap shows the
+  speaker for half a second in a program that has none.
 - Omit Caption components when there is no spoken Script. Use `typo:Track` for title, benefit, and CTA
   copy.
 - Keep no more than one or two text groups on screen at once. Align text handoffs to the final trimmed

--- a/.agents/skills/hypit/references/playbooks/formats/voiceover-desk-demo.md
+++ b/.agents/skills/hypit/references/playbooks/formats/voiceover-desk-demo.md
@@ -6,14 +6,21 @@ screen, product, hand, or proof changes.
 ## Author the SVML program
 
 1. Write one narration Script Segment with Selections/Moments for every visual proof beat.
-2. Generate one continuous narration Blob with `mimo:Preset`, `mimo:VoiceDesign`, or
-   `mimo:VoiceClone`. Do not split TTS to match picture cuts.
-3. Put the audio directly into an audio-only Speech Take:
+2. Take the voice sample once, with `mimo:Preset` or `mimo:VoiceDesign`.
+3. The narration is spoken by a take, and that take is the base. It is under the whole Segment and
+   the B-roll covers it; the viewer sees the desk only where nothing is over it, and the speech and
+   the picture are one generation either way — `../craft/generated-dependencies.md` says why that
+   matters. Cut the Segment to fit one generation.
 
 ```svml
 <program:Clock id="clock" frame-rate="30"/>
-<pipeline:Normalize id="narration-media" source={narration.audio}
-  video="none" audio="default" span-authority="audio" clock={clock}/>
+<seedance:ReferenceVideo id="narration-take" model="mini" prompt={narration-prompt}
+  duration={narration-duration.duration} generate-audio="true">
+  <seedance:Reference image={desk.image}/>
+  <seedance:Reference audio={narration-voice.audio}/>
+</seedance:ReferenceVideo>
+<pipeline:Normalize id="narration-media" source={narration-take.video}
+  video="primary-moving" audio="default" span-authority="video" clock={clock}/>
 <whisperx:SemanticTake id="narration-semantic" narrative={story}
   segment={story.segment.narration} media={narration-media.media}/>
 <speech:Track id="speech"
@@ -26,7 +33,12 @@ screen, product, hand, or proof changes.
    `{speech.audio}` directly to `film:Film`.
 5. Build each visual beat from supplied media or the vendored `broll-v1` Kit. Generated desk/screen
    shots use `seedance:FrameVideo` or `seedance:ReferenceVideo` with `generate-audio="false"`.
-6. Place visuals by the measured Script Selections/Moments. One sentence may span several visual
+6. Place visuals by the measured Script Selections/Moments.
+   The base is meant to stay hidden, so the covering Selections tile the Segment: its first word
+   opens one, its last word closes one, and nothing falls between. Join them with the Script's
+   absorbing markers — `../craft/generated-dependencies.md` holds the table. A gap shows the
+   speaker for half a second in a program that has none.
+ One sentence may span several visual
    cuts, and one visual may cover only part of a sentence.
 7. Add editorial explanation with `typo:Track`; add the complete Caption chain only when narration
    captions are wanted. Normalize only additional BGM/SFX before placing them on `audio:Track`.


### PR DESCRIPTION
I had carved these three formats out of the previous change as an exception — no one is on camera, so there seemed to be no speaking take to draw the Segment. That was wrong. There is always a take underneath speaking; the B-roll is over it.

`playbooks/formats/{voiceover-desk-demo,mass-tarot,mixcut}.md` each described narration generated on its own and placed in an audio-only Take. That is exactly the shape that gives a Segment one length and its picture another, which is what #48 removed everywhere else.

Each now generates the narration as a take with `generate-audio="true"`, from the sample `mimo:Preset` or `mimo:VoiceDesign` produced, and treats that take as the base.

## The rule that comes with it

Where the base is meant to stay hidden, the covering Selections tile the Segment: its first word opens one, its last word closes one, and nothing falls between. Join them with the Script's absorbing markers.

A gap does not read as black there. The base is a person, so it shows the speaker for half a second in a program that has none.

This is settled in the Script rather than by looking at anything — mark the covering ranges, read them back, confirm they meet. The absorbing table lives in `craft/generated-dependencies.md` and all three formats point at it.

## Verification

`pnpm test:release` 9 invariants, 0 failures. `VoiceClone`, `audio-only Take` and `audio-only Speech Take` no longer appear anywhere under `references/`.