### PR TITLE
fix: reach the project's own packages from every command, and say where the route stops

### DIFF
--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -5,6 +5,21 @@ description: Produce a complete video program from a description — a ranking, 
 
 # Hypit
 
+**Run the route to the end without stopping.** There are exactly two things worth interrupting the
+author for, and everything else is yours to decide:
+
+- **Spending their money.** A Build generates, and generating is billed. Say what it will cost and
+  get a yes before submitting one.
+- **Which observer reads the reference, and the credentials it needs.** Vertex or the calling agent
+  is a decision about the author's account, and `references/credentials.md` says what each one wants.
+  Ask once, at the start.
+
+Everything else — the working directory, the project location, which packages to use, which generator
+draws a picture, how to name a Segment, what to do about a difference the comparison reported — is a
+choice between things that all work, and asking costs the author an interruption to answer a question
+the references already answer. Decide it and keep going. A run that stops half way with a question is
+a run the author has to restart.
+
 Use this file only to route the task. Read the selected reference completely before acting; when
 that reference names required child references, read those completely in the stated order.
 

--- a/packages/reference-video-tools/src/tools.ts
+++ b/packages/reference-video-tools/src/tools.ts
@@ -9,6 +9,7 @@ import { loadNodePackageSelection } from "@hypit/package-loader-node";
 import { markupSurfaceHostFacetAbi } from "@hypit/markup";
 import type { RegisteredSurface, SurfaceVocabulary } from "@hypit/markup";
 import { exactModelHostAbi } from "@hypit/model-kit";
+import { videoCliDistribution } from "@hypit/video-cli";
 
 import { authorSource, invokedFrom, referenceRoot, referenceWords, renderElement, renderPreviews, spokenRange, standInSidecarPath } from "./authoring.js";
 import type { RenderElementInput, RenderPreviewsInput, SpokenRange, StandInFocus, StandInSidecar } from "./authoring.js";
