### PR TITLE
fix: a batch round is fanned out in one place, and every task says how it is answered

### DIFF
--- a/.agents/skills/hypit/references/element-review.md
+++ b/.agents/skills/hypit/references/element-review.md
@@ -61,7 +61,7 @@ them out: a missing base is not a neutral background, it is black, and text that
 can be illegible on the picture that will replace it.
 
 `render_element` does this itself. It finds every generation the Source declares — the takes, the
-stills, the slot contents — calls `make-placeholder` for each at the Canvas's own size, and declares
+stills, the slot contents — calls `make_placeholder` for each at the Canvas's own size, and declares
 them in a derived Run under the project's `.hypit/`. Never `hypit image`, which pays for a generation
 the video will not reuse, and never a placeholder drawn by a script written for the occasion.
 

--- a/.agents/skills/hypit/references/reconstruction/evidence.md
+++ b/.agents/skills/hypit/references/reconstruction/evidence.md
@@ -14,7 +14,7 @@ hypit-reference-video-tools compare_reconstruction --reference-id <reference-id>
 
 `record_observation` is how the `agent` observer returns an answer; on the `gemini` observer the tool
 writes its own and the command is unused. A long answer arrives whole with `--text-file <path>`;
-`--text <text>` suits a short one. `make-placeholder` writes the mocks a comparison render needs;
+`--text <text>` suits a short one. `make_placeholder` writes the mocks a comparison render needs;
 `comparison-round.md` says when. `list_svml_packages` and `inspect_svml_vocabulary` read installed
 vocabulary and have nothing to do with a reference video — `../vocabulary.md` documents them.
 

--- a/packages/reference-video-tools/src/authoring.ts
+++ b/packages/reference-video-tools/src/authoring.ts
@@ -818,7 +818,7 @@ function timingReport(reference: string | undefined, segments: readonly StandInT
  *   Canvas and Frames, Recipe values, bindings   the Source
  *   which elements share a window, in what order  the Script's words, through their Selections
  *   how long each Segment runs                    the reference's own words, or `estimate:Speech`
- *   the layers a Build has not made               `make-placeholder`, sized from the Canvas
+ *   the layers a Build has not made               `make_placeholder`, sized from the Canvas
  *
  * The one thing missing before a Build is real speech, and `standInTakes` supplies a Segment
  * skeleton for it. Given `reference_id` it reads the seconds out of that reference's transcript, so
@@ -1012,7 +1012,7 @@ export async function renderElement(input: RenderElementInput): Promise<Record<s
     declarations.push(`  <value id="stand-in-${segmentId}" type="@hypit/speech@1#SemanticTake" from="./${segmentId}.json"/>`);
     satisfactions.push(`  <satisfy output="${output}.take" candidate="stand-in-${segmentId}"/>`);
   }
-  // The layers a Build has not made, as placeholders of the Canvas's own size. `make-placeholder` is
+  // The layers a Build has not made, as placeholders of the Canvas's own size. `make_placeholder` is
   // the route's one tool for this: deterministic, Provider-free, and the same mock the comparison is
   // told to bypass. A mock never enters the project's own Source — it is declared in the derived Run
   // and nowhere else.

