### PR TITLE
A shot opens by seeking to it rather than decoding up to it

### DIFF
--- a/packages/reference-video-tools/src/media.ts
+++ b/packages/reference-video-tools/src/media.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { cpus } from "node:os";
 import { join, resolve } from "node:path";
 import { spawn } from "node:child_process";
 
@@ -141,6 +142,47 @@ async function extract(path: string, args: readonly string[], target: string): P
   return target;
 }
 
+/** How far before the mark to jump, leaving a short run-up to decode exactly. */
+const SEEK_RUN_UP = 2;
+
+/**
+ * Arguments that open `source` sitting on the frame at `at` seconds.
+ *
+ * Seeking only after `-i` decodes every frame from the start of the file and discards it, so opening
+ * a shot nine minutes in costs nine minutes of decoding. Seeking only before `-i` is immediate but
+ * lands on the nearest keyframe at or before the mark, which is a different picture. Doing both —
+ * jump to a keyframe a little early, then decode the short run-up — lands on the frame the slow way
+ * lands on. Measured on a 1080p source at nine minutes in: the same JPEG to the byte, 11.6s to 0.2s.
+ */
+function openAt(source: string, at: number): readonly string[] {
+  const jump = Math.max(0, at - SEEK_RUN_UP);
+  const runUp = at - jump;
+  return [
+    ...(jump > 0 ? ["-ss", String(round(jump))] : []),
+    "-i", source,
+    ...(runUp > 0 ? ["-ss", String(round(runUp))] : []),
+  ];
+}
+
+/**
+ * Run `work` over every item, with no more than `limit` of them in flight.
+ *
+ * A shot is cheap on its own and a long video has hundreds of them. Starting every one at once
+ * leaves that many ffmpeg processes competing for the same cores, so each takes long enough to be
+ * killed for hanging while all of them are in fact working.
+ */
+async function inPool<T>(items: readonly T[], limit: number, work: (item: T, index: number) => Promise<void>): Promise<void> {
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      await work(items[index]!, index);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, worker));
+}
+
 // An observer that reads images rather than video sees a shot as this many frames, sampled evenly
 // across it and tiled into one picture in reading order. Four is enough for a one-second shot to
 // show what moves; nine keeps a fifteen-second one legible at a cell width a reader can still resolve
@@ -205,19 +247,19 @@ export async function prepareMedia(videoPath: string, root: string, duration: nu
   const analysisVideo = await extract(videoPath, ["-i", videoPath, "-vf", "scale='min(720,iw)':-2", "-c:v", "libx264", "-preset", "veryfast", "-crf", "30", "-c:a", "aac", "-b:a", "64k"], join(root, "analysis.mp4"));
   const shotDir = join(root, "shots");
   await ensureDir(shotDir);
-  await Promise.all(bounds.map(async (bound, index) => {
+  // Bounded rather than all at once: a fifteen-second rule cuts a ten-minute reference into nearly
+  // two hundred shots, and two hundred concurrent ffmpeg runs starve each other.
+  await inPool(bounds, Math.max(1, cpus().length - 1), async (bound, index) => {
     const id = String(index + 1).padStart(3, "0");
     const clip = join(shotDir, `${id}.mp4`);
-    // `-ss` goes after `-i`: seeking the output decodes from the start and lands on the frame asked
-    // for, where seeking the input lands on the keyframe before it.
-    await extract(videoPath, ["-i", videoPath, "-ss", String(bound.start), "-t", String(Math.max(0.1, bound.end - bound.start)), "-c:v", "libx264", "-preset", "veryfast", "-crf", "23", "-c:a", "aac", "-b:a", "96k", "-movflags", "+faststart"], clip);
-    await extract(videoPath, ["-i", videoPath, "-ss", String(bound.start + (bound.end - bound.start) / 2), "-frames:v", "1", "-vf", "scale='min(720,iw)':-2", "-pix_fmt", "yuvj420p", "-q:v", "3"], join(shotDir, `${id}-representative.jpg`));
+    await extract(videoPath, [...openAt(videoPath, bound.start), "-t", String(Math.max(0.1, bound.end - bound.start)), "-c:v", "libx264", "-preset", "veryfast", "-crf", "23", "-c:a", "aac", "-b:a", "96k", "-movflags", "+faststart"], clip);
+    await extract(videoPath, [...openAt(videoPath, bound.start + (bound.end - bound.start) / 2), "-frames:v", "1", "-vf", "scale='min(720,iw)':-2", "-pix_fmt", "yuvj420p", "-q:v", "3"], join(shotDir, `${id}-representative.jpg`));
     await extract(videoPath, ["-sseof", "-0.1", "-i", clip, "-update", "1", "-frames:v", "1", "-vf", "scale='min(720,iw)':-2", "-pix_fmt", "yuvj420p", "-q:v", "3"], join(shotDir, `${id}-tail.jpg`));
     // Only the observer that reads pictures has anything to read them from, and building a tile per
     // shot is a decode per shot. The other observer is handed the clip itself.
     if (tiles) await shotTile(clip, bound.end - bound.start, join(shotDir, `${id}-frames.jpg`));
     if (await hasAudio(clip)) await extract(videoPath, ["-sseof", "-3", "-i", clip, "-map", "0:a:0", "-vn", "-ac", "1", "-ar", "16000", "-c:a", "pcm_s16le"], join(shotDir, `${id}-audio.wav`));
-  }));
+  });
   const inputs = bounds.map((_, index) => `[${index}:v]`).join("");
   const list = bounds.flatMap((_, index) => ["-i", join(shotDir, `${String(index + 1).padStart(3, "0")}-representative.jpg`)]);
   const columns = Math.min(4, bounds.length);


### PR DESCRIPTION
A ten-minute reference could not be prepared. It failed with `ffmpeg timed out`, which named neither of the two causes.

## What was wrong

`splitLong` cuts a shot into parts of at most fifteen seconds, so a 634 s reference becomes **195 shots**. For each of them `prepareMedia` did two things that scale badly:

- **Seeking only after `-i`.** That decodes every frame from the start of the file and throws it away. Exact, but a shot nine minutes in decodes nine minutes — and the clip and the representative still each paid it separately. Summed over 195 shots: about thirty hours of decoding.
- **`Promise.all` over all of them.** Every shot started at once, so 195 ffmpeg runs competed for the same cores. Each then took long enough to be killed for hanging while all of them were in fact working.

Raising the timeout would not have helped; the work was real.

## The change

One file, `packages/reference-video-tools/src/media.ts`:

- **`openAt(source, at)`** seeks before `-i` to a keyframe `SEEK_RUN_UP` seconds early, then after `-i` for the short remainder. Used by the shot clip and the representative still.
- **`inPool`** replaces `Promise.all`, holding at most `cpus - 1` shots in flight.

## Measured

Same source, nine minutes in, one still:

```
-ss after -i (before)   11569 ms
seek then run-up (after)  196 ms
cmp of the two JPEGs:   identical
```

The frame is the same to the byte, so the accuracy the old ordering existed for is kept.

## Not covered

`cutClip` and `cutFrame` still seek only after `-i`. They cut the comparison stretch out of `analysis.mp4` and carry the same cost, so they are worth the same change — left out here to keep this to the path that was failing.

Separately, this only makes a long reference *preparable*. 195 shots still means 195 observer calls, and the fifteen-second rule was set for short references. That is a question about what to charge for, not about whether the tool runs.

`pnpm check` clean, `pnpm test` 528 passed / 3 skipped, `pnpm test:release` 9 passed. The end-to-end run on the ten-minute video was not performed.