### PR TITLE
feat: the Producers a Fragment may call are listed with their ports

### DIFF
--- a/.agents/skills/hypit/references/local-author-package.md
+++ b/.agents/skills/hypit/references/local-author-package.md
@@ -52,9 +52,12 @@ hypit-reference-video-tools inspect_visual_contract
 
 It answers the questions a component is written against — which element kinds exist, which style
 names are admitted on them, which of those take an enum, how few keyframes an animation carries, and
-the four rules the seal enforces about parents, `order` and interpolation. Every line is generated
-from the Composition schema, so it says what will be accepted rather than what one package happened
-to do. `inspect_svml_vocabulary` answers the other half: what a Source may write.
+the four rules the seal enforces about parents, `order` and interpolation. Add
+`--producers-of @hypit/temporal` for the Producers a Fragment calls to turn a Script name into a
+window, with their port names, and the same for any package whose Producers you chain. Every line is
+generated from the Composition schema and the Modules themselves, so it says what will be accepted
+rather than what one package happened to do. `inspect_svml_vocabulary` answers the other half: what a
+Source may write.
 
 Open a package's source only when neither command settles it — a role whose shape the guide leaves
 implicit, an export whose signature you need exactly. Use `hypit paths --json` to locate

--- a/packages/reference-video-tools/src/cli.ts
+++ b/packages/reference-video-tools/src/cli.ts
@@ -16,7 +16,7 @@ function usage(): string {
     "  hypit-reference-video-tools observe_reference --reference-id <id> --batch <questions.json>",
     "  hypit-reference-video-tools record_observation --reference-id <id> --key <key> --text <text>|--text-file <path>",
     "  hypit-reference-video-tools inspect_svml_vocabulary --package <name> [--package <name> ...] [--tag <tag> ...] [--without-previews]",
-    "  hypit-reference-video-tools inspect_visual_contract [--shape visual-track|text-flow|text-typography|text-paint|text-document|path-command]",
+    "  hypit-reference-video-tools inspect_visual_contract [--shape visual-track|text-flow|text-typography|text-paint|text-document|path-command] [--producers-of <package> ...]",
     "  hypit-reference-video-tools paths",
     "  hypit-reference-video-tools compare_reconstruction --reference-id <id> --run <build.svrun> --segment <id>|--selection <id> --video <path>|--image <path> [--question <scope>] [--element <id>]",
     "  hypit-reference-video-tools compare_reconstruction --reference-id <id> --shot-id <id> --video <path>|--image <path> [--question <scope>] [--element <id>]",
@@ -306,7 +306,10 @@ async function main(): Promise<void> {
     };
     result = await tools.compare_reconstruction(input as { reference_id: string; shot_id?: string; segment?: string; selection?: string; run?: string; image_path?: string; video_path?: string; question?: string; element?: string });
   } else if (command === "inspect_visual_contract") {
-    result = await tools.inspect_visual_contract({ ...(one(flags, "shape") === undefined ? {} : { shape: one(flags, "shape")! }) });
+    result = await tools.inspect_visual_contract({
+      ...(one(flags, "shape") === undefined ? {} : { shape: one(flags, "shape")! }),
+      ...(many(flags, "producers-of").length === 0 ? {} : { producers: many(flags, "producers-of") }),
+    });
   } else if (command === "paths") {
     result = await tools.paths();
   } else if (command === "inspect_svml_vocabulary") {

--- a/packages/reference-video-tools/src/tools.ts
+++ b/packages/reference-video-tools/src/tools.ts
@@ -126,7 +126,7 @@ export type ReferenceVideoTools = {
   prepare_reference(input: PrepareReferenceInput): Promise<PrepareResult>;
   observe_reference(input: ObserveReferenceInput): Promise<Record<string, unknown>>;
   inspect_svml_vocabulary(input: InspectVocabularyInput): Promise<Record<string, unknown>>;
-  inspect_visual_contract(input: { readonly shape?: string }): Promise<Record<string, unknown>>;
+  inspect_visual_contract(input: { readonly shape?: string; readonly producers?: readonly string[] }): Promise<Record<string, unknown>>;
   paths(): Promise<Record<string, unknown>>;
   compare_reconstruction(input: CompareReconstructionInput): Promise<Record<string, unknown>>;
   record_observation(input: RecordObservationInput): Promise<Record<string, unknown>>;
@@ -1244,8 +1244,22 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
       assert(asked === undefined || asked.length === 0 || Object.hasOwn(shapes, asked),
         `shape must be one of ${Object.keys(shapes).join(", ")}`);
       const chosen = asked === undefined || asked.length === 0 ? Object.keys(shapes) : [asked];
+      // Which Producers a Fragment may call, read off the Modules the named packages carry. A
+      // component's Fragment names one per operation, and the names were reachable only by opening a
+      // package that already called them.
+      const wanted = input.producers ?? [];
+      const calls = wanted.length === 0 ? [] : (await loadNodePackageSelection(wanted, packageRoot).catch(() => []))
+        .flatMap((pack) => (pack.contribution.modules ?? []).flatMap((module) =>
+          module.manifest.producers.map((producer) => ({
+            module: `${module.manifest.name}@${module.manifest.version}`,
+            producer: producer.name,
+            inputs: producer.inputs.map((port) => port.name),
+            outputs: producer.outputs.map((port) => port.name),
+            ...(producer.needs.length === 0 ? {} : { needs: producer.needs.map((port) => port.name) }),
+          }))));
       return {
         shapes: chosen.map((name) => ({ shape: name, describes: describeSchema(shapes[name]!).join("\n") })),
+        ...(calls.length === 0 ? {} : { producers: calls }),
         // Each of these is refused somewhere, or follows from how the emitted CSS is written. None is
         // a convention: a rule stated here that the code does not hold would be worse than silence.
         rules: [


### PR DESCRIPTION
The last piece of "writing a component meant reading other packages' source".

A component's Fragment names **one Producer per operation**, and a component that occupies time calls `@hypit/temporal` to turn a Script name into a window. Those names — `project-selection-window`, `project-moment-point` and the rest — and their port names were reachable only by opening a package that already called them.

```
hypit-reference-video-tools inspect_visual_contract --producers-of @hypit/temporal
```

Each Producer with its input ports, its output ports, and its Needs where it has any. `@hypit/temporal` answers with ten:

```
project-program-point   | inputs ['semantic', 'spec']              -> outputs ['point']
project-selection-point | inputs ['semantic', 'selection', 'spec'] -> outputs ['point']
…
```

Read off the Modules the package carries rather than written down, so it cannot name a Producer that is not there. It composes with `--shape`, so one call answers both what a Producer may return and what it may call.

`local-author-package.md` gains one clause pointing at it, inside the paragraph that already introduces the contract command.

## Verification

`pnpm check` clean. `pnpm test` 497 passed, 3 skipped, 0 failed. `pnpm test:release` 9 passed. `pnpm docs:build` complete.