### PR TITLE
docs(readme): install Hypit with the skill command alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,8 @@ Hypit gives AI agents (Claude Code, Codex...) a language and system to create vi
 ## Install once
 
 ```bash
-npm install --global hypit
-npx skills add hypit-ai/hypit --global
+npx skills add hypit-ai/hypit -g
 ```
-
-The npm package is the Hypit Distribution: CLI, Studio, official components and managed-service
-source. The global skill is discoverable by later agent sessions in any project. Neither command
-clones an authoring repository into your project.
 
 ## Use the Hypit skill
 
@@ -70,17 +65,6 @@ Or start without a reference video:
 ```
 
 Your agent can check the environment, request only the credentials the video needs, preview the result, and build it.
-
-Projects, generated files and project-local components stay in that project directory. Machine
-programs such as WhisperX are installed on demand into the Hypit Program Home and reused by every
-project. Upstream npm packages such as one Fontsource family or HyperFrames are likewise installed
-only when selected, into a separate shared machine package home. Opening a new session does not
-install either again. Check with `hypit --version` and
-`npm outdated --global hypit`; update deliberately with `npm update --global hypit` and
-`npx skills update --global`.
-
-The supported desktop baseline is macOS 13+ or Windows 10/11 x64 with Node.js 22+. Repository cloning,
-pnpm and Corepack are contributor-only concerns.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,12 +46,8 @@ Hypit 给 AI Agents (Claude Code、Codex……) 打造了一门做视频的语�
 ## 只安装一次
 
 ```bash
-npm install --global hypit
-npx skills add hypit-ai/hypit --global
+npx skills add hypit-ai/hypit -g
 ```
-
-npm 包是 Hypit Distribution，包含 CLI、Studio、官方组件和托管服务源码；全局 skill 能被以后
-任何项目里的 Agent 会话发现。这两个命令都不会把创作仓库克隆进项目目录。
 
 ## 使用 Hypit skill
 
@@ -69,15 +65,6 @@ npm 包是 Hypit Distribution，包含 CLI、Studio、官方组件和托管服�
 ```
 
 Agent 会检查环境，只索取视频实际需要的凭据，展示预览并执行构建。
-
-项目源码、生成文件和项目私有组件始终留在项目目录里。WhisperX 等机器程序按需安装到
-Hypit Program Home；Fontsource 单个字体、HyperFrames 等上游 npm 包也只在实际选择后安装
-到独立的机器共享目录。两者都会被所有项目复用，新开会话不会再装一遍。用 `hypit --version` 和
-`npm outdated --global hypit` 检查版本，需要更新时显式执行 `npm update --global hypit` 和
-`npx skills update --global`。
-
-桌面支持基线是 macOS 13+ 或 Windows 10/11 x64，以及 Node.js 22+。克隆仓库、pnpm 和
-Corepack 只属于贡献者工作流。
 
 ## 许可证
 


### PR DESCRIPTION
README 安装段落原本是两条命令。skill 在首次需要 `hypit` 命令时会安装 Distribution，一条命令即可，因此安装块改为 `npx skills add hypit-ai/hypit -g`。

同时删除三段内容：
- 说明两条命令分工的段落
- 项目目录 / Program Home / 机器共享包目录的安装位置与更新命令段落
- 桌面支持基线（macOS 13+、Windows 10/11 x64、Node.js 22+）与 pnpm、Corepack 归属贡献者工作流的段落

中英文 README 同步修改。

`docs/quickstart.md` 与 `docs/zh/quickstart.md` 仍是两条命令的写法，本 PR 未涉及。