@@ -778,14 +779,44 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
     // answer was to read a guide and a directory listing by hand. The Build CLI deliberately never
     // scans a directory; this is a development tool, so it may.
     async list_svml_packages(): Promise<Record<string, unknown>> {
-      const scope = join(packageRoot, "node_modules", "@hypit");
-      const names = await readdir(scope).catch(() => [] as string[]);
-      assert(names.length > 0, `no installed @hypit packages under ${scope}`);
+      // Every scope, and the project's own directory, rather than `@hypit` alone. A project that
+      // declares a vocabulary gap and fills it publishes under its own scope, and a listing that
+      // cannot see those packages answers "which packages exist" with only half of them — including
+      // for the project asking.
+      // The installed packages a project does not carry are in the Distribution, and the ones it does
+      // are beside it. Reading only the root the project resolves from answers "which packages exist"
+      // with whichever half that root happens to hold.
+      const roots = [...new Set([join(packageRoot, "node_modules"),
+        ...(videoCliDistribution.packageRoot === undefined ? [] : [join(videoCliDistribution.packageRoot, "node_modules")])])];
+      const candidates: { readonly specifier: string; readonly directory: string }[] = [];
+      for (const modules of roots) {
+        const scopes = (await readdir(modules, { withFileTypes: true }).catch(() => []))
+          .filter((entry) => entry.isDirectory() && entry.name.startsWith("@"))
+          .map((entry) => entry.name);
+        for (const scope of scopes.sort()) {
+          const inside = await readdir(join(modules, scope)).catch(() => [] as string[]);
+          for (const name of inside.sort()) {
+            const specifier = `${scope}/${name}`;
+            if (!candidates.some((item) => item.specifier === specifier)) {
+              candidates.push({ specifier, directory: join(modules, scope, name) });
+            }
+          }
+        }
+      }
+      // A project's own packages are its `packages/<name>/`, which is where they are authored and
+      // where the loader finds them by name whether or not a package manager linked them.
+      for (const name of (await readdir(join(packageRoot, "packages")).catch(() => [] as string[])).sort()) {
+        const directory = join(packageRoot, "packages", name);
+        const own = await readJson<{ readonly name?: string }>(join(directory, "package.json"));
+        if (own?.name !== undefined && !candidates.some((item) => item.specifier === own.name)) {
+          candidates.push({ specifier: own.name, directory });
+        }
+      }
+      assert(candidates.length > 0, `no packages under ${roots.join(", ")} or ${join(packageRoot, "packages")}`);
       const packages: Record<string, unknown>[] = [];
-      for (const name of [...names].sort()) {
-        const specifier = `@hypit/${name}`;
+      for (const { specifier, directory } of candidates) {
         const manifest = await readJson<{ readonly hypit?: { readonly activation?: string }; readonly description?: string }>(
-          join(scope, name, "package.json"));
+          join(directory, "package.json"));
         if (manifest?.hypit?.activation === undefined) continue;
         // A package publishes several kinds of facet. Reading them all as one kind produced a null
         // for every facet that is not a Markup Surface, which is what an exact-model package mostly

--- a/packages/reference-video-tools/test/tools.test.ts
+++ b/packages/reference-video-tools/test/tools.test.ts
@@ -89,13 +89,18 @@ test("installed packages can be listed, and one that will not load is reported r
 
   const result = await createReferenceVideoTools({ packageRoot: root, generate: async () => "" }).list_svml_packages();
   const packages = result["packages"] as readonly Record<string, unknown>[];
-  assert.deepEqual(packages.map((item) => item["package_name"]), ["@hypit/with-activation"],
+  const named = (name: string) => packages.find((item) => item["package_name"] === name);
+  // The listing also reaches the Distribution, since a project holds its own packages and not the
+  // installed ones, so this asks about the two written above rather than about the whole answer.
+  assert.equal(named("@hypit/plain-library"), undefined,
     "a package without an activation contributes no author vocabulary and is not vocabulary to discover");
-  assert.equal(packages[0]!["description"], "declares a Surface");
-  assert.equal(typeof packages[0]!["unreadable"], "string",
+  const declared = named("@hypit/with-activation");
+  assert.ok(declared, "a package that declares an activation is vocabulary to discover");
+  assert.equal(declared["description"], "declares a Surface");
+  assert.equal(typeof declared["unreadable"], "string",
     "a package that declares an activation it cannot load is named, not silently dropped");
-  assert.equal(packages[0]!["tags"] !== undefined
-    && (packages[0]!["tags"] as readonly unknown[]).includes(null), false,
+  assert.equal(declared["tags"] !== undefined
+    && (declared["tags"] as readonly unknown[]).includes(null), false,
     "a facet that is not a Markup Surface has no tag, and reading one out of it produced a null entry");
 });
 

--- a/packages/studio/preview-check.ts
+++ b/packages/studio/preview-check.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { dirname, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 
 import { videoCliDistribution } from "@hypit/video-cli";
 
@@ -10,17 +11,52 @@ import { loadStudioRun } from "./src/run.js";
 import { readStudioSession } from "./src/session.js";
 import { inspectStudioRun } from "./src/studio-preflight.js";
 
-const runArgument = process.argv[2];
+/**
+ * Where a Source's imports resolve from: the nearest directory at or above it holding a
+ * `package.json`. This is the walk `hypit check` makes, and it is why a project is given a
+ * `package.json` of its own — a project's `packages/local-*` are installed against the project, so a
+ * root taken from anywhere else resolves none of them.
+ *
+ * The Run's own directory is not that root whenever the Run sits in a subdirectory, which is how one
+ * command resolved a project's packages and this one did not.
+ */
+function nearestPackageRoot(start: string): string | undefined {
+  let directory = resolve(start);
+  while (true) {
+    if (existsSync(join(directory, "package.json"))) return directory;
+    const parent = dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
+const flags = new Map<string, string>();
+const operands: string[] = [];
+for (let index = 2; index < process.argv.length; index += 1) {
+  const token = process.argv[index]!;
+  if (!token.startsWith("--")) { operands.push(token); continue; }
+  const [name, inline] = token.slice(2).split(/=(.*)/su);
+  const value = inline ?? process.argv[++index];
+  if (value === undefined) { process.stderr.write(`--${name} needs a value\n`); process.exit(2); }
+  flags.set(name!, value);
+}
+
+const runArgument = operands[0];
 if (runArgument === undefined) {
-  process.stderr.write("usage: hypit-preview-check <build.svrun> [<hypit.runtime.json>]\n");
+  process.stderr.write("usage: hypit-preview-check <build.svrun> [<hypit.runtime.json>]"
+    + " [--workspace <dir>] [--package-root <dir>]\n");
   process.exitCode = 2;
 } else {
-  const invokedFrom = process.env.INIT_CWD ?? process.cwd();
+  const invokedFrom = process.cwd();
   const runPath = resolve(invokedFrom, runArgument);
-  const runtimeArgument = process.argv[3];
+  const runtimeArgument = operands[1];
   const runtimePath = runtimeArgument === undefined ? undefined : resolve(invokedFrom, runtimeArgument);
-  const workspaceRoot = dirname(runPath);
-  const packageRoot = workspaceRoot;
+  const workspaceFlag = flags.get("workspace");
+  const packageRootFlag = flags.get("package-root");
+  const workspaceRoot = workspaceFlag === undefined ? dirname(runPath) : resolve(invokedFrom, workspaceFlag);
+  const packageRoot = packageRootFlag === undefined
+    ? nearestPackageRoot(dirname(runPath)) ?? workspaceRoot
+    : resolve(invokedFrom, packageRootFlag);
   const distributionPackageRoot = videoCliDistribution.packageRoot;
   if (distributionPackageRoot === undefined) throw new Error("active Hypit Distribution has no package root");
 


### PR DESCRIPTION
Three defects reported from using the repository, plus one first principle at the entry.

## `preview-check` fixed both roots to the Run's own directory

`packages/studio/preview-check.ts` set `workspaceRoot = dirname(runPath)` and `packageRoot = workspaceRoot`, with no override. A Run that did not sit at the project root therefore resolved the project's packages from wherever it did sit — so `hypit check` succeeded and `preview-check` failed on the same sources, which reads as the two commands disagreeing at random.

The package root is now the nearest `package.json` at or above the Run — the walk `hypit check` already makes, and the same one `reconstruction_check` was given. `--workspace` and `--package-root` override each independently, which is what `preview.md` already documents for `hypit-studio`.

Verified: a Run moved into `build/` fails without `--workspace` and reports the graph sound with it, and the project's own package resolves either way without `--package-root`.

`INIT_CWD` is gone from this entry point; nothing depended on it.

## `list_svml_packages` read one scope in one place

It scanned `<packageRoot>/node_modules/@hypit` only. A project's own packages were absent from the answer to "which packages exist" — including for the project asking — while `vocabulary.md` told the reader it read them. And pointed at a project root, it found no `@hypit` at all, because those live in the Distribution.

It now reads every scope under both the package root and the Distribution, plus the project's own `packages/`, deduplicated. From a project publishing one local package: **63 packages, its own among them**, where before the same call answered with none.

The listing's test asserted the whole answer was exactly one package. That was an isolation this function no longer has, so it now asks about the two packages it writes: the one with an activation is there, the one without is not.

## The route runs to the end

`SKILL.md` opens with the two things worth interrupting the author for:

- **Spending their money.** A Build generates, and generating is billed.
- **Which observer reads the reference, and the credentials it needs.** Vertex or the calling agent is a decision about the author's account. Asked once, at the start.

Everything else — the working directory, the project location, which packages, which generator, how to name a Segment, what to do about a reported difference — is a choice between things that all work, and asking costs an interruption to answer a question the references already answer. A run that stops half way with a question is a run the author has to restart.

## Verification

`pnpm check` clean. `pnpm test` 497 passed, 3 skipped, 0 failed. `pnpm test:release` 9 passed.