### PR TITLE
docs(hypit): the base of a Segment is whichever picture speaks it

### DIFF
--- a/.agents/skills/hypit/references/playbooks/craft/frame-coverage.md
+++ b/.agents/skills/hypit/references/playbooks/craft/frame-coverage.md
@@ -18,8 +18,8 @@ an interval inherits its edges whenever its length comes from something other th
 - a window derived from speech, which starts and stops with words and therefore excludes the silence
   around and between them;
 - an insert, whose material ends where the generator stopped rather than where its window does — and
-  then draws nothing for the rest of it, because `playback` defaults to `once-start`, so the base
-  returns mid-phrase. This is the one edge on the list a machine can find before a Build:
+  then draws nothing for the rest of it, because `playback` defaults to `once-start`, so whatever it
+  was covering is alone again mid-phrase. This is the one edge on the list a machine can find before a Build:
   `reconstruction_check` reads each Recipe and refuses the default on generated material.
   `generated-dependencies.md` says what to set instead. The Segment's own picture has no such edge —
   the take that speaks it is the take that draws it, so the two lengths are one number;

--- a/.agents/skills/hypit/references/playbooks/craft/generated-dependencies.md
+++ b/.agents/skills/hypit/references/playbooks/craft/generated-dependencies.md
@@ -78,7 +78,33 @@ One generation carries both, and that is what makes the Segment's length and its
 same number. Generating the speech separately makes them two numbers arrived at independently — the
 Segment as long as whatever a voice generator produced, the picture as long as whatever a video
 generator was asked for — and two numbers arrived at independently do not agree. Where they disagree,
-the picture ends first and nothing is under it.
+the picture ends first and there is nothing to take its place.
+
+### The base of a Segment is whichever picture speaks it
+
+**Speech decides which picture is the base, and depth has nothing to say about it.** Read the
+reference this way: the picture showing a person saying the words the transcript carries for that
+stretch is that Segment's base, wherever it sits in the frame and whatever else is on screen with it.
+
+This is the reading that goes wrong most often. A reference cuts to a full-frame board with the
+speaker inset in a corner, and the board is the larger, lower, more obviously "background" thing —
+so the board is authored as the base and the speaker as an insert over it. It is the other way
+round: the inset speaks, so the inset is the base, and the board is what covers most of it. Nothing
+about being large, or full-frame, or visually underneath makes a picture a base.
+
+Check it against the words rather than the layout. A person whose mouth moves over speech that is not
+theirs is B-roll — `../../reconstruction/continuity.md` is what keeps a moving mouth from becoming a
+speaker — and a small inset saying the transcript's words is the base.
+
+### Stack order is authored per Segment, never once for "the base"
+
+A picture is the base *of a Segment*. The same Track can hold the base for one Segment and something
+almost entirely covered in the next, and those two are different stack orders decided separately.
+
+So do not fix a Track's `stack-order` because of what it is: give each unit the order its own stretch
+needs, from what the reference shows over it there. A `stack-order: 0` written once because "this is
+the base" is what leaves a Segment's speaker under a panel that was only meant to cover the Segment
+before it.
 
 ### A Segment fits one generation
 
@@ -150,8 +176,8 @@ Decide, for each thing you place, which of three kinds it is:
   is exactly right, and the gap is the point.
 
 **Where the base is meant to stay hidden, the covering Selections tile the Segment.** A voiceover-led
-stretch still has a speaking take under it — that is where the speech comes from — and the reference
-never shows it, so every word of that Segment is inside one covering Selection or the next, with the
+stretch still has a speaking take — that is where the speech comes from, so it is the base — and the
+reference never shows it, so every word of that Segment is inside one covering Selection or the next, with the
 markers above joining them. A gap does not read as black there; it reads as a presenter appearing for
 half a second in a program that has none.
 
@@ -175,8 +201,8 @@ its window are two numbers arrived at separately. Where the material is the shor
 whatever is beneath. `hold-start` pins the last frame for the rest of the window, `loop-start`
 repeats, `stretch` retimes to fit.
 
-What appears is the base — the insert leaves early and the shot beneath returns mid-phrase. Read it
-as an insert with the wrong length rather than as an edit, and give the Recipe a `playback` that says
+What appears is the Segment's base — the insert leaves early and the picture that speaks the stretch
+is alone again mid-phrase. Read it as an insert with the wrong length rather than as an edit, and give the Recipe a `playback` that says
 what should happen there. `reconstruction_check` reads the Recipe before a Build and refuses the
 default on generated material.
 

--- a/.agents/skills/hypit/references/reconstruction/continuity.md
+++ b/.agents/skills/hypit/references/reconstruction/continuity.md
@@ -13,6 +13,11 @@ These invariants override superficial layer order and shot boundaries:
   presence. The `agent` observer has no audio evidence and reads these from the frames and the word
   timings instead, which `observers.md` describes: the transcript is what decides whether anyone is
   speaking at all, so it is what keeps a moving mouth in B-roll from becoming a speaker.
+- The same evidence decides which picture is the Segment's base: whichever one shows a person saying
+  the words the transcript carries there, however small it is and whatever is on screen over it. A
+  full-frame board with the speaker inset in a corner is a base the size of the corner, covered by
+  most of a board. `../playbooks/craft/generated-dependencies.md` holds the rule and what follows
+  from it for stack order.
 - One overlay that continues across a cut remains one visual track spanning its full observed
   lifetime. Do not recreate it once per shot.
 - Merge two or three incorrectly split clips only when continuity evidence confirms one camera shot


### PR DESCRIPTION
Asked whether the principle "whoever speaks is the base, regardless of z" was carried through. It was not — the word was only ever used positionally.

## What the docs said

Four mentions, all describing a position:

```
frame-coverage.md          so the base returns mid-phrase
generated-dependencies.md  the base shows through
generated-dependencies.md  the insert leaves early and the shot beneath returns
generated-dependencies.md  a speaking take under it
```

Nothing said what makes a picture the base. Put that beside `overlays.md`'s *"higher recipe `stack-order` values render above lower ones"* and a reader arrives at the wrong rule: the base is the thing at the bottom, so pin it to `stack-order: 0`. Which is how `ad-test-reverse` came to have twelve `media.base` Items all at `stack-order: 0`, and how a full-frame still could sit under the whole program.

The "one generation carries the speech and the picture" rule from #48 was close but answers a different question — it is about *generation*, not about which picture is the base.

## What it says now

**Speech decides it, and depth has nothing to say about it.** The picture showing a person saying the words the transcript carries for that stretch is that Segment's base, wherever it sits in the frame and whatever else is on screen with it.

The reading that goes wrong is stated as the case it is: a reference cuts to a full-frame board with the speaker inset in a corner, the board is larger and more obviously "background", so the board is authored as the base and the speaker as an insert over it. It is the other way round — a base the size of the corner, covered by most of a board.

Checked against the words rather than the layout. A person whose mouth moves over speech that is not theirs is B-roll; a small inset saying the transcript's words is the base.

## Stack order follows

A picture is the base *of a Segment*. The same Track can hold the base for one Segment and be almost entirely covered in the next, and those are two orders decided separately from what the reference shows over each stretch.

A `stack-order: 0` written once because "this is the base" is what leaves a Segment's speaker under a panel that was only meant to cover the Segment before it.

## Both sides

`continuity.md` carries the same test on the observation side, beside the transcript rule that already keeps a moving mouth in B-roll from becoming a speaker. Same evidence, second question — and the judgement happens while reading the reference, not while authoring.

The positional wordings elsewhere are reworded so nothing contradicts it.

## Verification

`pnpm test:release` 9 invariants, 0 failures.