### PR TITLE
fix: a managed program on Windows gets a console of its own

### DIFF
--- a/.agents/skills/hypit/references/environment.md
+++ b/.agents/skills/hypit/references/environment.md
@@ -197,12 +197,9 @@ service on `127.0.0.1:8765`, and then starts the Worker. The first start may dow
 Whisper and language-alignment model weights, so it can take substantially longer than later starts.
 Do not run `uv sync` in an author project and do not install the `whisperx` Python package by hand.
 
-On Windows, treat `runtime up` printing `Ready whisperx` as a provisioning result, not as proof that
-the HTTP service is still reachable from the next command. Some terminal/automation hosts reap child
-processes when the launching command exits, which leaves `runtime status` reporting `whisperx: down`
-or makes `127.0.0.1:8765` refuse connections even though the managed environment is installed. Run
-`runtime up` from a normal PowerShell session (or keep the launching session alive), then verify the
-service before `prepare_reference` or a Build:
+`runtime up` printing `Ready whisperx` reports that the service answered its health probe. Verify it
+again before `prepare_reference` or a Build, since a first start can spend several minutes loading the
+model:
 
 ```powershell
 Invoke-WebRequest -UseBasicParsing http://127.0.0.1:8765/health
@@ -210,10 +207,10 @@ hypit programs status
 hypit doctor
 ```
 
-If the health check fails, do not reinstall Python packages. Re-run `hypit runtime up` while the
-PowerShell session remains open and inspect `hypit runtime logs`; the managed WhisperX log is also at
-`$env:LOCALAPPDATA\Hypit\programs\whisperx\program.log`. A first start can spend several minutes
-loading the model before the health endpoint answers, so poll rather than launching a second copy.
+If the health check fails, do not reinstall Python packages: poll rather than launching a second copy,
+and read `hypit runtime logs`. The managed WhisperX log is also at
+`$env:LOCALAPPDATA\Hypit\programs\whisperx\program.log`, with the service's error stream beside it
+in `program.err.log`.
 
 The log may contain a `torchcodec` warning about missing `libtorchcodec_core*.dll`, especially when
 the host FFmpeg build is newer than the versions supported by that optional decoder. The warning is

