### PR TITLE
fix: resolve a project's packages from the project, and declare the shapes gpt-image makes

### DIFF
--- a/packages/gpt-image/src/index.ts
+++ b/packages/gpt-image/src/index.ts
@@ -21,8 +21,10 @@ export const gptImage2Ports: GenerationPortTable = sealGenerationPortTable({
       name: "aspectRatio",
       value: {
         kind: "enum",
-        values: ["auto", "1:1", "3:2", "2:3", "4:3", "3:4", "5:4", "4:5",
-          "16:9", "9:16", "2:1", "1:2", "3:1", "1:3", "21:9", "9:21"],
+        // What the model produces. The wider shapes an image API will name in general — 2:1, 3:1,
+        // 21:9 and their inverses — this one refuses, and the refusal arrives from the Provider
+        // after the request was made rather than from validation before it.
+        values: ["auto", "1:1", "3:2", "2:3", "4:3", "3:4", "5:4", "4:5", "16:9", "9:16"],
       },
       minItems: 1,
       maxItems: 1,
@@ -77,8 +79,7 @@ const gptImageAttributes: readonly SurfaceAttributeVocabulary[] = [
     kind: "literal",
     required: true,
     summary: "The shape of the generated picture.",
-    values: ["auto", "1:1", "3:2", "2:3", "4:3", "3:4", "5:4", "4:5",
-      "16:9", "9:16", "2:1", "1:2", "3:1", "1:3", "21:9", "9:21"],
+    values: ["auto", "1:1", "3:2", "2:3", "4:3", "3:4", "5:4", "4:5", "16:9", "9:16"],
   },
   {
     name: "resolution",

--- a/packages/reference-video-tools/src/authoring.ts
+++ b/packages/reference-video-tools/src/authoring.ts
@@ -132,6 +132,25 @@ function repositoryRoot(): string {
   return found;
 }
 
+/**
+ * Where installed packages are resolved from, found the way `hypit check` finds it: the nearest
+ * directory at or above the project that holds a `package.json`.
+ *
+ * A project's own `packages/local-*` are installed against the project, so a root taken from
+ * anywhere else resolves none of them. This is the same walk `packages/cli/src/main.ts` performs,
+ * and the reason a project is given a `package.json` of its own — without one the walk passes
+ * through it and lands on the tree.
+ */
+function nearestPackageRoot(start: string): string | undefined {
+  let directory = resolve(start);
+  while (true) {
+    if (existsSync(join(directory, "package.json"))) return directory;
+    const parent = dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
 /** Where a relative path on the command line is measured from. */
 export function invokedFrom(): string {
   return process.env.INIT_CWD ?? process.cwd();
@@ -750,8 +769,11 @@ export async function renderElement(input: RenderElementInput): Promise<Record<s
   const element = input.element;
   const cwd = invokedFrom();
   const runPath = resolve(cwd, input.run);
-  const packageRoot = repositoryRoot();
   const projectRoot = dirname(runPath);
+  // Where installed packages are found, which is not where the Hypit tree is. A project carries its
+  // own `packages/local-*`, so the search starts at the project and walks up the way the CLI's does —
+  // resolving against the tree instead would miss every package the project installed for itself.
+  const packageRoot = nearestPackageRoot(projectRoot) ?? repositoryRoot();
   const outPath = resolve(cwd, input.out);
 
   const runSource = await readFile(runPath, "utf8").catch(() => undefined);
@@ -1057,7 +1079,9 @@ export async function renderElement(input: RenderElementInput): Promise<Record<s
   const frames = join(compareRoot, "frames");
   await rm(frames, { recursive: true, force: true });
   await mkdir(frames, { recursive: true });
-  const hyperframesCli = createRequire(join(packageRoot, "packages/provider-hyperframes-local/package.json"))
+  // The runtime ships with the tree, not with the project. Resolving it against the package root
+  // finds nothing whenever those two differ, which is every project that installs packages of its own.
+  const hyperframesCli = createRequire(join(repositoryRoot(), "packages/provider-hyperframes-local/package.json"))
     .resolve("hyperframes/bin/hyperframes.mjs");
   const drawn = spawnSync(process.execPath, [
     hyperframesCli, "render", stage,


### PR DESCRIPTION
## The package root is not the tree root

`render_element` took its package root from `repositoryRoot()`. A project that installs packages of its own resolved none of them — the tree has no `packages/local-<slug>`, the project does. Running it from a project directory required pointing `HYPIT_REPOSITORY` at the project, which then broke everything that legitimately needs the tree.

They are two questions. The package root is the nearest directory at or above the project holding a `package.json`, which is the walk `packages/cli/src/main.ts` performs and the walk a project's own `package.json` exists to stop. The tree root is where `packages/studio` and the rest live.

**The HyperFrames runtime was the same defect pointing the other way.** It ships with the tree, and was resolved against the package root:

```
Cannot find module 'hyperframes/bin/hyperframes.mjs'
Require stack:
- projects/ad-archive-reverse/packages/provider-hyperframes-local/package.json
```

Found while the two roots were the same directory; missing the moment separating them made them differ. It reads from the tree now.

Verified by rendering an element from inside `projects/ad-archive-reverse`, which carries its own `package.json` and its own `local-tierboard`. Both the project's package and the runtime resolve.

## gpt-image declared shapes it does not make

The enum carried `2:1`, `1:2`, `3:1`, `1:3`, `21:9` and `9:21` alongside the shapes the model produces. Single-image probes confirm `1:1`, `3:2` and `16:9` work and `2:1` and `3:1` do not — the model refuses them, and the refusal arrives from the Provider **after the request was sent** rather than from validation before it. `packages/provider-kie/src/mapping.ts` passes `aspectRatio` straight through with no constraint of its own, so nothing upstream catches it: a Source is told it may ask for a shape, and the Build fails on it.

The enum now names what comes back. Other image packages declare their own sets and are untouched — `minimax-h3` and `seedream` both keep `21:9`, which their models do accept.

## Verification

`pnpm check` clean; `pnpm test` 500 tests, 0 failures. A render run from a project directory returns its result rather than a module-resolution failure.