### PR TITLE
fix: a Selection may open in one Segment and close in another, and the cut keeps it

### DIFF
--- a/packages/markup/src/types.ts
+++ b/packages/markup/src/types.ts
@@ -131,6 +131,13 @@ export type SurfaceRecipePropertyVocabulary = {
   /** Optional package-owned subsection inside the page. */
   readonly section?: string;
   readonly values?: readonly string[];
+  /**
+   * The default as it is written in a Recipe, which is text even when it reads as a number: `"0"`,
+   * not `0`. A Recipe property's value arrives as written and each Style decodes its own, so what a
+   * fallback records is the source line an author would have typed. A number here is refused deep
+   * inside the surface declaration, where the complaint is about the whole vocabulary rather than
+   * about this field.
+   */
   readonly fallback?: string;
 };
 

--- a/packages/media-track/src/manifest.ts
+++ b/packages/media-track/src/manifest.ts
@@ -308,7 +308,7 @@ const appearanceRecipeProperties = [
   { name: "radius", required: false, fallback: "0",
     summary: "Rounds the clipped corners by a pixel radius, and is read only for a `rounded` clip." },
   { name: "padding", required: false, fallback: "0",
-    summary: "Insets the picture from the Frame edges, written as one, two or four pixel numbers." },
+    summary: "Insets the picture from the Frame edges. It admits one, two or four values — all sides, then vertical and horizontal, then each side — which no single number can carry, so it is written as text: `padding: \"14\"` and `padding: \"8 12\"`. A bare number is refused." },
   { name: "border-width", required: false, fallback: "0",
     summary: "Draws a border of this pixel width, and draws none at `0`." },
   { name: "border-style", required: false, values: ["solid", "dashed", "dotted"], fallback: "solid",

--- a/packages/reference-video-tools/src/slice.ts
+++ b/packages/reference-video-tools/src/slice.ts
@@ -113,9 +113,41 @@ export function sliceSource(source: string, segment: string): SliceResult {
   const kept = new RegExp(`<${segment}\\b[^>]*>.*?</${segment}>`, "su").exec(body);
   if (kept === null) throw new Error(`the Script has no <${segment}> Segment`);
 
+  /**
+   * A Selection may open in one Segment and close in another — the Script says so and the parser
+   * records each end's own Segment. Cutting the Script to one Segment left the surviving end of such a
+   * Selection with no partner, and the fragment was refused outright with SCRIPT_SELECTION_UNCLOSED:
+   * not the element dropped, the whole render.
+   *
+   * The end that is missing is supplied at the fragment's own edge. What that expresses is exactly
+   * what the Selection covers inside this stretch — from its mark to the end of the Segment, or from
+   * the start of the Segment to its mark — which is what a render over this stretch has to show.
+   */
+  // The end of a name has to be asserted, not merely looked past: a lookahead alone backtracks, and
+  // `@title-out!` was read as an open called `title-ou` with a `t` after it.
+  const opened = new Set([...kept[0].matchAll(/(?<![\w/])@([a-z][a-z0-9-]*)(?![a-z0-9!-])/gu)].map((match) => match[1]!));
+  const closed = new Set([...kept[0].matchAll(/@\/([a-z][a-z0-9-]*)~?/gu)].map((match) => match[1]!));
+  const marked = new Set([...kept[0].matchAll(/@([a-z][a-z0-9-]*)!/gu)].map((match) => match[1]!));
+  let fragment = kept[0];
+  for (const id of opened) {
+    if (closed.has(id) || marked.has(id)) continue;
+    const end = fragment.lastIndexOf("</");
+    fragment = `${fragment.slice(0, end)} @/${id}\n    ${fragment.slice(end)}`;
+    closed.add(id);
+  }
+  for (const id of closed) {
+    if (opened.has(id)) continue;
+    // After the Segment's own opening tag and the speaker tag that follows it, which is where the
+    // Segment's first spoken word begins.
+    const speaker = /^<[^>]*>\s*<[^>]*>/su.exec(fragment);
+    const at = speaker === null ? fragment.indexOf(">") + 1 : speaker[0].length;
+    fragment = `${fragment.slice(0, at)} @${id}${fragment.slice(at)}`;
+    opened.add(id);
+  }
+
   // Which Script names survive: the Segment itself, and every Selection and Moment marked inside it.
   const alive = new Set<string>([`segment.${segment}`]);
-  for (const match of kept[0].matchAll(/@([a-z][a-z0-9-]*)\b/gu)) {
+  for (const match of fragment.matchAll(/@\/?([a-z][a-z0-9-]*)\b/gu)) {
     alive.add(`selection.${match[1]!}`);
     alive.add(`moment.${match[1]!}`);
   }
@@ -130,7 +162,7 @@ export function sliceSource(source: string, segment: string): SliceResult {
   // already, so this is the one case: a close that has not arrived yet, which the fragment reaches by
   // no longer closing.
   const later = new Set<string>();
-  for (const match of body.slice(kept.index + kept[0].length).matchAll(/@([a-z][a-z0-9-]*)\b/gu)) {
+  for (const match of body.slice(kept.index + kept[0].length).matchAll(/@\/?([a-z][a-z0-9-]*)\b/gu)) {
     later.add(`selection.${match[1]!}`);
     later.add(`moment.${match[1]!}`);
   }
@@ -247,7 +279,7 @@ export function sliceSource(source: string, segment: string): SliceResult {
   if (rebuiltOpen === null) throw new Error("the Script was removed by the cut");
   const rebuiltStart = rebuiltOpen.index + rebuiltOpen[0].length;
   const rebuiltEnd = text.indexOf("</script>", rebuiltStart);
-  text = `${text.slice(0, rebuiltStart)}\n    ${kept[0]}\n  ${text.slice(rebuiltEnd)}`;
+  text = `${text.slice(0, rebuiltStart)}\n    ${fragment}\n  ${text.slice(rebuiltEnd)}`;
 
   return {
     text,


### PR DESCRIPTION
Reported as a design limit the author had to work around. It is not one.

## The language admits it

`generated-dependencies.md` says *"A Selection is free to open in one Segment and close in another"*, and the parser agrees — asked directly with a Selection opened in `one` and closed in `two`:

```
PARSED. selection spanning: open segment = one | close segment = two
```

`SCRIPT_SELECTION_UNCLOSED` fires only after the whole Source is read, for a Selection with no close anywhere.

## The cut threw the other end away

`sliceSource` rebuilds the Script body as the kept Segment's text alone, so the surviving end of a cross-Segment Selection lost its partner. The fragment then held an unbalanced marker and was refused outright — **not the element dropped, the whole render**.

The missing end is supplied at the fragment's own edge. That expresses exactly what the Selection covers inside this stretch: from its mark to the end of the Segment, or from the start of the Segment to its mark — which is what a render over this stretch has to show.

**Measured** on a Selection opened in `chatgpt` and closed in `claude-gemini`:

| | before | after |
|---|---|---|
| `--segment chatgpt` | `SCRIPT_SELECTION_UNCLOSED` | renders, fragment carries `@spanning … @/spanning` |
| `--segment claude-gemini` | `SCRIPT_SELECTION_UNCLOSED` | renders, open supplied at the Segment's first word |
| `--segment perplexity` | `SCRIPT_SELECTION_UNCLOSED` | renders |

## One defect found while writing it

Reading the markers needs the end of a name asserted, not merely looked past. `[a-z0-9-]*` backtracks, so `@title-out!` matched an open called `title-ou` followed by a `t`, and the fragment gained a close for a Selection that never existed — `SCRIPT_SELECTION_CLOSE: Selection "title-ou" closes without an open`.

## Two constraints stated where they are read

- **`fallback`** on a Recipe property is the default *as written*, which is text even when it reads as a number. A number there is refused deep inside the surface declaration, where the complaint is about the whole vocabulary rather than the field. Stated in the declaration a package author reads.
- **`padding`** on a Media Track Recipe admits one, two or four values — all sides, then vertical and horizontal, then each side — which no single number can carry, so it is written as text. Its summary said *"one, two or four pixel numbers"*, which reads as a number and is refused. Verified the corrected text reaches `inspect_svml_vocabulary`, where an author meets it.

Collapsing `createMarkupSurfaceHostFacet`'s two overloads into one signature was tried and **reverted**: they narrow the handler's parameter type from `mode`, and the build depends on it. The verbose error a wrong property produces is the cost of a deep object literal, not of the overloads.

## Verification

`pnpm check` clean. `pnpm test` 497 passed, 3 skipped, 0 failed. `pnpm test:release` 9 passed.