### PR TITLE
fix: stop the boxes that clip from being measured without the ink they hold

### DIFF
--- a/packages/media-track/src/lower.ts
+++ b/packages/media-track/src/lower.ts
@@ -51,19 +51,27 @@ function paint(value: MediaPaint): string {
   return `radial-gradient(circle at ${value.center.x * 100}% ${value.center.y * 100}%,${value.stops.map(stop).join(",")})`;
 }
 
-function pathData(path: SpatialPath): string {
+/**
+ * A Path is drawn in Canvas pixels, and the element it clips is the Frame's own box — positioned at
+ * the Frame's origin, so its coordinates start there. Handed the Canvas numbers unchanged, the clip
+ * region lands one Frame origin down and to the right of where it was drawn, which for any Frame away
+ * from the corner is entirely outside the box: the Item renders blank.
+ */
+function pathData(path: SpatialPath, origin: SpatialFrame): string {
+  const x = (value: number): number => value - origin.xPx;
+  const y = (value: number): number => value - origin.yPx;
   return path.commands.map((command) => {
     switch (command.kind) {
-      case "move": return `M ${command.xPx} ${command.yPx}`;
-      case "line": return `L ${command.xPx} ${command.yPx}`;
-      case "quadratic": return `Q ${command.controlX} ${command.controlY} ${command.xPx} ${command.yPx}`;
-      case "cubic": return `C ${command.control1X} ${command.control1Y} ${command.control2X} ${command.control2Y} ${command.xPx} ${command.yPx}`;
+      case "move": return `M ${x(command.xPx)} ${y(command.yPx)}`;
+      case "line": return `L ${x(command.xPx)} ${y(command.yPx)}`;
+      case "quadratic": return `Q ${x(command.controlX)} ${y(command.controlY)} ${x(command.xPx)} ${y(command.yPx)}`;
+      case "cubic": return `C ${x(command.control1X)} ${y(command.control1Y)} ${x(command.control2X)} ${y(command.control2Y)} ${x(command.xPx)} ${y(command.yPx)}`;
       case "close": return "Z";
     }
   }).join(" ");
 }
 
-function frameStyles(value: MediaFramePresentation): VisualStyleDeclaration[] {
+function frameStyles(value: MediaFramePresentation, frame: SpatialFrame): VisualStyleDeclaration[] {
   const styles: VisualStyleDeclaration[] = [
     { name: "box-sizing", value: "border-box" },
     { name: "height", value: "100%" },
@@ -76,7 +84,7 @@ function frameStyles(value: MediaFramePresentation): VisualStyleDeclaration[] {
   else {
     styles.push({ name: "overflow", value: "hidden" });
     if (value.clip.kind === "rounded") styles.push({ name: "border-radius", value: px(value.clip.radiusPx) });
-    if (value.clip.kind === "path") styles.push({ name: "clip-path", value: `path("${pathData(value.clip.path)}")` });
+    if (value.clip.kind === "path") styles.push({ name: "clip-path", value: `path("${pathData(value.clip.path, frame)}")` });
   }
   if (value.border !== undefined) {
     styles.push({ name: "border", value: `${value.border.widthPx}px ${value.border.style} ${value.border.color}` });
@@ -91,13 +99,22 @@ function frameStyles(value: MediaFramePresentation): VisualStyleDeclaration[] {
   return styles;
 }
 
+/**
+ * The box a layer is fitted into: the Frame less its border and its padding.
+ *
+ * The border was left out, and it is drawn inward — `box-sizing: border-box` puts it inside the
+ * Frame's own rectangle — so a fitted picture was sized against a box wider and taller than the one
+ * it had to sit in. What that looks like is the picture offset by the border width down and to the
+ * right, with the same amount cut off its far edges, and a `contain` fit that no longer contains.
+ */
 function innerFrame(item: MediaItemProgram): SpatialFrame {
-  const { padding } = item.presentation;
+  const { border, padding } = item.presentation;
+  const edge = border?.widthPx ?? 0;
   return {
-    xPx: item.frame.xPx + padding.leftPx,
-    yPx: item.frame.yPx + padding.topPx,
-    widthPx: item.frame.widthPx - padding.leftPx - padding.rightPx,
-    heightPx: item.frame.heightPx - padding.topPx - padding.bottomPx,
+    xPx: item.frame.xPx + edge + padding.leftPx,
+    yPx: item.frame.yPx + edge + padding.topPx,
+    widthPx: item.frame.widthPx - edge * 2 - padding.leftPx - padding.rightPx,
+    heightPx: item.frame.heightPx - edge * 2 - padding.topPx - padding.bottomPx,
   };
 }
 
@@ -131,6 +148,11 @@ function sampleElements(
     { name: "transform-origin", value: "center center" },
     { name: "width", value: px(content.widthPx) },
   ];
+  // A blur reads across the box and paints past it — roughly twice its radius — so a `contain` fit
+  // that was letterboxed on purpose had its blurred copy spilling into the letterbox it was fitted
+  // away from. Clipping the wrapper ends the overscan at the fitted rectangle; the Gaussian still
+  // reads real content across the whole box, so only the spill goes.
+  if (layer.appearance.filter.blurPx > 0) wrapperStyle.push({ name: "overflow", value: "hidden" });
   const wrapperElement: VisualElement = {
     id: wrapper,
     parent,
@@ -297,7 +319,7 @@ export function lowerMediaItemElements(
     parent = handoff;
   }
   const frame = `${item.id}:frame`;
-  elements.push({ id: frame, parent, order: order.value++, kind: "box", style: frameStyles(item.presentation) });
+  elements.push({ id: frame, parent, order: order.value++, kind: "box", style: frameStyles(item.presentation, item.frame) });
   for (const layer of item.layers) {
     elements.push(...layerElements(
       layer,

--- a/packages/media-track/src/motion.ts
+++ b/packages/media-track/src/motion.ts
@@ -111,9 +111,21 @@ function translate(directionValue: MediaMotionDirection, amount: number): string
   return `translateY(${amount}px)`;
 }
 
-function style(state: MotionState): VisualStyleDeclaration[] {
+/**
+ * `clipping` is decided once per animation, not per keyframe.
+ *
+ * `inset(0% 0% 0% 0%)` reads as a no-op and is not one: it clips the element and its descendants to
+ * the border box, which removes the Frame's own drop shadows for the whole window. So an Item given
+ * any lifecycle at all — a plain fade among them — lost its shadows, while the same Item with no
+ * enter or exit kept them.
+ *
+ * Every keyframe of one animation has to declare the same properties, so a wipe cannot drop the
+ * property on the frames where it happens to be neutral: it would hold its last declared inset for
+ * ever. The question is whether this animation clips anywhere.
+ */
+function style(state: MotionState, clipping: boolean): VisualStyleDeclaration[] {
   return [
-    { name: "clip-path", value: state.clipPath },
+    ...(clipping ? [{ name: "clip-path", value: state.clipPath }] : []),
     { name: "filter", value: state.filter },
     { name: "opacity", value: state.opacity },
     { name: "transform", value: state.transform },
@@ -130,11 +142,13 @@ export function lifecycleAnimation(value: MediaLifecycleMotion, durationFrames: 
   if (value.exit !== undefined) {
     for (let frame = Math.max(0, durationFrames - value.exit.durationFrames); frame <= durationFrames; frame += 1) frames.add(frame);
   }
+  const ordered = [...frames].sort((left, right) => left - right);
+  const clipping = ordered.some((atFrame) => lifecycleStateAt(value, durationFrames, atFrame).clipPath !== neutral.clipPath);
   return {
-    keyframes: [...frames].sort((left, right) => left - right).map((atFrame) => ({
+    keyframes: ordered.map((atFrame) => ({
       atFrame,
       easing: "linear",
-      style: style(lifecycleStateAt(value, durationFrames, atFrame)),
+      style: style(lifecycleStateAt(value, durationFrames, atFrame), clipping),
     })),
   };
 }
@@ -339,11 +353,12 @@ export function lifecycleAnimationWindow(
     const next = lifecycleStateAt(value, outerDurationFrames, ordered[index + 1]!);
     return JSON.stringify(previous) !== JSON.stringify(current) || JSON.stringify(current) !== JSON.stringify(next);
   });
+  const clipping = compact.some((frame) => lifecycleStateAt(value, outerDurationFrames, frame).clipPath !== neutral.clipPath);
   return {
     keyframes: compact.map((frame) => ({
       atFrame: frame - startOffset,
       easing: "linear",
-      style: style(lifecycleStateAt(value, outerDurationFrames, frame)),
+      style: style(lifecycleStateAt(value, outerDurationFrames, frame), clipping),
     })),
   };
 }

--- a/packages/media-track/test/media-track.test.ts
+++ b/packages/media-track/test/media-track.test.ts
@@ -324,23 +324,28 @@ test("an Item keeps ordered Paint/sample layers, two-frame fit and frame present
   const media = elements.find((element) => element.id === "content");
   assert.equal(media?.kind, "image");
   const wrapper = elements.find((element) => element.id === "content:sampling");
+  // The fitting box is the Frame less its 2px border and its 10px padding. `box-sizing: border-box`
+  // draws the border inside the Frame, so the content starts 12px in and is 24px smaller each way.
   assert.deepEqual(wrapper?.style, [
-    { name: "height", value: "280px" },
-    { name: "left", value: "60px" },
+    { name: "height", value: "276px" },
+    { name: "left", value: "62px" },
     { name: "position", value: "absolute" },
-    { name: "top", value: "10px" },
+    { name: "top", value: "12px" },
     { name: "transform-origin", value: "center center" },
-    { name: "width", value: "280px" },
+    { name: "width", value: "276px" },
   ]);
 });
 
 test("an owned clip path is an explicit Media input and lowers only over the Item's pixels", () => {
+  // A Path is drawn in Canvas pixels, which is what `spatial` declares three times over. The Frame
+  // sits at 100,200, so a trapezoid filling it is written from there and arrives at the Frame's own
+  // box translated back to 0,0.
   const clipped = bindMediaItemClipPath(itemSpec(), {
     commands: [
-      { kind: "move", xPx: 0, yPx: 0 },
-      { kind: "line", xPx: 400, yPx: 0 },
-      { kind: "line", xPx: 360, yPx: 300 },
-      { kind: "line", xPx: 40, yPx: 300 },
+      { kind: "move", xPx: 100, yPx: 200 },
+      { kind: "line", xPx: 500, yPx: 200 },
+      { kind: "line", xPx: 460, yPx: 500 },
+      { kind: "line", xPx: 140, yPx: 500 },
       { kind: "close" },
     ],
   });

--- a/packages/ranking/src/render.ts
+++ b/packages/ranking/src/render.ts
@@ -598,9 +598,15 @@ export function renderTopThree(space: ProgramSpace, program: TopThreeProgram): V
       else elements.push(simpleText({ id: "rank", parent: root, order: 2, text: String(index + 1),
         typography: { ...style.text, color: rankColor(style.slotColors, index), sizePx: style.iconSizePx * 0.45 },
         x: 0, y: 0, width: style.iconSizePx, height: style.iconSizePx }));
+      // The label's box is one line box, and a line box is not the ink: accents reach above it and
+      // descenders below. It clips, so at a tight `line-height` the tops and tails were shaved. The
+      // box grows by one line box's worth of leading at each end and its top moves up by the same,
+      // so the text stays where it was painted and only the clip rectangle moves.
+      const labelSlack = style.text.sizePx * 0.25;
       elements.push(simpleText({ id: "label", parent: root, order: 3, text: item.label, typography: style.text,
-        x: -style.slotGapPx / 2, y: style.iconSizePx + style.labelGapPx,
-        width: style.iconSizePx + style.slotGapPx, height: style.text.sizePx * style.text.lineHeight }));
+        x: -style.slotGapPx / 2, y: style.iconSizePx + style.labelGapPx - labelSlack,
+        width: style.iconSizePx + style.slotGapPx,
+        height: style.text.sizePx * style.text.lineHeight + labelSlack * 2 }));
       return elements;
     };
     presents.push(present({


### PR DESCRIPTION
An audit for the shape that cut the caption's outline — **a box measured from geometry, ink painted outside it, something clipping to it** — found thirteen cases across `hyperframes`, `media-track` and `ranking`. Each was put to a separate agent to refute; six others did not survive. Eleven of the thirteen are fixed here.

## `clip-path: inset(0% 0% 0% 0%)` is not a no-op, in two more places

It clips an element **and its descendants** to the border box. `media-track` emitted it as the resting value of every lifecycle animation, so an Item given any enter or exit at all — a plain `fade` among them — lost its Frame's drop shadows for the whole window, while the same Item with no lifecycle kept them. A Sequence whose members crossfade or push lost them the same way.

Both now decide **once per animation** whether anything clips. Per-keyframe omission would be wrong: every keyframe of one animation must declare the same properties, so a wipe that dropped the property on its neutral frames would hold its last inset for ever.

## A clip Path was displaced by its own Frame

`spatial` declares a Path in **Canvas pixels** — "this many pixels along the Canvas x axis", three times over in the vocabulary an author reads. It was handed to a `clip-path` on the Frame's own box, whose coordinates start at the Frame's origin, so the region landed one origin down and to the right. For any Frame away from the corner that is entirely outside the box, and **the Item renders blank**.

The Path is translated into that box's space at the single point it is lowered.

The test covering this was written against the implementation rather than the declaration — its path was a trapezoid in Frame-local coordinates. Its coordinates now say what `spatial` says they are. **This is a contract decision**, not just a bugfix: the declaration is what an author reads through `inspect_svml_vocabulary`, and a standalone Path record whose meaning depends on which Frame consumes it could not be shared by two Items.

## A bordered Frame fitted its picture against the wrong box

`box-sizing: border-box` draws the border inward, so a picture fitted to the Frame less its *padding* was sized against a box wider and taller than the one it sits in: offset by the border width down and right, the same amount cut off the far edges, and a `contain` fit that no longer contained.

## A blurred layer painted past the fit it was given

A Gaussian reads across its box and paints roughly twice its radius outside it, so a `contain`-fitted layer spilled into the letterbox it had been fitted away from.

## A Text Flow's outline is reserved on the flow box

The plain-text path was given room in #73; the flow path renders grapheme by grapheme and had none. The reserve goes on the one element carrying **both** the clip and the `max-content` sizing — padding the graphemes would put `2 × width` between every adjacent pair of letters.

That one fix also settles two further findings: the **shrink fitter** measures glyph rectangles against that box, so it now stops before the ring reaches it; and the **ellipsis clamp** limits line boxes inside it.

## A ranking label was one line box tall

A line box is not the ink — accents reach above it, descenders below — and it clips. The box gains a quarter of the type size at each end and its top moves up by the same, so the text stays exactly where it was painted and only the clip rectangle moves.

## Two are not fixed

- **A Text Box tail on a clipping flow.** The clip removes it, and taking it out of the box needs an anchor positioned across it. The `frame` case has no fix at all, because the root *is* the clip.
- **`metric-edge` with a clip.** Trimming the box to the cap height or the ink is what that property is for; clipping to the trimmed box then cuts an accent. The room to leave is a font metric this layer does not have.

## One correction to the record

The `sequence.ts` change landed in `271c26f9`, whose message describes only the Text Flow reserve. It was written by a verifying agent in the working tree and swept in by a `git add -A packages/`. What it does is described above.

## Verification

`pnpm check` clean. `pnpm test` 497 passed, 3 skipped, 0 failed. `pnpm test:release` 9 passed. `media-track` and `ranking` suites pass directly; two of their assertions encoded the pre-fix geometry and now state the corrected one with the reason.