### PR TITLE
docs(hypit): point the skill at the repository's own docs

### DIFF
--- a/.agents/skills/hypit/references/local-author-package.md
+++ b/.agents/skills/hypit/references/local-author-package.md
@@ -36,10 +36,10 @@ rules here are the contract, the closest package is only a shape to learn from.
 
 Then read:
 
-1. `https://narratage.hypit.ai/guide/component-anatomy` — the roles every component package fills, and how to find each
+1. `../../../../docs/guide/component-anatomy.md` — the roles every component package fills, and how to find each
    one in an existing package. Read this first; it is what the rest is measured against.
-2. `https://narratage.hypit.ai/guide/author-packages`
-3. `https://narratage.hypit.ai/guide/packages` and `https://narratage.hypit.ai/guide/conventions`
+2. `../../../../docs/guide/author-packages.md`
+3. `../../../../docs/guide/packages.md` and `../../../../docs/guide/conventions.md`
 4. the installed `@hypit/component-kit` README
 
 Use `hypit paths --json` to locate the installed Distribution. Then open the closest existing

--- a/.agents/skills/hypit/references/preview.md
+++ b/.agents/skills/hypit/references/preview.md
@@ -89,7 +89,7 @@ Studio keeps three stages of an item's time apart, and reading one for another m
   one outer window alongside its reveal phases.
 
 A projection line connects a source to its realized window, and the projection view is read-only.
-`https://narratage.hypit.ai/guide/studio-temporal-windows` is authoritative for what each stage carries.
+`../../../../docs/guide/studio-temporal-windows.md` is authoritative for what each stage carries.
 
 When the executed lineage names a Selection or Moment, dragging the realized block may issue
 `timeline.adjust` against that shared semantic identity. Script owns the inverse from semantic Anchor
@@ -100,4 +100,4 @@ read-only.
 Studio is a browser preview **for a person to look at**. It is not a source of images for an
 automated comparison — that is what the local still render above is for.
 
-`https://narratage.hypit.ai/quickstart/preview` is authoritative.
+`../../../../docs/quickstart/preview.md` is authoritative.

--- a/.agents/skills/hypit/references/quickstart.md
+++ b/.agents/skills/hypit/references/quickstart.md
@@ -4,14 +4,14 @@ Published docs and installed package declarations are authoritative:
 
 | Need | Read |
 |---|---|
-| Script semantics | `https://narratage.hypit.ai/quickstart/script` |
-| SVS Recipes | `https://narratage.hypit.ai/quickstart/styles` |
-| Media and Seedance | `https://narratage.hypit.ai/quickstart/generation` |
+| Script semantics | `../../../../docs/quickstart/script.md` |
+| SVS Recipes | `../../../../docs/quickstart/styles.md` |
+| Media and Seedance | `../../../../docs/quickstart/generation.md` |
 | Reusable Seedance Prompt Kits | the installed `@hypit/seedance-kits` README and selected Kit |
-| Normalization, alignment and SemanticTrack assembly | `https://narratage.hypit.ai/quickstart/timing` |
-| Caption, Media, Text, Audio Tracks | `https://narratage.hypit.ai/quickstart/tracks` and installed package READMEs |
-| Film and rendering | `https://narratage.hypit.ai/quickstart/composition` |
-| Run Source, durable Runtime, Builds, retrieval, and reuse | `https://narratage.hypit.ai/quickstart/run` and `runtime.md` |
+| Normalization, alignment and SemanticTrack assembly | `../../../../docs/quickstart/timing.md` |
+| Caption, Media, Text, Audio Tracks | `../../../../docs/quickstart/tracks.md` and installed package READMEs |
+| Film and rendering | `../../../../docs/quickstart/composition.md` |
+| Run Source, durable Runtime, Builds, retrieval, and reuse | `../../../../docs/quickstart/run.md` and `runtime.md` |
 
 Canonical path:
 

--- a/.agents/skills/hypit/references/runtime.md
+++ b/.agents/skills/hypit/references/runtime.md
@@ -1,6 +1,6 @@
 # Durable Runtime and Build lifecycle
 
-Read `https://narratage.hypit.ai/quickstart/run` as the authority for Run Source, Target, Candidate, Runtime Profile,
+Read `../../../../docs/quickstart/run.md` as the authority for Run Source, Target, Candidate, Runtime Profile,
 Build, retrieval, and reuse syntax. Use this file as the operational checklist.
 
 ## Author the Runtime Profile


### PR DESCRIPTION
The skill sent the agent to `narratage.hypit.ai` for Script semantics, SVS Recipes, generation, timing, Tracks, Film/rendering, Run sources, and the package authoring guide.

Every one of those pages is a Markdown file in this repository — `docs/quickstart/` and `docs/guide/` are exactly the pages the site publishes. Reading the remote copy means:

- the agent's ground truth is whatever happened to be deployed;
- it needs a network hop;
- it can drift from the checkout the agent is standing in;
- a change and its documentation cannot land in the same PR.

All eleven references across `references/{quickstart,preview,runtime,local-author-package}.md` now point at the local files by relative path from the skill file. Verified that every path resolves to an existing file; no `narratage.hypit.ai` URL remains under `references/`.