--- a/packages/reference-video-tools/src/cli.ts
+++ b/packages/reference-video-tools/src/cli.ts
@@ -24,7 +24,7 @@ function usage(): string {
     "  hypit-reference-video-tools review_element --run <build.svrun> --element <id> --segment <id>|--selection <id> --video <path>|--image <path> --intent-file <path> [--question <scope>]",
     "  hypit-reference-video-tools review_element --run <build.svrun> --batch <reviews.json>",
     "  hypit-reference-video-tools record_review --run <build.svrun> --review-id <id> --text <text>|--text-file <path>",
-    "  hypit-reference-video-tools make-placeholder --out <path> --width <w> --height <h> [--color light|mid|dark|white|black|#RRGGBB] [--video] [--seconds <s>]",
+    "  hypit-reference-video-tools make_placeholder --out <path> --width <w> --height <h> [--color light|mid|dark|white|black|#RRGGBB] [--video] [--seconds <s>]",
     "  hypit-reference-video-tools render_element <build.svrun> --element <id> --out <path.png|path.mp4> [--segment <id>] [--selection <id>] [--reference-id <id>]",
     "  hypit-reference-video-tools render_element <build.svrun> --batch <renders.json> [--reference-id <id>]",
     "  hypit-reference-video-tools render_previews <package-dir> [...]",
@@ -54,7 +54,7 @@ function usage(): string {
     "",
     "render_element draws one element of a Source the way that Source configures it, without a Build",
     "and without a Provider: the Canvas, frame rate, Recipe values and bindings are read from the",
-    "Source, and the layers a Build has not made are mocked with make-placeholder at the Canvas's size.",
+    "Source, and the layers a Build has not made are mocked with make_placeholder at the Canvas's size.",
     "Name the stretch in words — --segment or --selection — so no reference timestamp is ever read",
     "across; without either, the whole program is drawn. An --out ending .mp4, .mov or .webm writes the",
     "stretch as a clip, and any other extension writes one still from the middle of it.",
@@ -108,7 +108,7 @@ function usage(): string {
     "`both_sides_still` says why. Both sides have to be still, because a render's base is a flat",
     "placeholder and is therefore still whatever the reference does.",
     "",
-    "make-placeholder writes a correctly-sized placeholder for a media slot the Source declares as a",
+    "make_placeholder writes a correctly-sized placeholder for a media slot the Source declares as a",
     "generation and a Build has not filled. It is deterministic and Provider-free: the comparison round",
     "uses its output to mock an empty slot, and the observer is told the slot is a placeholder so it is",
     "bypassed rather than reported as a difference. `--color` picks the fill from the named presets (the",
@@ -366,7 +366,7 @@ async function main(): Promise<void> {
       ...(flags.get("without-previews") === true ? { include_previews: false } : {}),
     };
     result = await tools.inspect_svml_vocabulary(input as { package_names: readonly string[]; tags?: readonly string[]; include_previews?: boolean });
-  } else if (command === "make-placeholder") {
+  } else if (command === "make_placeholder") {
     const input = supplied ?? {
       out: required(flags, "out"),
       width: Number(required(flags, "width")),

--- a/packages/reference-video-tools/src/tools.ts
+++ b/packages/reference-video-tools/src/tools.ts
@@ -614,6 +614,38 @@ type Request = {
 };
 type Asker = (key: string, request: Request) => Promise<Observation>;
 
+/**
+ * Attempt every entry of a `--batch` round, and keep one entry's failure to itself.
+ *
+ * Four commands take a batch and all four want the same thing from it: every entry attempted, the
+ * ones that threw reported beside the input that produced them, and the rest returned whole. Written
+ * out per command that was the same twenty lines four times, differing only in the noun.
+ *
+ * What stays at the call site is the result's own shape — `compared`/`comparisons`,
+ * `reviewed`/`reviews` — because that is the part a reader of the output is looking for, and a helper
+ * that also invented those names would need an argument per noun to say nothing extra.
+ */
+/** A round that reaches no Provider: bounded by the machine's cores rather than by anyone's quota. */
+const locallyPaced = (items: number) => ({ concurrency: Math.max(1, Math.min(cpus().length - 1, items)), gapMs: 0 });
+
+async function runBatch<T>(
+  items: readonly T[],
+  rate: { readonly concurrency: number; readonly gapMs: number },
+  run: (item: T) => Promise<Record<string, unknown>>,
+): Promise<{
+  readonly done: readonly Record<string, unknown>[];
+  readonly failures: readonly { readonly error: string; readonly input: T }[];
+}> {
+  const settled = await pacedMap(items, rate.concurrency, rate.gapMs, async (item) => {
+    try { return { ok: true as const, value: await run(item) }; }
+    catch (error) { return { ok: false as const, error: error instanceof Error ? error.message : String(error), input: item }; }
+  });
+  return {
+    done: settled.flatMap((item) => item.ok ? [item.value] : []),
+    failures: settled.flatMap((item) => item.ok ? [] : [{ error: item.error, input: item.input }]),
+  };
+}
+
 async function pacedMap<T, R>(items: readonly T[], concurrency: number, gapMs: number, run: (item: T, index: number) => Promise<R>): Promise<readonly R[]> {
   const result = new Array<R>(items.length);
   let cursor = 0;
@@ -934,6 +966,7 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
             key, instruction, prompt: [...parts, prompt].join("\n\n"), image_refs: asPictures(media, state),
             ...(sound === true && words.length > 0 ? { transcript_ref: transcriptRef } : {}),
             ...(spoken.length === 0 ? {} : { transcript_words: spoken }),
+            record_with: `record_observation --reference-id ${state.reference_id} --key ${key} --text-file <the answer>`,
           });
           return observation("pending", "awaiting the agent observer");
         },
@@ -1132,24 +1165,18 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
       if (input.questions !== undefined) {
         const round = input.questions;
         assert(round.length > 0, "questions is empty");
-        const batchRate = rateFor((await loadState(input.reference_id)).observer ?? "gemini", "listing", round.length);
-        const answers = await pacedMap(round, batchRate.concurrency, batchRate.gapMs, async (asked) => {
-          try {
-            return { ok: true as const, value: await tools.observe_reference({
-              reference_id: input.reference_id, shot_ids: asked.shot_ids, question: asked.question,
-            }) };
-          } catch (error) {
-            return { ok: false as const, error: error instanceof Error ? error.message : String(error), asked };
-          }
-        });
-        const done = answers.filter((item) => item.ok).map((item) => item.value!);
-        const failed = answers.filter((item) => !item.ok);
+        const rate = rateFor((await loadState(input.reference_id)).observer ?? "gemini", "listing", round.length);
+        const { done, failures } = await runBatch(round, rate, async (asked) => await tools.observe_reference({
+          reference_id: input.reference_id, shot_ids: asked.shot_ids, question: asked.question,
+        }));
         return {
           reference_id: input.reference_id,
           asked: done.length,
-          failed: failed.length,
+          failed: failures.length,
           answers: done,
-          ...(failed.length === 0 ? {} : { failures: failed.map((item) => ({ error: item.error, asked: item.asked })) }),
+          ...(failures.length === 0 ? {} : { failures }),
+          // The one thing gathered across the whole round: an observer that answers out of band owes
+          // one task per question, and they are answered together rather than call by call.
           pending_observations: done.flatMap((item) => (item["pending_observations"] ?? []) as readonly unknown[]),
         };
       }
@@ -1466,24 +1493,15 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
         assert(batch.length > 0, "comparisons is empty");
         // Each entry cuts and tiles its own two sides, so on the observer that answers out of band
         // this round is ffmpeg work rather than a queue of requests.
-        const batchRate = rateFor((await loadState(input.reference_id)).observer ?? "gemini", "ffmpeg", batch.length);
-        const results = await pacedMap(batch, batchRate.concurrency, batchRate.gapMs, async (one) => {
-          const merged = { reference_id: input.reference_id, ...one };
-          // One comparison that throws — an unreadable render, a Selection the Script does not mark —
-          // takes only itself down. The rest of the list is what the caller came for.
-          try { return { ok: true as const, value: await tools.compare_reconstruction(merged) }; }
-          catch (error) { return { ok: false as const, error: error instanceof Error ? error.message : String(error), input: merged }; }
-        });
-        const done = results.filter((item) => item.ok).map((item) => item.value!);
-        const failed = results.filter((item) => !item.ok);
+        const rate = rateFor((await loadState(input.reference_id)).observer ?? "gemini", "ffmpeg", batch.length);
+        const { done, failures } = await runBatch(batch, rate,
+          async (one) => await tools.compare_reconstruction({ reference_id: input.reference_id, ...one }));
         return {
           reference_id: input.reference_id,
           compared: done.length,
-          failed: failed.length,
+          failed: failures.length,
           comparisons: done,
-          ...(failed.length === 0 ? {} : {
-            failures: failed.map((item) => ({ error: item.error, input: item.input })),
-          }),
+          ...(failures.length === 0 ? {} : { failures }),
         };
       }
       const state = await loadState(input.reference_id);
@@ -1752,20 +1770,14 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
         assert(batch.length > 0, "reviews is empty");
         // Local work throughout — a decode per entry and no request anywhere — so it is paced by the
         // machine, the way `render_element` is.
-        const atOnce = Math.max(1, Math.min(cpus().length - 1, batch.length));
-        const results = await pacedMap(batch, atOnce, 0, async (one) => {
-          const merged = { ...one, run: input.run };
-          try { return { ok: true as const, value: await tools.review_element(merged) }; }
-          catch (error) { return { ok: false as const, error: error instanceof Error ? error.message : String(error), input: merged }; }
-        });
-        const done = results.filter((item) => item.ok).map((item) => item.value!);
-        const failed = results.filter((item) => !item.ok);
+        const { done, failures } = await runBatch(batch, locallyPaced(batch.length),
+          async (one) => await tools.review_element({ ...one, run: input.run }));
         return {
           run: runPath,
           reviewed: done.length,
-          failed: failed.length,
+          failed: failures.length,
           reviews: done,
-          ...(failed.length === 0 ? {} : { failures: failed.map((item) => ({ error: item.error, input: item.input })) }),
+          ...(failures.length === 0 ? {} : { failures }),
         };
       }
 
