### PR TITLE
docs(hypit): say where a Caption Cue ends

### DIFF
--- a/.agents/skills/hypit/references/playbooks/craft/captions.md
+++ b/.agents/skills/hypit/references/playbooks/craft/captions.md
@@ -81,6 +81,28 @@ an omission.
 `docs/quickstart/composition.md` still show them; a Recipe carrying either is refused as an unknown
 property, since the Style admits exactly the required keys plus the documented optional ones.
 
+## Cue boundaries are marked in the Script, with `||`
+
+A Recipe holds no rule for where one Cue ends and the next begins. **The Script does**, as a `||`
+between two complete Alignment Units — `docs/quickstart/script.md` is authoritative for it, and
+`packages/script/src/parser.ts` reads it into the breaks the Caption Document carries.
+
+```
+<PRESENTER> It's generally good || at a lot of || different things, ||
+  but it's not || as specialized || as some of these || other models.
+```
+
+A Segment with no `||` in it is **one Cue**, however long it is: the whole passage renders as a
+single line and runs off both edges of the frame. That is the shape to recognise — a caption that
+overflows is a Segment nobody broke, not a Style whose width or size is wrong, and widening the box
+or shrinking the type will not close it.
+
+Mark the breaks where the reference breaks. The observation for a shot says what is on screen at
+once, and that is the Cue.
+
+`||` cannot sit inside a Dual Text unit or split one, since a break falls between units and never
+through one. Timing is not authored with it: each Cue is still timed from the alignment.
+
 ## Keep the Script authoritative
 
 - Preserve the exact Script display text. Do not copy burned-in reference subtitles or rewrite the

--- a/.agents/skills/hypit/references/playbooks/craft/generated-dependencies.md
+++ b/.agents/skills/hypit/references/playbooks/craft/generated-dependencies.md
@@ -142,7 +142,9 @@ Decide, for each thing you place, which of three kinds it is:
 
   A plain `@a … @/a @b … @/b` closes on one word's end and opens on another word's start, and the
   pause between those two words is in neither Selection. Written `@/a~` or `~@b` the two windows meet,
-  and what is under them stays under them. `docs/quickstart/script.md` is authoritative for the
+  and what is under them stays under them. The same file carries `||`, which marks where one Caption
+  Cue ends and the next begins — `captions.md` says what happens to a Segment nobody broke.
+  `docs/quickstart/script.md` is authoritative for the
   markers.
 - **Genuinely coming and going** — an insert that appears for one phrase and leaves. A plain Selection
   is exactly right, and the gap is the point.


### PR DESCRIPTION
A run through the route wrote `cue-min-words` into a Style, had it refused, and only then found that Cue boundaries are marked in the Script with `||`.

#54 said those two keys are not read. It did not say what replaced them, so a reader learned the old way was closed without learning the new one — which is the worse half of the two to be missing.

## What the code does

`||` between two complete Alignment Units. `packages/script/src/parser.ts:343,498,648,667` reads it, `packages/script/src/narrative.ts:75` turns it into the breaks the Caption Document carries, `packages/caption/src/display.ts:29` consumes them. `docs/quickstart/script.md:114,137` is authoritative and the skill had nothing.

**A Segment with no `||` is one Cue.** The whole passage renders as a single line and runs off both edges. That reads as a Style whose width or size is wrong, and it is not: widening the box or shrinking the type will not close it. Worth naming, because it is the symptom a reader will actually meet.

Marked where the reference breaks — the observation for a shot says what is on screen at once, and that is the Cue.

## The pattern behind it

`||` sits beside the absorbing markers in the same quickstart page, and the absorbing markers were missing from the skill for the same reason until #48. Four Script markers, all authoritative in `docs/quickstart/script.md`, all previously absent. The section on joining two Selections now points at `||`, so a reader who finds one finds the other.

## Verification

`pnpm test:release` 9 invariants, 0 failures. All four markers — `||`, `@id!`, `~@`, `@/` — now appear in the skill.