### PR TITLE
fix: record the compiler the CLI now depends on

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,6 +432,9 @@ importers:
       '@hypit/workspace':
         specifier: workspace:*
         version: link:../workspace
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
 
   packages/comment-sticker:
     dependencies:


### PR DESCRIPTION
`hypit check` typechecks a project's own author packages, which needs the compiler, so `packages/cli` declares `typescript`. The lockfile was not rewritten with it.

A clone installs with `--frozen-lockfile`, so CI refused the install on both platforms before running anything:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile"
  because pnpm-lock.yaml is not up to date with <ROOT>/packages/cli/package.json
  * 1 dependencies were added: typescript@5.9.3
```

Written with `pnpm lockfile:refresh`, which is what keeps `projects/` importers out of a file a clone installs from. Three added lines.

Verified the way CI runs it — `projects/` set aside, `pnpm install --frozen-lockfile`: *Lockfile is up to date, resolution step is skipped*. `pnpm check` clean, `pnpm test:release` 9 passed.