@@ -1907,19 +1919,15 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
         const round = input.renders;
         assert(round.length > 0, "renders is empty");
         // Local work rather than a quota, so it is paced by the machine and not by the launch gap.
-        const atOnce = Math.max(1, Math.min(cpus().length - 1, round.length));
-        const results = await pacedMap(round, atOnce, 0, async (one) => {
-          const merged = { ...one, run: one.run ?? input.run, ...(one.reference_id ?? input.reference_id === undefined ? {} : { reference_id: input.reference_id }) };
-          try { return { ok: true as const, value: await renderElement(merged as RenderElementInput) }; }
-          catch (error) { return { ok: false as const, error: error instanceof Error ? error.message : String(error), input: merged }; }
-        });
-        const done = results.filter((item) => item.ok).map((item) => item.value!);
-        const failed = results.filter((item) => !item.ok);
+        const { done, failures } = await runBatch(round, locallyPaced(round.length), async (one) => await renderElement({
+          ...one, run: one.run ?? input.run,
+          ...(one.reference_id ?? input.reference_id === undefined ? {} : { reference_id: input.reference_id }),
+        } as RenderElementInput));
         return {
           rendered: done.length,
-          failed: failed.length,
+          failed: failures.length,
           renders: done,
-          ...(failed.length === 0 ? {} : { failures: failed.map((item) => ({ error: item.error, input: item.input })) }),
+          ...(failures.length === 0 ? {} : { failures }),
         };
       }
       return await renderElement(input);

