### PR TITLE
fix: check the project's own author packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,12 +10,13 @@
   "dependencies": {
     "@hypit/compiler-node": "workspace:*",
     "@hypit/elaborator": "workspace:*",
-    "@hypit/workspace": "workspace:*",
     "@hypit/package-loader-node": "workspace:*",
     "@hypit/protocol": "workspace:*",
     "@hypit/run": "workspace:*",
     "@hypit/runtime": "workspace:*",
     "@hypit/runtime-host-node": "workspace:*",
-    "@hypit/source": "workspace:*"
+    "@hypit/source": "workspace:*",
+    "@hypit/workspace": "workspace:*",
+    "typescript": "5.9.3"
   }
 }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -26,6 +26,7 @@ import {
   summarizeBuildCatalog,
 } from "./archive.js";
 import { unreachedGenerations } from "./reachability.js";
+import { typecheckProjectPackages } from "./package-typecheck.js";
 import { checkRunFile, collectRunFrontends, loadRunFile } from "./run-file.js";
 import type { CliDistribution } from "./distribution.js";
 import type {
@@ -1656,6 +1657,12 @@ export async function runCli(
     throw new Error(`${args.command} requires a self-described Run Source; check Author Sources independently`);
   }
   if (args.command === "check") {
+    // A project's own packages decide their element field names in TypeScript, and nothing authored
+    // carries them, so this is the only place before a Build that can read them.
+    const packageDiagnostics = typecheckProjectPackages(sourcePackageRoot, distribution.packageRoot);
+    if (packageDiagnostics.length > 0) {
+      throw new Error(`this project's own author packages do not typecheck:\n${packageDiagnostics.join("\n")}`);
+    }
     if (runMode) {
         const loaded = await checkRunFile({
           workspace,

--- a/packages/cli/src/package-typecheck.ts
+++ b/packages/cli/src/package-typecheck.ts
@@ -1,0 +1,88 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+
+/**
+ * Typecheck the author packages a project owns.
+ *
+ * A project-local package builds its picture in TypeScript: its Producer returns a list of elements,
+ * and the field names on those elements are fixed by the Composition Types it imports. Nothing
+ * authored carries them, so `check` has no Record to validate — the object does not exist until the
+ * Producer runs, which is at Build.
+ *
+ * The compiler decides them without running anything. A media element's artifact field is `artifact`,
+ * and writing `source` instead is `TS2353: 'source' does not exist in type 'VisualMediaElement'` —
+ * available in a second, and otherwise first seen as a Build failure blaming a field the author never
+ * typed.
+ *
+ * That check never ran on a project because the CLI loads TypeScript through tsx, which strips types
+ * without reading them, and the tree's own `tsconfig.json` covers the packages it ships rather than
+ * the ones a project writes.
+ *
+ * The options come from the Distribution's own `tsconfig.json`, so a project package is held to
+ * exactly the standard the packages it imports are held to, and there is one place to change it.
+ */
+export function typecheckProjectPackages(
+  projectRoot: string,
+  distributionRoot: string | undefined,
+): readonly string[] {
+  if (distributionRoot === undefined) return [];
+  const root = resolve(projectRoot);
+  const distribution = resolve(distributionRoot);
+  // A Distribution checking itself is `pnpm check`, over a different and much larger file set.
+  if (root === distribution) return [];
+  if (!existsSync(resolve(root, "packages"))) return [];
+
+  const require = createRequire(resolve(distribution, "package.json"));
+  let ts: typeof import("typescript");
+  // A Distribution that ships no compiler cannot do this, and saying nothing is better than refusing
+  // a project over the toolchain it was handed.
+  try { ts = require("typescript") as typeof import("typescript"); } catch { return []; }
+
+  // Where the compiler finds the packages a project imports. Hypit resolves `@hypit/x` by its own
+  // walk to `<root>/packages/x`, and nothing links it into `node_modules`, so Node resolution — which
+  // is what TypeScript follows — reaches none of them from a project. The Distribution says where
+  // each one is in its own `package.json`, so the mapping is read rather than guessed.
+  const paths: Record<string, string[]> = {};
+  for (const entry of readdirSync(resolve(distribution, "packages"), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const home = resolve(distribution, "packages", entry.name);
+    const manifest = resolve(home, "package.json");
+    if (!existsSync(manifest)) continue;
+    const declared = JSON.parse(readFileSync(manifest, "utf8")) as {
+      name?: string;
+      exports?: string | Record<string, unknown>;
+    };
+    if (declared.name === undefined) continue;
+    const root_ = typeof declared.exports === "string" ? declared.exports : declared.exports?.["."];
+    if (typeof root_ === "string") paths[declared.name] = [resolve(home, root_)];
+    // A deep import such as `@hypit/studio/src/domain.js` names a file inside the package.
+    paths[`${declared.name}/*`] = [resolve(home, "*")];
+  }
+
+  const shipped = resolve(distribution, "tsconfig.json");
+  const declared = existsSync(shipped)
+    ? (ts.readConfigFile(shipped, ts.sys.readFile).config as { compilerOptions?: Record<string, unknown> }).compilerOptions
+    : undefined;
+  const parsed = ts.parseJsonConfigFileContent({
+    compilerOptions: {
+      ...(declared ?? { target: "ES2023", module: "NodeNext", moduleResolution: "NodeNext", strict: true }),
+      // A project is read, never emitted, and its own layout decides nothing here.
+      noEmit: true, declaration: false, sourceMap: false, composite: false, rootDir: undefined,
+      skipLibCheck: true,
+      baseUrl: root,
+      paths,
+      typeRoots: [resolve(distribution, "node_modules/@types")],
+    },
+    include: ["packages/*/src/**/*.ts"],
+  }, ts.sys, root);
+  if (parsed.fileNames.length === 0) return [];
+
+  const host = {
+    getCanonicalFileName: (name: string): string => name,
+    getCurrentDirectory: (): string => root,
+    getNewLine: (): string => "\n",
+  };
+  return ts.getPreEmitDiagnostics(ts.createProgram(parsed.fileNames, parsed.options))
+    .map((item) => ts.formatDiagnostic(item, host).trimEnd());
+}

--- a/packages/composition/src/track.ts
+++ b/packages/composition/src/track.ts
@@ -1177,6 +1177,12 @@ function normalizeElement(element: VisualElement): VisualElement {
       } }),
     };
   }
+  // Spreading an absent artifact produced `{}`, which is not an artifact and is not nothing either:
+  // the field the author actually wrote was dropped without a word, and the refusal came one call
+  // later from the identity check, naming `.artifact` — a field they had not typed.
+  if (element.artifact === undefined) {
+    throw new Error(`${element.id} is a ${element.kind} element with no artifact.`);
+  }
   return {
     ...common,
     kind: element.kind,

--- a/packages/media/src/manifest.ts
+++ b/packages/media/src/manifest.ts
@@ -8,7 +8,9 @@ export const mediaTypes = {
   renderedVisual: { module: mediaModuleRef, name: "RenderedVisual" }, timelineAudio: { module: mediaModuleRef, name: "TimelineAudio" },
   muxed: { module: mediaModuleRef, name: "MuxedMedia" }, fontArtifact: { module: mediaModuleRef, name: "FontArtifactRef" },
   fontStack: { module: mediaModuleRef, name: "FontStackRef" },
-  compositableSurface: { module: mediaModuleRef, name: "CompositableSurfaceRef" }, blobArtifact: artifactTypes.blob,
+  compositableSurface: { module: mediaModuleRef, name: "CompositableSurfaceRef" },
+  /** Declared by `@hypit/artifact`. A Type is identified by the Module that owns it, not the one that re-exports it. */
+  blobArtifact: artifactTypes.blob,
 } satisfies Record<string, TypeRef>;
 
 export const mediaMarkupSurfaces = [

--- a/packages/protocol/src/identity.ts
+++ b/packages/protocol/src/identity.ts
@@ -13,6 +13,11 @@ export type ModuleRef = {
   readonly version: string;
 };
 
+/**
+ * A Type is its owning Module and its name, and nothing else is compared. Two Types whose values
+ * carry identical shapes are distinct, so one is refused where the other is declared — there is no
+ * structural fallback to fall back to.
+ */
 export type TypeRef = {
   readonly module: ModuleRef;
   readonly name: string;

--- a/services/whisperx/src/hypit_whisperx_service/resources.py
+++ b/services/whisperx/src/hypit_whisperx_service/resources.py
@@ -25,8 +25,17 @@ def prepare_punkt_tab(root: Path) -> Path:
     import nltk
 
     root = root.expanduser().resolve()
+    target = root / "tokenizers" / "punkt_tab"
+    # Already installed is already done. `nltk.download` fetches its index before it looks at what is
+    # on disk, so preparing an installation that needs nothing still needed the network, and a machine
+    # without it failed at the step whose whole job is to make the machine ready offline.
+    try:
+        assert_punkt_tab(root)
+        return target
+    except RuntimeError:
+        pass
     root.mkdir(parents=True, exist_ok=True)
     if not nltk.download("punkt_tab", download_dir=str(root), quiet=False, raise_on_error=True):
         raise RuntimeError("NLTK could not install punkt_tab")
     assert_punkt_tab(root)
-    return root / "tokenizers" / "punkt_tab"
+    return target


### PR DESCRIPTION
A project-local package builds its picture in TypeScript: its Producer returns a list of elements, and the field names on those elements are fixed by the Composition Types it imports. Nothing authored carries them, so `check` had no Record to validate — the object does not exist until the Producer runs, which is at Build.

So a package writing `source:` where the Type declares `artifact:` passed `hypit check` completely green, and failed a paid Build.

## The compiler already decides this

It just never ran on a project. The CLI loads TypeScript through tsx, which strips types without reading them, and the tree's own `tsconfig.json` covers the packages it ships rather than the ones a project writes.

`hypit check` now typechecks `<project>/packages/*/src`, using the options the Distribution checks itself by — so a project package is held to exactly the standard the packages it imports are held to, and there is one place to change it.

Node resolution reaches none of those packages from a project: Hypit resolves `@hypit/x` by its own walk to `<root>/packages/x`, and nothing links it into `node_modules`. The mapping is therefore read out of each Distribution package's own `exports` rather than guessed.

**Measured on a real project**, `hypit check` at 1.8s in total:

| | Errors reported |
|---|---|
| As authored | 1 — `assertSpatialFrame` given a label it does not take, so its refusal names nothing. A real bug, never visible before. |
| With the reported typo | 2 — that one, plus exactly `TS2353: 'source' does not exist in type 'VisualMediaElement'`, at the file and line. |

## The Build-time refusal described a state it manufactured

`artifact: { ...element.artifact }` on an absent artifact is `{}`. The field the author actually wrote was dropped without a word, and the identity check one call later reported `.artifact` as invalid — naming a field they had not typed. A media element with no artifact now says that.

## `hypit-whisperx-prepare`

The reported cause does not hold: `download_dir` is passed explicitly, so `NLTK_DATA` never decided where anything went. What actually fails is that `nltk.download` fetches its index before it looks at what is on disk — so preparing an installation that needed nothing still needed the network, at the step whose whole job is to make a machine ready offline. Already installed is now already done.

## Two facts, placed rather than documented

Both were confirmed, and both already have everything they need in the error message, so each went into the declaration the author is already reading rather than into a skill file:

- `TypeRef` — a Type is its owning Module and its name, and nothing else is compared; two Types with identical value shapes are distinct.
- `mediaTypes.blobArtifact` — declared by `@hypit/artifact`, which is the Module that identifies it whatever re-exports it.

## Verification

`pnpm check` clean. `pnpm test` 497 passed, 3 skipped, 0 failed. `pnpm test:release` 9 passed. `pnpm docs:build` complete.