### PR TITLE
fix: a gate that saw nothing refuses, a round is one call, and an answer is about what was asked

### DIFF
--- a/.agents/skills/hypit/references/environment.md
+++ b/.agents/skills/hypit/references/environment.md
@@ -280,11 +280,9 @@ WhisperX, for example, lives under `programs/whisperx/`; OpenCV under
 `programs/image-opencv/`. Service process records and logs live with the program. Project Build and
 Worker state remains under `<project>/.hypit/`.
 
-Reference-video state joins it there, at `.hypit/reference-video-tools/<reference-id>/`, resolved
-against the directory the command ran in rather than against a project boundary. Run every
-`hypit-reference-video-tools` command that touches a reference from the same directory: the clips,
-frames, transcript and observations one command writes are what the next one expects to find at that
-relative path.
+Reference-video state sits beside the Distribution, at `.hypit/reference-video-tools/<reference-id>/`,
+wherever the command is run from. It is keyed by the video, so two reconstructions of one file share
+the observations it cost money to make; each command reports the root it used.
 
 This split is why opening a second project cannot install WhisperX again, and why updating the npm
 Distribution does not overwrite a Python environment or a user's project-local component.

--- a/.agents/skills/hypit/references/reconstruction/reconstruction-loop.md
+++ b/.agents/skills/hypit/references/reconstruction/reconstruction-loop.md
@@ -58,6 +58,9 @@ hypit-reference-video-tools render_element projects/<name>/build.svrun \
   --element <id> --segment <id>|--selection <id> --reference-id <id> --out <path>.mp4
 ```
 
+A whole round is one call: `--batch <renders.json>`, an array of `{element, segment|selection, out}`
+inheriting the Run and the reference. They run together.
+
 `--element` takes the element's bare id — `captions`, the `id=` the Source wrote on the element. The
 command appends the output suffix itself when it looks for the track, so `--element captions.track`
 matches nothing: it refuses with `the Source places no element named captions.track` and lists the
@@ -67,6 +70,11 @@ It reads the Canvas, the Recipe values and the Script text out of the Source, mo
 Build has not made, and drives the package's Producer. Nothing is transcribed by hand, so nothing is
 transcribed one line at a time — which is what made a caption system look correct while its lines
 collided.
+
+**It draws the whole stretch, not the element alone.** `--element` names which element the comparison
+is about; the picture is everything the Source places over those words, so two elements over one
+Segment produce the same picture. Scope the comparison with `--question` — that is what tells the
+observer which part of it to read.
 
 `--reference-id` names the reference, and it times the stand-in from that reference's own transcript,
 so each Segment runs for as long as the reference spends on its words. Pass it every time: the
@@ -267,10 +275,12 @@ When the difference is structural rather than cosmetic, repair in the order give
 Producer, Type and Validator agreement, Surface vocabulary and decoding, implementation behaviour,
 then source usage. Fixing source usage over a broken implementation hides the defect one layer down.
 
-## The reference is asked once
+## One comparison round
 
 **There is one comparison round.** What it returns is the whole difference set this reconstruction
-gets. Repair against that set and stop; do not compare again.
+gets. Repair against that set and stop; do not compare again. This bounds the comparing, and nothing
+else: a narrow `observe_reference --question` settles disagreeing evidence at any point, which is
+what `workflow.md` is for.
 
 The reference has nothing further to say after it: it already showed every stretch, and a second look
 re-reads the same frames to check your own work. That spends the expensive half of the route — the

--- a/.agents/skills/hypit/references/reconstruction/workflow.md
+++ b/.agents/skills/hypit/references/reconstruction/workflow.md
@@ -23,14 +23,9 @@ video. This route runs both, at the step the sequence names;
 `node_modules/@hypit` relative to the working directory and refuses when it is empty, so run it from
 the repository root.
 
-**Run every `hypit-reference-video-tools` command that touches a reference from the same directory.**
-`prepare_reference` writes the reference under `.hypit/reference-video-tools/<reference-id>` relative
-to the working directory, and `observe_reference`, `record_observation`, `compare_reconstruction`,
-`render_element` and `reconstruction_check` all read it back from that same relative path. Run one
-from the project and the next from its parent and the second looks in a directory the first never
-wrote to: it reports no prepared reference at all. Pick one directory at the start and stay in it for
-the whole route — the repository root, where `list_svml_packages` already has to run, is the one that
-costs nothing. The two vocabulary subcommands carry no reference state and are outside this.
+A reference is found from the Distribution rather than from where you are standing, so these commands
+may be run from anywhere. What does depend on where you are is which packages resolve: name the
+project with `--package-root` when the command is not run from inside it.
 
 Defaults are sufficient for normal use. Each also accepts `--input <json>`. Follow this sequence:
 
@@ -152,7 +147,7 @@ The frames are already on disk at
 them. When evidence disagrees — one shot against the next, a shot against a whole-reference pass, or
 an observation against what the video plainly is — settle it with a narrow
 `observe_reference --question` over that shot, which puts the question to the reference's own
-observer. On the `gemini` observer that means you do not open the frame yourself;
+observer; several at once is `--batch <questions.json>`, an array of `{shot_ids, question}`. On the `gemini` observer that means you do not open the frame yourself;
 `reconstruction-loop.md` says which rule binds on which path. Do not re-observe
 the full shot: that is paid, and at temperature `1.0` it returns a paraphrase rather than a
 correction.

--- a/packages/reference-video-tools/src/authoring.ts
+++ b/packages/reference-video-tools/src/authoring.ts
@@ -746,9 +746,16 @@ function silentWav(sampleFrames: number): Buffer {
 }
 
 export type RenderElementInput = {
-  readonly run: string;
-  readonly element: string;
-  readonly out: string;
+  /**
+   * A round of renders, run together. Each entry names its own element, stretch and output and
+   * inherits `run` and `reference_id`. The route renders every element before it compares any, and
+   * each render is now written under its own directory, so a round has nothing to serialise for.
+   */
+  readonly renders?: readonly RenderElementInput[];
+  /** Required for one render; a round carries them per entry and inherits `run` from the outer input. */
+  readonly run?: string;
+  readonly element?: string;
+  readonly out?: string;
   readonly segment?: string;
   readonly selection?: string;
   /**
@@ -827,20 +834,26 @@ function timingReport(reference: string | undefined, segments: readonly StandInT
  * beside the output, name which of the two clocks sized each Segment.
  */
 export async function renderElement(input: RenderElementInput): Promise<Record<string, unknown>> {
+  // A round carries these per entry; one render has to name all three itself.
+  assert(input.run !== undefined, "run is required");
+  assert(input.element !== undefined, "element is required");
+  assert(input.out !== undefined, "out is required");
   const element = input.element;
+  const out = input.out;
+  const run = input.run;
   const cwd = invokedFrom();
-  const runPath = resolve(cwd, input.run);
+  const runPath = resolve(cwd, run);
   const projectRoot = dirname(runPath);
   // Where installed packages are found, which is not where the Hypit tree is. A project carries its
   // own `packages/local-*`, so the search starts at the project and walks up the way the CLI's does —
   // resolving against the tree instead would miss every package the project installed for itself.
   const packageRoot = nearestPackageRoot(projectRoot) ?? repositoryRoot();
-  const outPath = resolve(cwd, input.out);
+  const outPath = resolve(cwd, out);
 
   const runSource = await readFile(runPath, "utf8").catch(() => undefined);
   assert(runSource !== undefined, `cannot read ${runPath}`);
   const author = /<author\s+source="([^"]+)"/u.exec(runSource)?.[1];
-  assert(author !== undefined, `${input.run} declares no <author source="…"/>`);
+  assert(author !== undefined, `${run} declares no <author source="…"/>`);
   const svmlPath = resolve(projectRoot, author);
   let svml = await readFile(svmlPath, "utf8").catch(() => undefined);
   assert(svml !== undefined, `cannot read ${svmlPath}`);
@@ -883,7 +896,15 @@ export async function renderElement(input: RenderElementInput): Promise<Record<s
   };
 
   // The derived Run is written here, and so is the cut, so the directory comes first.
-  const compareRoot = join(projectRoot, ".hypit", "compare");
+  // One directory per render, named for what this render is. Every call used to write one shared
+  // `.hypit/compare` and empty it on the way in, so two renders could not run at once — the second
+  // deleted the first one's sliced Source and mocks out from under it. The route asks for every
+  // element to be rendered before any is compared, which is a set of renders with nothing to say to
+  // each other, and they can now run together.
+  const renderKey = createHash("sha256")
+    .update(`${resolve(out)}\u0000${element}\u0000${focus.segment ?? focus.selection ?? ""}`)
+    .digest("hex").slice(0, 12);
+  const compareRoot = join(projectRoot, ".hypit", "compare", renderKey);
   await rm(compareRoot, { recursive: true, force: true });
   await mkdir(compareRoot, { recursive: true });
 
@@ -898,9 +919,9 @@ export async function renderElement(input: RenderElementInput): Promise<Record<s
   if (focusedSegment !== undefined) {
     sliced = sliceSource(svml, focusedSegment);
     sourcePath = join(compareRoot, "sliced.svml");
-    // The fragment sits two directories below the Source it came from, so its own relative imports
+    // The fragment sits three directories below the Source it came from, so its own relative imports
     // have to reach back the same distance the derived Run's carried files do.
-    const repointed = sliced.text.replace(/(\s(?:source|from)=")\.\//gu, "$1../../");
+    const repointed = sliced.text.replace(/(\s(?:source|from)=")\.\//gu, "$1../../../");
     await writeFile(sourcePath, repointed, "utf8");
     // Everything downstream reads the Source: which Takes to stand in for, which media to mock, which
     // outputs to satisfy. Left on the original it would declare mocks for elements the cut removed,

--- a/packages/reference-video-tools/src/checks.ts
+++ b/packages/reference-video-tools/src/checks.ts
@@ -1,5 +1,5 @@
 import { readFile, readdir } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 
 import { markupSurfaceHostFacetAbi } from "@hypit/markup";
 import type { RegisteredSurface } from "@hypit/markup";
@@ -498,13 +498,23 @@ export async function reconstructionCheck(
   // Every package this Source imports. The scope is whatever the Source wrote: a project that declares
   // a vocabulary gap and fills it publishes under its own scope, and those elements draw exactly as an
   // installed one does.
-  const imports = [...svml.matchAll(/<import\s+as="([^"]+)"\s+from="(@[^"@/]+\/[^"@]+)@\d+"/gu)]
-    .map((match) => ({ alias: match[1] ?? "", specifier: match[2] ?? "" }));
+  // Attribute order is not significant in this markup, and a pattern that fixed it read a Source
+  // written the other way round as importing nothing at all — then passed it, because nothing to
+  // compare and nothing found look alike from here.
+  const imports = [...svml.matchAll(/<import\b([^>]*?)\/?>/gsu)]
+    .map((match) => ({
+      alias: /\bas="([^"]+)"/u.exec(match[1] ?? "")?.[1] ?? "",
+      specifier: /\bfrom="(@[^"@/]+\/[^"@]+)@\d+"/u.exec(match[1] ?? "")?.[1] ?? "",
+    }))
+    .filter((item) => item.alias.length > 0 && item.specifier.length > 0);
   if (imports.length === 0) {
     return {
       run: runPath,
-      passed: true,
-      summary: ["the Source imports no package; nothing to compare."],
+      // Not one aliased package import could be read. Whether the Source truly imports nothing or
+      // this failed to read it, what follows knows nothing about what the Source draws — and a
+      // reading that came back empty is not a reconstruction that is covered.
+      passed: false,
+      summary: [`no aliased package import could be read from ${svmlPath}, so nothing is known about what this Source draws.`],
       elements: [],
       playback: [],
       uncovered: [],
@@ -743,14 +753,33 @@ export async function reconstructionCheck(
   const running = await playbackReport();
 
   if (drawn.length === 0 && running.length === 0) {
+    // Nothing placed and nothing seen are the same answer from here, and only one of them is a pass.
+    // A project whose vocabulary resolved and placed no drawing element has nothing to require; one
+    // whose packages did not resolve, or none of whose packages publishes a Surface that draws, has
+    // been read by something that could not see — and the names of what it could not see were being
+    // dropped on the way out.
+    const blind = unresolved.length > 0 || drawingTags.size === 0;
     return {
       run: runPath,
-      passed: true,
-      summary: ["no drawing element is placed in the Source; nothing to require."],
+      passed: !blind,
+      summary: [unresolved.length > 0
+        ? `${unresolved.length} imported package${unresolved.length === 1 ? "" : "s"} could not be resolved from ${packageRoot}, so nothing is known about what the Source draws.`
+        : drawingTags.size === 0
+          ? `no package the Source imports publishes a Surface that draws, so nothing is known about what the Source draws.`
+          : "no drawing element is placed in the Source; nothing to require."],
       elements: [],
       playback: [],
       uncovered: [],
       out_of_bounds: overhang,
+      ...(unresolved.length === 0 ? {} : {
+        unresolved_packages: {
+          names: unresolved,
+          package_root: packageRoot,
+          note: "A project that publishes its own packages resolves them from the project root, where "
+            + "`packages/<name>/package.json` carries the scoped name. Run the command from that directory, "
+            + "or pass --package-root <project directory>.",
+        },
+      }),
     };
   }
 
@@ -776,6 +805,7 @@ export async function reconstructionCheck(
     readonly range?: { readonly segment?: string; readonly selection?: string };
     readonly status: string;
     readonly id?: string;
+    readonly image_path?: string;
     readonly stand_in?: { readonly timing?: { readonly basis?: string } };
   };
   // What the comparison was made against, as a reader would name it: a shot, or the words a Segment
@@ -786,9 +816,25 @@ export async function reconstructionCheck(
     ?? (entry.range?.selection === undefined ? undefined : `selection ${entry.range.selection}`)
     ?? "an unnamed stretch";
   const logPath = join(preparedRoot, reference, "comparisons.jsonl");
-  const logged = (await readFile(logPath, "utf8").catch(() => ""))
+  // A reference is keyed by the video, and rightly: its observations are about that video and cost
+  // real money, so two reconstructions of one file share them. Its comparisons are not about the
+  // video — they are about one reconstruction — and they were being kept in the same place, so a
+  // second project reconstructing the same file was credited with the first one's looking, over
+  // Segments its own Script does not contain.
+  //
+  // What separates them is already on every row: the render it compared. A render belongs to the
+  // project that produced it, so a row whose picture is not under this project is not this project's
+  // evidence. Nothing has to move and no earlier log has to be migrated.
+  const inThisProject = (entry: LoggedComparison): boolean => {
+    if (entry.image_path === undefined) return false;
+    const at = resolve(entry.image_path);
+    return at === packageRoot || at.startsWith(`${packageRoot}${sep}`);
+  };
+  const everything = (await readFile(logPath, "utf8").catch(() => ""))
     .split("\n").filter((line) => line.trim().length > 0)
     .flatMap((line) => { try { return [JSON.parse(line) as LoggedComparison]; } catch { return []; } });
+  const elsewhere = everything.length - everything.filter(inThisProject).length;
+  const logged = everything.filter(inThisProject);
   // A pair handed out and not yet reported on. Naming these separately is what keeps an element with
   // three open comparisons from reading as one that was never looked at.
   const awaiting = logged.filter((entry) => entry.status === "pending");
@@ -879,6 +925,10 @@ export async function reconstructionCheck(
     summary.push(`${unresolved.length} imported package${unresolved.length === 1 ? "" : "s"} could not be resolved, `
       + "so nothing is known about what they draw.");
   }
+  if (elsewhere > 0) {
+    summary.push(`${elsewhere} comparison${elsewhere === 1 ? "" : "s"} in this reference's log compared a render `
+      + "outside this project and are not counted here.");
+  }
   if (awaiting.length > 0) {
     summary.push(`${awaiting.length} comparison${awaiting.length === 1 ? " is" : "s are"} still waiting for `
       + "the differences to be recorded.");
@@ -887,6 +937,9 @@ export async function reconstructionCheck(
   return {
     run: runPath,
     reference_id: reference,
+    // Where this command actually read and resolved from. Said here, no document has to describe it
+    // from the outside and go stale when it moves.
+    roots: { reference: preparedRoot, packages: packageRoot },
     passed: never.length === 0 && running.length === 0 && coverage.gaps.length === 0 && unresolved.length === 0,
     summary,
     elements,

--- a/packages/reference-video-tools/src/cli.ts
+++ b/packages/reference-video-tools/src/cli.ts
@@ -2,7 +2,7 @@
 import { readFile } from "node:fs/promises";
 
 import { createReferenceVideoTools } from "./tools.js";
-import type { CompareReconstructionInput } from "./tools.js";
+import type { CompareReconstructionInput, ObserveReferenceInput, RenderElementInput } from "./tools.js";
 
 type Flags = ReadonlyMap<string, string | readonly string[] | boolean>;
 
@@ -13,6 +13,7 @@ function usage(): string {
     "  hypit-reference-video-tools prepare_reference --video-path <path> [--observer gemini|agent] [--redo media|transcript|people|voices|systems|places|all]",
     "  hypit-reference-video-tools observe_reference --reference-id <id> [--shot-id <id> ...] [--reobserve]",
     "  hypit-reference-video-tools observe_reference --reference-id <id> --shot-id <id> [--shot-id <id> ...] --question <text>",
+    "  hypit-reference-video-tools observe_reference --reference-id <id> --batch <questions.json>",
     "  hypit-reference-video-tools record_observation --reference-id <id> --key <key> --text <text>|--text-file <path>",
     "  hypit-reference-video-tools inspect_svml_vocabulary --package <name> [--package <name> ...] [--tag <tag> ...] [--without-previews]",
     "  hypit-reference-video-tools compare_reconstruction --reference-id <id> --run <build.svrun> --segment <id>|--selection <id> --video <path>|--image <path> [--question <scope>] [--element <id>]",
@@ -20,6 +21,7 @@ function usage(): string {
     "  hypit-reference-video-tools compare_reconstruction --reference-id <id> --batch <comparisons.json>",
     "  hypit-reference-video-tools make-placeholder --out <path> --width <w> --height <h> [--color light|mid|dark|white|black|#RRGGBB] [--video] [--seconds <s>]",
     "  hypit-reference-video-tools render_element <build.svrun> --element <id> --out <path.png|path.mp4> [--segment <id>] [--selection <id>] [--reference-id <id>]",
+    "  hypit-reference-video-tools render_element <build.svrun> --batch <renders.json> [--reference-id <id>]",
     "  hypit-reference-video-tools render_previews <package-dir> [...]",
     "  hypit-reference-video-tools preview_check <build.svrun> [<hypit.runtime.json>]",
     "  hypit-reference-video-tools reconstruction_check <build.svrun> [--reference-id <id>]",
@@ -230,6 +232,19 @@ async function main(): Promise<void> {
     };
     result = await tools.prepare_reference(input as { video_path: string; observer?: "gemini" | "agent"; redo?: "media" | "transcript" | "people" | "voices" | "systems" | "places" | "all" });
   } else if (command === "observe_reference") {
+    // A round of narrow questions is a list, and a list is too long for flags.
+    const askFile = one(flags, "batch");
+    if (askFile !== undefined) {
+      const parsed: unknown = JSON.parse(await readFile(askFile, "utf8"));
+      const list = Array.isArray(parsed) ? parsed : (parsed as { questions?: unknown }).questions;
+      if (!Array.isArray(list)) throw new Error(`${askFile} must hold a JSON array of {shot_ids, question}, or an object with a "questions" array`);
+      result = await tools.observe_reference({
+        reference_id: required(flags, "reference-id"),
+        questions: list as ObserveReferenceInput["questions"] & object,
+      });
+      report(`${JSON.stringify(result, null, 2)}\n`);
+      return;
+    }
     const input = supplied ?? {
       reference_id: required(flags, "reference-id"),
       ...(many(flags, "shot-id").length === 0 ? {} : { shot_ids: many(flags, "shot-id") }),
@@ -299,6 +314,19 @@ async function main(): Promise<void> {
     };
     result = await tools.make_placeholder(input as { out: string; width: number; height: number; color?: string; video?: boolean; seconds?: number });
   } else if (command === "render_element") {
+    const renderFile = one(flags, "batch");
+    if (renderFile !== undefined) {
+      const parsed: unknown = JSON.parse(await readFile(renderFile, "utf8"));
+      const list = Array.isArray(parsed) ? parsed : (parsed as { renders?: unknown }).renders;
+      if (!Array.isArray(list)) throw new Error(`${renderFile} must hold a JSON array of renders, or an object with a "renders" array`);
+      result = await tools.render_element({
+        ...(operands[0] === undefined ? {} : { run: operands[0] }),
+        ...(one(flags, "reference-id") === undefined ? {} : { reference_id: one(flags, "reference-id") }),
+        renders: list,
+      } as RenderElementInput);
+      report(`${JSON.stringify(result, null, 2)}\n`);
+      return;
+    }
     const run = operands[0];
     if (supplied === undefined && run === undefined) throw new Error(`a <build.svrun> is required\n\n${usage()}`);
     const input = supplied ?? {

--- a/packages/reference-video-tools/src/tools.ts
+++ b/packages/reference-video-tools/src/tools.ts
@@ -1,6 +1,7 @@
 import type { Part } from "@google/genai";
 import { access, appendFile, mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
+import { cpus } from "node:os";
 import { createHash } from "node:crypto";
 import { deflateSync } from "node:zlib";
 import { basename, dirname, join, resolve } from "node:path";
@@ -44,6 +45,12 @@ export type ObserveReferenceInput = {
   readonly shot_ids?: readonly string[];
   readonly question?: string;
   readonly reobserve?: boolean;
+  /**
+   * A round of narrow questions, asked together. Each entry names its own shots and its own question
+   * and inherits `reference_id`. No narrow question's answer depends on another's, which is why the
+   * route asks them at once — and why asking them one process at a time was a shell loop.
+   */
+  readonly questions?: readonly { readonly shot_ids: readonly string[]; readonly question: string }[];
 };
 export type RecordObservationInput = {
   readonly reference_id: string;
@@ -964,6 +971,29 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
     },
 
     async observe_reference(input): Promise<Record<string, unknown>> {
+      if (input.questions !== undefined) {
+        const round = input.questions;
+        assert(round.length > 0, "questions is empty");
+        const answers = await pacedMap(round, concurrency, gapMs, async (asked) => {
+          try {
+            return { ok: true as const, value: await tools.observe_reference({
+              reference_id: input.reference_id, shot_ids: asked.shot_ids, question: asked.question,
+            }) };
+          } catch (error) {
+            return { ok: false as const, error: error instanceof Error ? error.message : String(error), asked };
+          }
+        });
+        const done = answers.filter((item) => item.ok).map((item) => item.value!);
+        const failed = answers.filter((item) => !item.ok);
+        return {
+          reference_id: input.reference_id,
+          asked: done.length,
+          failed: failed.length,
+          answers: done,
+          ...(failed.length === 0 ? {} : { failures: failed.map((item) => ({ error: item.error, asked: item.asked })) }),
+          pending_observations: done.flatMap((item) => (item["pending_observations"] ?? []) as readonly unknown[]),
+        };
+      }
       const state = await loadState(input.reference_id);
       const selected = input.shot_ids === undefined ? state.shots : state.shots.filter((shot) => input.shot_ids!.includes(shot.shot_id));
       assert(selected.length > 0, "no requested shot ids exist");
@@ -1156,8 +1186,15 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
       assert(input.package_names.length > 0, "package_names must not be empty");
       const loaded = await loadNodePackageSelection(input.package_names, packageRoot);
       const requested = input.tags === undefined ? undefined : new Set(input.tags);
+      // The answer is about the packages that were named. Loading one brings its dependencies with
+      // it, and every one of their Surfaces used to be returned as well — asking what `@hypit/ranking`
+      // offers answered with twenty Surfaces of which six were its own, sixty-four kilobytes for a
+      // question about six. The rest are reachable by naming them, which is what `list_svml_packages`
+      // is for.
+      const named = new Set(input.package_names);
       const surfaces: Record<string, unknown>[] = [];
       for (const pack of loaded) {
+        if (!named.has(pack.specifier)) continue;
         for (const facet of pack.contribution.hostFacets ?? []) {
           const implementation = facet.implementation as RegisteredSurface;
           if (requested !== undefined && !requested.has(implementation.tag) && !requested.has(implementation.surface)) continue;
@@ -1469,6 +1506,25 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
     },
 
     async render_element(input): Promise<Record<string, unknown>> {
+      if (input.renders !== undefined) {
+        const round = input.renders;
+        assert(round.length > 0, "renders is empty");
+        // Local work rather than a quota, so it is paced by the machine and not by the launch gap.
+        const atOnce = Math.max(1, Math.min(cpus().length - 1, round.length));
+        const results = await pacedMap(round, atOnce, 0, async (one) => {
+          const merged = { ...one, run: one.run ?? input.run, ...(one.reference_id ?? input.reference_id === undefined ? {} : { reference_id: input.reference_id }) };
+          try { return { ok: true as const, value: await renderElement(merged as RenderElementInput) }; }
+          catch (error) { return { ok: false as const, error: error instanceof Error ? error.message : String(error), input: merged }; }
+        });
+        const done = results.filter((item) => item.ok).map((item) => item.value!);
+        const failed = results.filter((item) => !item.ok);
+        return {
+          rendered: done.length,
+          failed: failed.length,
+          renders: done,
+          ...(failed.length === 0 ? {} : { failures: failed.map((item) => ({ error: item.error, input: item.input })) }),
+        };
+      }
       return await renderElement(input);
     },
 


### PR DESCRIPTION
An external run of the reconstruction route reported eleven workarounds it had to invent. Each was verified against current main — several no longer held — and the rest reduce to three defects. Most of the fix is code; **the skill is 110 words shorter**.

## A verdict was emitted without the coverage that produced it

`reconstruction_check` returned `passed: true` on two paths that both mean *it saw nothing*:

1. **No drawing element found.** A project placed outside the checkout — which `runtime.md` recommends — resolved no vocabulary, so `drawn` was empty, and the answer was `"no drawing element is placed in the Source; nothing to require."` Identical to the answer for a Source that genuinely places none. The reporter worked around it with a directory junction.
2. **No import read.** The pattern required `as=` before `from=`. Attribute order is not significant in this markup, so a Source written the other way round "imported no package" and passed — `hypit check` accepts the same file and resolves 54 outputs.

Both refuse now, and each says which of the two it was, carrying the names it could not resolve. Both early returns also skipped frame coverage silently; that goes with them.

Each command now reports the roots it read and resolved from. That is what lets two paragraphs describing those roots *from the outside* be **deleted rather than corrected**.

## An artifact was keyed to a wider scope than the call that made it

A reference is keyed by the video. That is right for observations — two reconstructions of one file should share what cost money to make — and wrong for comparisons, which are about one reconstruction. A second project reconstructing the same file was **credited with the first one's looking**, over Segments its own Script does not contain.

The render each row names is what separates them: a row whose picture is not under this project is not this project's evidence. Nothing moves, no log is migrated, and the excluded count is reported. Measured on the two projects on disk: 1 and 6 rows excluded, both still passing on their own evidence.

Every render wrote one shared `.hypit/compare` and emptied it on entry, so **two renders could not run at once** — the second deleted the first one's sliced Source out from under it. That is why a hand-written script still had to run twelve renders serially. Each render now has its own directory, and a round is one call: `render_element --batch`. Narrow questions get the same form, `observe_reference --batch` — which is what the route already tells the author to do with them.

## An answer was about more than the question

Asking what one package offers returned every Surface its dependencies declare as well: **twenty Surfaces for `@hypit/ranking`, six of them its own**, 64KB for a question about six. It now answers about the packages that were named; the rest are reachable by naming them. `@hypit/ranking` 64KB → 38KB, `@hypit/caption-fine` → 2 surfaces.

## Two corrections, no additions

- `render_element` **draws the whole stretch**, not the element alone. `--element` names which element the comparison is about, so two elements over one Segment produce the same picture, and `--question` is what scopes the reading. The help said it "draws one element of a Source".
- A heading of mine from earlier today, *"The reference is asked once"*, generalised past its own body — which bounds **the comparing** and nothing else. A narrow `observe_reference --question` settles disagreeing evidence at any point, as `workflow.md` has always said.

## Verification

`pnpm check` clean. `pnpm test` 497 passed, 3 skipped, 0 failed. `pnpm test:release` 9 passed. `pnpm docs:build` complete. Four renders launched at once now complete; both projects on disk still pass on their own evidence, and a round of three renders runs as one call.