### PR TITLE
a Cue spaces the boundary rather than every Word

### DIFF
--- a/packages/caption-fine/src/render.ts
+++ b/packages/caption-fine/src/render.ts
@@ -18,6 +18,7 @@ import type { ProgramSpace } from "@hypit/program-space";
 
 import { assertFineCaptionParameters, FINE_CAPTION_FAMILY } from "./style.js";
 import { assertFineCaptionSchedule } from "./schedule.js";
+import { joinSurfaces, uniformGap, wordGapBetween, wordGaps } from "./spacing.js";
 import type {
   FineCaptionActiveUnderline,
   FineCaptionGlyphPaint,
@@ -593,6 +594,19 @@ function cueElements(
   const transform = anchorTransform(parameters);
   const cueMotion = cueAnimation(parameters, durationFrames);
   const cueLoop = parameters.motion.loopTarget === "cue" ? loopAnimation(parameters, durationFrames) : undefined;
+  const gapPx = `${compactNumber(parameters.layout.wordGapPx)}px`;
+  const atomSurfaces = atoms.map((atom) => atom.wordIds.map((wordId) => wordText.get(wordId) ?? ""));
+  // A Cue whose boundaries all agree carries one `column-gap`, which is also what keeps a row that
+  // wraps from opening on a margin. A Cue that mixes scripts spaces each element instead.
+  const atomGaps = atomSurfaces.map((surfaces, index) => {
+    const previous = atomSurfaces[index - 1];
+    return previous === undefined ? false : wordGapBetween(previous.at(-1) ?? "", surfaces[0] ?? "");
+  });
+  const cueGap = uniformGap(atomGaps);
+  // The Visual IR carries physical margins, so the leading edge follows the Cue's own direction.
+  const marginStart = parameters.layout.direction === "rtl" ? "margin-right" : "margin-left";
+  const spacedStyle = (spaced: boolean): readonly VisualStyleDeclaration[] =>
+    spaced ? [{ name: marginStart, value: gapPx }] : [];
   const fonts = parameters.typography.exactFonts;
   push({
     id: "placement",
@@ -642,7 +656,7 @@ function cueElements(
       { name: "border-radius", value: `${compactNumber(parameters.cueBox.radiusPx)}px` },
       { name: "border-style", value: "solid" },
       { name: "border-width", value: `${compactNumber(parameters.cueBox.borderWidthPx)}px` },
-      { name: "column-gap", value: `${compactNumber(parameters.layout.wordGapPx)}px` },
+      ...(cueGap === true ? [{ name: "column-gap", value: gapPx }] as const : []),
       { name: "direction", value: parameters.layout.direction },
       { name: "display", value: "flex" },
       { name: "flex-wrap", value: "wrap" },
@@ -675,12 +689,17 @@ function cueElements(
       const next = atoms[prefixIndex + 1];
       const nextStart = next === undefined ? durationFrames : atomFrames.get(next.id)?.start;
       if (nextStart === undefined) throw new Error("Fine Caption is missing timing for the next Atom");
-      const prefixText = atoms.slice(0, prefixIndex + 1).map((prefixAtom) => prefixAtom.wordIds
-        .map((wordId) => {
-          const text = wordText.get(wordId);
-          if (text === undefined) throw new Error(`Fine Caption Atom references unknown word ${wordId}`);
-          return text;
-        }).join("\u00A0")).join(" ");
+      // A no-break space inside an atom keeps its words on one row; the boundaries between atoms
+      // take an ordinary space. Both are spaced only where the surfaces meeting there call for one.
+      const prefixText = joinSurfaces(
+        atoms.slice(0, prefixIndex + 1).map((prefixAtom, index) => {
+          for (const wordId of prefixAtom.wordIds) {
+            if (!wordText.has(wordId)) throw new Error(`Fine Caption Atom references unknown word ${wordId}`);
+          }
+          return joinSurfaces(atomSurfaces[index] ?? [], "\u00A0");
+        }),
+        " ",
+      );
       const layerId = `joined-box-${prefixIndex + 1}`;
       push({
         id: layerId,
@@ -725,7 +744,12 @@ function cueElements(
     const timing = atomFrames.get(atom.id);
     if (timing === undefined) throw new Error(`Fine Caption is missing timing for Atom ${atom.id}`);
     const atomId = `atom-${atomIndex + 1}`;
-    const atomText = atom.wordIds.map((wordId) => wordText.get(wordId) ?? "").join(" ");
+    const surfaces = atomSurfaces[atomIndex] ?? [];
+    // The base glyphs and the activated copy stacked over them are laid out from this one list, so
+    // the karaoke wipe keeps sitting on the letterforms it reveals.
+    const gaps = wordGaps(surfaces);
+    const wordGap = uniformGap(gaps);
+    const atomText = joinSurfaces(surfaces, " ");
     const entryId = `${atomId}-entry`;
     const typewriterId = `${atomId}-typewriter`;
     const loopId = `${atomId}-loop`;
@@ -753,6 +777,8 @@ function cueElements(
       style: [
         { name: "display", value: "inline-flex" },
         { name: "min-width", value: "0" },
+        // A row that wraps opens at its own edge, so an atom that starts one carries no margin.
+        ...(cueGap === undefined && wordsOnLine > 0 ? spacedStyle(atomGaps[atomIndex] ?? false) : []),
         { name: "transform-origin", value: "center center" },
       ],
       ...(entryAnimation === undefined ? {} : { animation: entryAnimation }),
@@ -795,7 +821,7 @@ function cueElements(
       parent: responseId,
       kind: "box",
       style: [
-        { name: "column-gap", value: `${compactNumber(parameters.layout.wordGapPx)}px` },
+        ...(wordGap === true ? [{ name: "column-gap", value: gapPx }] as const : []),
         { name: "display", value: "inline-flex" },
         { name: "min-width", value: "0" },
         { name: "overflow-wrap", value: "anywhere" },
@@ -837,7 +863,10 @@ function cueElements(
         parent: atomId,
         kind: "text",
         text,
-        style: glyphStyle(parameters, parameters.basePaint, parameters.underline),
+        style: [
+          ...glyphStyle(parameters, parameters.basePaint, parameters.underline),
+          ...(wordGap === undefined ? spacedStyle(gaps[wordIndex] ?? false) : []),
+        ],
         ...glyphPaintFields(parameters.basePaint),
         fonts,
         attributes: [{ name: "data-caption-word", value: wordId }],
@@ -854,7 +883,7 @@ function cueElements(
         parent: atomId,
         kind: "box",
         style: [
-          { name: "column-gap", value: `${compactNumber(parameters.layout.wordGapPx)}px` },
+          ...(wordGap === true ? [{ name: "column-gap", value: gapPx }] as const : []),
           { name: "display", value: "inline-flex" },
           { name: "inset", value: "0" },
           // The wipe's own `clip-path` is what reveals this layer a word at a time, and it clips to the
@@ -874,9 +903,12 @@ function cueElements(
           parent: activeId,
           kind: "text",
           text,
-          style: kind === "glyph"
-            ? glyphStyle(parameters, parameters.activePaint)
-            : transparentGlyphStyle(parameters, parameters.activeUnderline),
+          style: [
+            ...(kind === "glyph"
+              ? glyphStyle(parameters, parameters.activePaint)
+              : transparentGlyphStyle(parameters, parameters.activeUnderline)),
+            ...(wordGap === undefined ? spacedStyle(gaps[wordIndex] ?? false) : []),
+          ],
           // The underline layer paints no glyph at all, so it declares no glyph Paint either.
           ...(kind === "glyph" ? glyphPaintFields(parameters.activePaint) : {}),
           fonts,

--- a/packages/caption-fine/src/spacing.ts
+++ b/packages/caption-fine/src/spacing.ts
@@ -1,0 +1,69 @@
+/**
+ * Where a word gap belongs between two adjacent display surfaces.
+ *
+ * A Display Word is one lexical unit, and in Han, Hiragana and Katakana that unit is a single
+ * character. A gap applied to every boundary therefore sets Chinese and Japanese as though every
+ * character were a word, so each boundary decides its own gap from the two characters that meet
+ * across it.
+ *
+ * The classes follow pangu.js: a CJK character beside a half-width letter, digit, bracket or
+ * operator takes one space. The gap pangu inserts is an ordinary space, so a boundary either
+ * carries the Style's `word-gap` or carries nothing.
+ */
+
+/** The three scripts the Script tokenizer treats as one character per lexical unit. */
+const CJK = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u;
+
+/**
+ * Full-width punctuation, including the bracket, quotation and dash pairs.
+ *
+ * These glyphs are drawn inside a full-width em box with their own side bearing, so a gap beside
+ * one paints a second space over the one the font already carries. The ranges cover CJK
+ * punctuation, the full-width ASCII forms, the curly quotes and the ellipsis, and stop short of
+ * the full-width digits and letters at `０-９`, `Ａ-Ｚ` and `ａ-ｚ`, which
+ * are ordinary word characters.
+ */
+const FULL_WIDTH_PUNCTUATION =
+  /[、-〃〈-】〔-〟！-／：-＠［-｀｛-･‘’“”—…]/u;
+
+/**
+ * Half-width brackets and quotation marks take their space on the outside of the pair, which falls
+ * out of reading the boundary characters: `displayWordSurfaces` attaches an opener to the surface
+ * that follows it and a closer to the surface before it, so `中文(注)中文` meets `(` on the right
+ * of one boundary and `)` on the left of the next, and both take a gap.
+ *
+ * A boundary with no CJK character on either side keeps the gap it has today. Latin spacing is not
+ * what this decides.
+ */
+export function wordGapBetween(previous: string, next: string): boolean {
+  const left = [...previous].at(-1);
+  const right = [...next].at(0);
+  if (left === undefined || right === undefined) return false;
+  if (FULL_WIDTH_PUNCTUATION.test(left) || FULL_WIDTH_PUNCTUATION.test(right)) return false;
+  return !(CJK.test(left) && CJK.test(right));
+}
+
+/** Every boundary in order. The first surface opens the run, so its entry is always `false`. */
+export function wordGaps(surfaces: readonly string[]): readonly boolean[] {
+  return surfaces.map((surface, index) => {
+    const previous = surfaces[index - 1];
+    return previous === undefined ? false : wordGapBetween(previous, surface);
+  });
+}
+
+/**
+ * A run whose boundaries all agree carries one `column-gap` on its container. A mixed run cannot,
+ * because `column-gap` is uniform, and takes a margin per element instead.
+ */
+export function uniformGap(gaps: readonly boolean[]): boolean | undefined {
+  const boundaries = gaps.slice(1);
+  if (boundaries.length === 0) return false;
+  if (boundaries.every((gap) => gap)) return true;
+  return boundaries.some((gap) => gap) ? undefined : false;
+}
+
+/** Join surfaces back into prose, spacing only the boundaries that carry a gap. */
+export function joinSurfaces(surfaces: readonly string[], separator: string): string {
+  const gaps = wordGaps(surfaces);
+  return surfaces.map((surface, index) => (gaps[index] ? `${separator}${surface}` : surface)).join("");
+}


### PR DESCRIPTION
A Display Word is one lexical unit, and `LEXICAL_UNIT` gives Han, Hiragana and Katakana one unit per character so that karaoke can highlight Chinese a character at a time. The Fine Caption renderer put `column-gap: word-gap` on the Cue, on each Atom and on the activated copy stacked over it. `column-gap` is uniform, so at a 56px size every Chinese character was set a quarter of an em from the next: 你 好 世 界.

## The rule

`spacing.ts` decides each boundary from the two characters that meet across it, following pangu.js.

- Two CJK characters take no gap.
- A CJK character beside a half-width letter, digit, bracket or operator takes one.
- Full-width punctuation takes none: the glyph is drawn inside a full-width em box with its own side bearing.
- Half-width brackets take their gap on the outside of the pair. That falls out of reading the boundary — `displayWordSurfaces` attaches an opener to the surface after it and a closer to the surface before it, so `中文(注)中文` meets `(` on the right of one boundary and `)` on the left of the next.

A Cue whose boundaries all agree still carries one `column-gap`, so English is laid out exactly as before and a row that wraps still opens at its own edge. A Cue that mixes scripts carries a margin per element instead. The Visual IR admits physical margins only, so the leading edge follows the Cue's `direction`.

## Karaoke

The base glyphs and the activated copy are laid out from the same gap list, which is what keeps the wipe sitting on the letterforms it reveals. Word timing is untouched: it comes from the Cue's per-unit frames and reaches no style.

## Verified by rendering

| input | result |
| --- | --- |
| `hello world` | one 14px cue gap, no margins — byte-identical to before |
| `你好世界` | no gap anywhere |
| `here 你好世界 ok` | spaces only the two authored boundaries |
| `你好，世界。` | no gap |
| `中文(注)中文` | spaces outside the bracket pair |
| `中文（注）中文` | no gap |
| `版本3.0发布` | spaces around the number |

The boundary rule was exercised over 21 cases covering ％ against %, …… , —— and a half-width comma in Chinese. `tsc --noEmit` clean; 497 tests pass, 3 skipped, 0 fail.

## Out of scope

Four sites outside the caption packages still join words with `" "` and will render Chinese spaced in plain text: the `services/whisperx` segment-text fallback, and `transcript.ts`, `authoring.ts` and `checks.ts` in `packages/reference-video-tools`. `cleanProjection` in `@hypit/script` is what collapses those.

A boundary with no CJK character on either side keeps the gap it has today, so `A/B` is unchanged. Latin spacing is not what this decides.