--- a/packages/reference-video-tools/src/types.ts
+++ b/packages/reference-video-tools/src/types.ts
@@ -76,6 +76,15 @@ export type ObservationTaskRequest = {
    */
   readonly transcript_ref?: string;
   readonly transcript_words?: string;
+  /**
+   * The command line that closes this task, ready to run.
+   *
+   * A sweep hands out four tasks per shot, so a reference of any length produces more of these than
+   * anyone will match against a usage string by hand. Carrying the command here is what keeps the
+   * choice of recording verb off the caller entirely: every task says how it is answered, the way a
+   * comparison and a review already do.
+   */
+  readonly record_with: string;
 };
 
 export type ReferenceState = {

--- a/test/hypit-skill-reachability.mjs
+++ b/test/hypit-skill-reachability.mjs
@@ -68,7 +68,7 @@ function read(path, at) {
     if (at === undefined) return readFileSync(join(repositoryRoot, path), "utf8");
     // A path that does not exist at that commit is an answer, not an error: `--links` asks exactly
     // that question. `git show` says so on stderr, which would otherwise interleave with the report.
-    return execFileSync("git", ["show", `${at}:${path}`], { cwd: repositoryRoot, encoding: "utf8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] });
+    return execFileSync("git", ["show", `${at}:${path}`], { cwd: repositoryRoot, encoding: "utf8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"], windowsHide: true });
   } catch {
     return null;
   }
@@ -88,7 +88,7 @@ function everySkillFile(at) {
     visit(skillRoot);
     return found.sort();
   }
-  const listed = execFileSync("git", ["ls-tree", "-r", "--name-only", at, "--", skillRoot], { cwd: repositoryRoot, encoding: "utf8" });
+  const listed = execFileSync("git", ["ls-tree", "-r", "--name-only", at, "--", skillRoot], { cwd: repositoryRoot, encoding: "utf8", windowsHide: true });
   return listed.split("\n").filter((line) => line.endsWith(".md")).sort();
 }
 


### PR DESCRIPTION
Follow-up to #84, which turned main red. Three things, one of them a repair.

## Why CI failed on #84

`test/hypit-skill-reachability.mjs` started two child processes without `windowsHide`, and the repository-hygiene suite refuses that (`test/repository-hygiene.test.mjs:295`). Both runners reported it, because the check is a static AST scan rather than anything platform-dependent.

I did not catch it because I ran `pnpm check` and `pnpm test` but not `pnpm test:release`. `node test/run.mjs` globs `*.test.ts`, so the hygiene suite — an `.mjs` file — was never in it. CI runs all three.

## The redundancy that was real

An audit of the VLM commands looked at four candidate merges and rejected all four: the caller is always handed the literal command line for the next step, so a second command name costs code rather than caller cognition. What was actually duplicated was the batch fan-out — four copies of attempt-all / catch-per-entry / partition / shape-result.

`runBatch` now owns the attempting and the isolating. The result's own nouns stay at the call site: `compared`/`comparisons` and `reviewed`/`reviews` are what a reader of the output looks for, and a helper that invented them too would need an argument per noun to say nothing extra. **The line count is about flat** — the saving is that one place decides an entry's failure takes only itself down, not four.

One behaviour change: `observe_reference --batch` reported a failed entry under `asked`; it is `input` now, matching the other three.

## The gap the audit exposed

The argument for keeping `record_observation` and `record_review` separate is that no caller ever chooses between them — each is printed in the result that hands out the task. That was true of `compare_reconstruction` and `review_element` and false of the sweep, which hands out four tasks per shot and named no command at all. `ObservationTaskRequest` now carries `record_with`.

## Naming

`make-placeholder` was the one command spelled with a hyphen while the other fifteen used an underscore; the method behind it was already `make_placeholder`. Nothing in the history records a reason.

## Verification

All three CI gates locally this time:

- `pnpm check` clean
- `pnpm test` — 501 tests, 0 failures
- `pnpm test:release` — 9 tests, 0 failures, including the check that caught #84

Behaviour exercised rather than asserted:

- A batch of three with one entry naming a shot that does not exist returns `asked: 2, failed: 1`, the bad input beside its error, and the other two answered.
- A sweep over four shots hands out 15 tasks; 15 carry `record_with`; the command one of them prints records successfully against the key it names.
- `make_placeholder` writes its PNG; the hyphen form is gone.