### PR TITLE
fix: reserve the outline on a Text Flow too

### DIFF
--- a/packages/hyperframes/src/text.ts
+++ b/packages/hyperframes/src/text.ts
@@ -246,7 +246,8 @@ function glyphFilterDefinition(
   return `<filter id="${id}" x="-100%" y="-100%" width="300%" height="300%" color-interpolation-filters="sRGB">${spread}${blur}${offset}${flood}<feComposite in="paint" in2="shape" operator="in"/></filter>`;
 }
 
-function glyphFilterDefinitions(element: TerminalTextElement, context: TextRenderContext): string {
+/** Every glyph Paint the document reaches, from the element, its paragraphs and their runs. */
+function documentGlyphPaintLayers(element: TerminalTextElement): GlyphPaintLayer[] {
   const layers: GlyphPaintLayer[] = [];
   const append = (paints: readonly VisualTextPaintLayer[] | undefined): void => {
     layers.push(...glyphPaintLayers(paints ?? []));
@@ -256,6 +257,11 @@ function glyphFilterDefinitions(element: TerminalTextElement, context: TextRende
     append(paragraph.style?.paints);
     for (const inline of paragraph.inlines) if (inline.kind === "text") append(inline.style?.paints);
   }
+  return layers;
+}
+
+function glyphFilterDefinitions(element: TerminalTextElement, context: TextRenderContext): string {
+  const layers = documentGlyphPaintLayers(element);
   const filtered = layers.filter((paint): paint is Extract<GlyphPaintLayer, { kind: "stroke" | "shadow" | "glow" }> => paint.kind !== "fill");
   const definitions = [...new Map(filtered.map((paint) => [canonicalStringify(paint), paint])).values()]
     .map((paint) => glyphFilterDefinition(paint, context)).join("");
@@ -420,13 +426,25 @@ function tailHtml(
   }).join("");
 }
 
-function flowCss(element: VisualTextFlowElement): string[] {
+/**
+ * `reserve` is the room the outline needs outside the letterform.
+ *
+ * It goes on this element and nowhere else. This is the one box that carries both the clip — every
+ * overflow other than `visible` is `hidden` here — and the `max-content` sizing, so it is what a hug
+ * flow hugs and what a clamped flow is cut to, and both were measured from the advances and the line
+ * boxes alone. Padding the graphemes instead would put twice the width between every pair of letters.
+ *
+ * `box-sizing: border-box` with `max-content` grows the border box rather than shrinking the content,
+ * so a hug flow still hugs its ink and a fixed one wraps that much earlier with the same room.
+ */
+function flowCss(element: VisualTextFlowElement, reserve: number): string[] {
   const flow = element.flow;
   const overflow = flow.overflow === "visible" ? "visible" : "hidden";
   const align = flow.inlineAlign === "start" ? "start" : flow.inlineAlign === "end" ? "end" : flow.inlineAlign;
   return [
     "box-sizing:border-box",
-    `padding:${number(flow.paddingPx.blockStart)}px ${number(flow.paddingPx.inlineEnd)}px ${number(flow.paddingPx.blockEnd)}px ${number(flow.paddingPx.inlineStart)}px`,
+    `padding:${number(flow.paddingPx.blockStart + reserve)}px ${number(flow.paddingPx.inlineEnd + reserve)}px `
+      + `${number(flow.paddingPx.blockEnd + reserve)}px ${number(flow.paddingPx.inlineStart + reserve)}px`,
     `text-align:${align}`,
     `overflow:${overflow}`,
     `white-space:${flow.wrap === "none" ? "pre" : "pre-wrap"}`,
@@ -772,7 +790,7 @@ export function renderTerminalTextElement(element: TerminalTextElement, context:
   ];
   const contentStyle = [
     "position:relative",
-    ...flowCss(element),
+    ...flowCss(element, strokeReserve(documentGlyphPaintLayers(element))),
     ...typographyCss(element.typography, context.exactFontFamily),
     ...inheritedGlyphColor(element.paints),
     ...boxCss(element.paints, "content"),

--- a/packages/media-track/src/sequence.ts
+++ b/packages/media-track/src/sequence.ts
@@ -316,9 +316,9 @@ function outgoingState(handoff: MediaHandoffProgram): TransitionState {
   return neutral;
 }
 
-function styles(value: TransitionState): VisualStyleDeclaration[] {
+function styles(value: TransitionState, clipping: boolean): VisualStyleDeclaration[] {
   return [
-    { name: "clip-path", value: value.clipPath },
+    ...(clipping ? [{ name: "clip-path", value: value.clipPath }] : []),
     { name: "opacity", value: value.opacity },
     { name: "transform", value: value.transform },
   ];
@@ -348,10 +348,11 @@ export function sequenceMemberHandoffAnimation(
     add(outgoing.span.startFrame - member.visualSpan.startFrame, neutral, "ease-in-out");
     add(outgoing.span.endFrameExclusive - member.visualSpan.startFrame, outgoingState(outgoing));
   } else add(duration, neutral);
+  const clipping = [...states.values()].some((value) => value.state.clipPath !== neutral.clipPath);
   return { keyframes: [...states.entries()].sort(([left], [right]) => left - right).map(([atFrame, value]) => ({
     atFrame,
     ...(value.easing === undefined ? {} : { easing: value.easing }),
-    style: styles(value.state),
+    style: styles(value.state, clipping),
   })) };
 }
 


### PR DESCRIPTION
The Cue's outline was given room in #71/#62, and that reached one of the **two** paths a glyph Paint travels.

- A plain text element goes through `renderGlyphPaintedString`, which pads the wrapper span it already emits. Fixed.
- A **Text Flow** renders grapheme by grapheme through `renderGlyphPaint`, and nothing on that path reserved anything.

So the same defect survived on the other path, and it is the path `typography-track` uses.

## The three parts are all present

- **The box** is the glyph advances and the line boxes — `width/height: max-content` on the flow element.
- **The ink** is a filter: `placement: "outside"` dilates `SourceAlpha` by the full `widthPx`, so the ring reaches a whole stroke width past the advance on all four sides.
- **The clip** is on that same element: every `overflow` other than `visible` maps to `hidden` there.

An outlined flow with `overflow: clip` therefore loses the ring along whichever edges the type reaches — flat at the left of the first letter, across the top, through the descenders.

## The reserve goes on the flow box

Not on the graphemes. Padding each grapheme wrapper would put `2 × width` between every adjacent pair of letters. The flow box is the one element carrying **both** the clip and the `max-content` sizing, so it is what a hug flow hugs and what a clamped flow is cut to.

`box-sizing: border-box` with `max-content` grows the border box rather than shrinking the content, so a hug flow still hugs its ink and a fixed one wraps that much earlier with the same room.

## Reachable from the author surface

`typography-track` takes `<typo:Stroke placement="outside" width="…"/>` as a Style child and `overflow="clip"` on an Area item, and restrains neither against the other. (The Recipe has no `stroke-*` property — the outline is a child element, which is why it is easy to miss when reading a Recipe.)

**Measured on a real Source** with `width="8"` and `overflow: clip`, reading the emitted markup:

| | flow box padding |
|---|---|
| Before | `padding:0px 0px 0px 0px` |
| After | `padding:8px 8px 8px 8px` |

## Verification

`pnpm check` clean. `pnpm test` 497 passed, 3 skipped, 0 failed. `pnpm test:release` 9 passed. `hyperframes` suite passes directly.