### PR TITLE
fix(reference-video-tools): find the Hypit tree by what it holds

### DIFF
--- a/packages/reference-video-tools/src/authoring.ts
+++ b/packages/reference-video-tools/src/authoring.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
-import { readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 
 import { writePlaceholder } from "./placeholder.js";
@@ -89,26 +89,28 @@ export type StandInFocus = {
 };
 
 /**
- * The Hypit checkout this package is installed into.
+ * The Hypit tree this package is installed into.
  *
  * Studio's domain and the HyperFrames runtime are both found from it, and neither can be found from
  * the working directory: a command run from a project directory would resolve no packages, and one
- * that assumed the root would work there and crash anywhere else, on a missing module rather than on
- * anything a reader could act on. Walking up from this module reaches the checkout from wherever the
- * package was installed. `HYPIT_REPOSITORY` names one explicitly, the same override
- * `locate-repository.mjs` reads.
+ * that assumed the root would work there and crash anywhere else. Walking up from this module reaches
+ * the tree from wherever the package was installed.
+ *
+ * What identifies it is holding the packages this module imports. A name in `package.json` does not:
+ * a checkout and an installed Distribution carry different ones, so a check against either name
+ * refuses the other, and the refusal reads as "this is not a Hypit checkout" while standing inside
+ * one.
  */
-function isCheckout(directory: string): boolean {
-  try {
-    const manifest = JSON.parse(readFileSync(join(directory, "package.json"), "utf8")) as { readonly name?: string };
-    return manifest.name === "@hypit/repository";
-  } catch { return false; }
+const NEEDED = ["studio", "hyperframes", "script", "estimate"] as const;
+
+function isHypitTree(directory: string): boolean {
+  return NEEDED.every((name) => existsSync(join(directory, "packages", name, "package.json")));
 }
 
-function nearestCheckout(start: string): string | undefined {
+function nearestTree(start: string): string | undefined {
   let directory = resolve(start);
   while (true) {
-    if (isCheckout(directory)) return directory;
+    if (isHypitTree(directory)) return directory;
     const parent = dirname(directory);
     if (parent === directory) return undefined;
     directory = parent;
@@ -116,14 +118,17 @@ function nearestCheckout(start: string): string | undefined {
 }
 
 function repositoryRoot(): string {
+  // An explicit override is taken as given. Re-deriving it would refuse a layout the caller can see
+  // and this cannot, which leaves no way out of a wrong guess.
   const override = process.env.HYPIT_REPOSITORY?.trim();
   if (override !== undefined && override.length > 0) {
     const directory = resolve(override);
-    assert(isCheckout(directory), `HYPIT_REPOSITORY is not a Hypit checkout: ${directory}`);
+    assert(existsSync(directory), `HYPIT_REPOSITORY names no directory: ${directory}`);
     return directory;
   }
-  const found = nearestCheckout(dirname(fileURLToPath(import.meta.url))) ?? nearestCheckout(process.cwd());
-  assert(found !== undefined, "no Hypit checkout above this package or the working directory; set HYPIT_REPOSITORY");
+  const found = nearestTree(dirname(fileURLToPath(import.meta.url))) ?? nearestTree(process.cwd());
+  assert(found !== undefined,
+    `no Hypit tree above ${dirname(fileURLToPath(import.meta.url))} or ${process.cwd()} — one holding packages/${NEEDED.join(", packages/")}. Set HYPIT_REPOSITORY to name it.`);
   return found;
 }
 


### PR DESCRIPTION
The tools located the checkout by requiring its `package.json` to be named `@hypit/repository`:

```ts
return manifest.name === "@hypit/repository";
```

This repository's root `package.json` is named **`hypit`**, and nothing in the tree carries the other name. So every command that needs Studio or HyperFrames — `render_element`, `render_previews`, `compare_reconstruction` with a word range — refused to run, with *"no Hypit checkout above this package or the working directory"*, while standing inside the checkout.

`HYPIT_REPOSITORY` did not open the door either. The override ran the same name check and asserted a second time, so a caller who could see the layout had no way to say so. A model running the route worked around this by fabricating a checkout under `/tmp` with a marker `package.json` and symlinks — and then had to symlink `.hypit` as well, because the reference state it needed was written elsewhere.

The comment beside the check pointed at `locate-repository.mjs`, which is not in the tree.

## What identifies a tree now

Holding the packages this module imports: `packages/{studio,hyperframes,script,estimate}`. A checkout and an installed Distribution carry different names and the same packages, so a name check refuses one of them while standing inside it.

An explicit `HYPIT_REPOSITORY` is taken as given — only that the directory exists — because re-deriving it refuses a layout the caller can see and this cannot, which leaves no way out of a wrong guess. The failure message now names both places searched and what was looked for.

## Verification

- `pnpm check` clean; `pnpm test` 0 failures.
- `reconstruction_check` run **from a project directory** now returns its result. That is the invocation that previously needed the fabricated `/tmp` checkout.

One note for whoever runs this locally: `pnpm check` fails on a working tree where `projects/` has been linked in by a local `pnpm install` — three `TS7031`s in `packages/temporal/src/component.ts` that do not exist in CI. `pnpm install --frozen-lockfile` with that directory set aside clears them. It is the same friction `pnpm lockfile:refresh` exists for, showing up in type resolution rather than in the lockfile.