### PR TITLE
fix: the physical locator expands a Windows short path

### DIFF
--- a/packages/package-loader-node/src/location.ts
+++ b/packages/package-loader-node/src/location.ts
@@ -84,7 +84,12 @@ function readPackage(root: string, expectedName: string): LocatedNodePackage | u
     throw new Error(`${path}.version must be a string`);
   }
   return {
-    root: realpathSync(root),
+    // `.native` because this is the physical path, and on Windows the JavaScript `realpathSync`
+    // resolves symlinks and junctions without expanding an 8.3 short name. A temporary directory
+    // under a service account arrives as `RUNNER~1\AppData\...`, so a root located here and the same
+    // root canonicalized through the asynchronous `realpath` — which does go through libuv — are two
+    // different strings for one directory, and every comparison between them fails.
+    root: realpathSync.native(root),
     manifest: {
       name: expectedName,
       ...(value.version === undefined ? {} : { version: value.version }),


### PR DESCRIPTION
`check (windows-latest)` has been failing on main while `check (ubuntu-latest)` passes. It is not anyone's feature branch — main itself is red at `392246d1`.

```
not ok 261 - one physical locator distinguishes CLI packages, resources and project ownership
  + actual   C:\Users\RUNNER~1\AppData\Local\Temp\...\node_modules\cli-only
  - expected C:\Users\runneradmin\AppData\Local\Temp\...\node_modules\cli-only
```

## Cause

`locateNodePackage` returns what the test's own name calls a *physical* path, and canonicalizes with `realpathSync` to get one. On Windows that is the JavaScript implementation: it resolves symlinks and junctions but leaves an 8.3 short name alone. `os.tmpdir()` under a service account yields `C:\Users\RUNNER~1\AppData\...`, so the located root and the same root canonicalized through the *asynchronous* `realpath` — which goes through libuv, and does expand it — are two different strings for one directory.

The test compares the two. On Linux and macOS there are no short names, so they agree and it passes.

## Fix

`realpathSync.native` goes through libuv like its asynchronous counterpart, so the two agree on every platform. One line, at `packages/package-loader-node/src/location.ts:87`.

Nothing else in the repository calls the non-native form, so this is the only site with the latent mismatch.

## Verification

Local checks pass, but macOS cannot produce a short name — the platform this actually fixes is the one CI reports on. `pnpm check` clean, 531 tests 0 failures, `pnpm test:release` 9 of 9.