--- a/packages/runtime-local/src/programs.ts
+++ b/packages/runtime-local/src/programs.ts
@@ -117,6 +117,66 @@ function run(root: string, command: ManagedProgramCommand): Promise<{ ok: boolea
  * weights; `mismatch` is not, and stops the wait — a program that is answering
  * with another identity will not become the right one by waiting.
  */
+/** POSIX: its own session, and stdio already pointed at the log. */
+async function startDetached(start: ManagedProgramCommand, root: string, logFd: number): Promise<number | undefined> {
+  const child = spawn(start.command, [...start.args], {
+    cwd: start.cwd ?? root,
+    env: { ...process.env, ...start.env },
+    shell: false,
+    detached: true,
+    windowsHide: true,
+    stdio: ["ignore", logFd, logFd],
+  });
+  child.unref();
+  return child.pid;
+}
+
+/** A PowerShell single-quoted literal, which escapes by doubling the quote and nothing else. */
+function powershellLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+/**
+ * Windows: a console of its own, hidden, so the launching console's destruction does not take it.
+ *
+ * The script is fed on stdin rather than as a command-line argument, so no quoting of ours crosses a
+ * shell boundary. `Start-Process` refuses to send both streams to one file, so the error stream gets
+ * its own beside the log; `-PassThru` reports the new process, which is the pid everything after this
+ * waits on and stores.
+ */
+async function startWithOwnConsole(start: ManagedProgramCommand, root: string, logPath: string): Promise<number | undefined> {
+  const errorPath = `${logPath.replace(/\.log$/u, "")}.err.log`;
+  const environment = Object.entries(start.env ?? {})
+    .map(([name, value]) => `$env:${name} = ${powershellLiteral(String(value))}`).join("\n");
+  const argumentList = start.args.length === 0
+    ? ""
+    : ` -ArgumentList @(${start.args.map(powershellLiteral).join(", ")})`;
+  const script = [
+    "$ErrorActionPreference = 'Stop'",
+    environment,
+    `$p = Start-Process -FilePath ${powershellLiteral(start.command)}${argumentList}`
+      + ` -WorkingDirectory ${powershellLiteral(start.cwd ?? root)}`
+      + ` -RedirectStandardOutput ${powershellLiteral(logPath)}`
+      + ` -RedirectStandardError ${powershellLiteral(errorPath)}`
+      + " -WindowStyle Hidden -PassThru",
+    "[Console]::Out.Write($p.Id)",
+  ].filter((line) => line.length > 0).join("\n");
+
+  const printed = await new Promise<string>((settle) => {
+    const shell = spawn("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", "-"], {
+      windowsHide: true,
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+    let output = "";
+    shell.stdout.on("data", (chunk: Buffer) => { output += chunk.toString("utf8"); });
+    shell.on("error", () => settle(""));
+    shell.on("close", () => settle(output.trim()));
+    shell.stdin.end(script, "utf8");
+  });
+  const pid = Number(printed);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
+}
+
 async function waitForReady(program: ManagedProgram, pid: number, maxWaitMs: number): Promise<ManagedProgramState> {
   const deadline = Date.now() + maxWaitMs;
   let state = await program.probe();
@@ -178,24 +238,27 @@ async function bringUp(
   await rotateLog(logPath);
   const log = await open(logPath, "a");
   try {
-    const child = spawn(program.start.command, [...program.start.args], {
-      cwd: program.start.cwd ?? root,
-      env: { ...process.env, ...program.start.env },
-      shell: false,
-      // Outliving this process is the point, and each platform grants that differently. POSIX
-      // wants its own session. Windows already gives an unreferenced child its own lifetime, and
-      // asking to detach there costs the console: a detached process has none, so every console
-      // grandchild it starts is handed a fresh visible window instead. That is what a transcribing
-      // program looks like when `uv` re-execs Python and Python opens a pool of workers. Taking
-      // the hidden console instead leaves one console for the whole tree, and no window at all.
-      detached: process.platform !== "win32",
-      windowsHide: true,
-      stdio: ["ignore", log.fd, log.fd],
-    });
-    child.unref();
-    if (child.pid === undefined) {
+    // Outliving this process is the point, and what grants it differs by platform.
+    //
+    // POSIX wants its own session, which `detached` gives.
+    //
+    // Windows ties a process's lifetime to the console it is attached to. A child spawned from here
+    // inherits this one, so when the launching `node` exits its console is destroyed and every
+    // process on it is sent CTRL_CLOSE_EVENT and terminated. `unref` does not change that — it
+    // removes an event-loop reference and nothing else — so the service reported ready, answered one
+    // health probe, and was gone by the next command, with no error anywhere to read.
+    //
+    // What it needs is a console of its own, hidden. `detached` on Windows means DETACHED_PROCESS,
+    // which is no console at all, and then the first console grandchild — `uv` re-execing Python,
+    // Python opening workers — allocates a fresh visible one. `Start-Process -WindowStyle Hidden`
+    // creates a new console and hides it, which is the combination neither spawn option reaches.
+    const pid = process.platform === "win32"
+      ? await startWithOwnConsole(program.start, root, logPath)
+      : await startDetached(program.start, root, log.fd);
+    if (pid === undefined) {
       return { ...base, action: "unchanged", state: initial, detail: `${program.start.command} did not start`, logPath };
     }
+    const child = { pid };
     onProgress?.({ id: program.id, phase: "waiting" });
     const state = await waitForReady(program, child.pid, maxWaitMs);
     if (state.state === "ready") onProgress?.({ id: program.id, phase: "ready" });


### PR DESCRIPTION
WhisperX has been unusable on Windows. The service reported ready, answered the supervisor's one health probe, and was gone by the next command — no traceback, no exit code, the port left in `TIME_WAIT`.

## The cause

Windows ties a process's lifetime to **the console it is attached to**. A managed program spawned from `programs.ts` inherited the launching `node`'s console, so when `hypit runtime up` exited, its console was destroyed and Windows sent `CTRL_CLOSE_EVENT` to every process on it.

The spawn options read:

```ts
detached: process.platform !== "win32",
```

and the comment above them claimed *"Windows already gives an unreferenced child its own lifetime"*. **It does not.** `unref()` removes a libuv event-loop reference and changes nothing about console ownership.

The rest of that comment was right about the cost it was avoiding: `detached` on Windows means `DETACHED_PROCESS`, which is *no console at all*, and the first console grandchild — `uv` re-execing Python, Python opening workers — then allocates a fresh **visible** one.

So both spawn options were wrong, in opposite directions.

## The fix

The combination neither reaches: **a new console, hidden.** `Start-Process -WindowStyle Hidden` creates one. In the reproduction that found this, the same executable with the same six environment variables, started that way, was still serving after the shell that launched it had exited.

The Windows path goes through it:

- the script is fed on **stdin**, so no quoting of ours crosses a shell boundary;
- `-PassThru` reports the new process, which is the pid `waitForReady` and the pid file already use;
- the error stream goes to `program.err.log` beside the log, because `Start-Process` refuses to send both streams to one file.

POSIX is untouched — same `detached: true`, same session, same single log.

## The documentation went with the inference

`environment.md` told the reader that *"some terminal/automation hosts reap child processes when the launching command exits"* and to *"run `runtime up` from a normal PowerShell session (or keep the launching session alive)"*. Keeping a session open never helped: an interactive window destroys its console when the launching command exits exactly as an automation host does. The paragraph and its workaround are gone; what remains is the polling advice, which was independently true, and the new `program.err.log` path.

## What is verified and what is not

`pnpm check` clean, `pnpm test` 497 passed, `pnpm test:release` 9 passed, `runtime-local` suite passes, and the POSIX launch path is unchanged and exercised.

**The Windows behaviour is not verified from this machine.** It rests on the reproduction reported against this code — service killed with the launcher; same binary under `Start-Process -WindowStyle Hidden` surviving it — and on what `Start-Process` documents. It needs a run on Windows before it is trusted.