### PR TITLE
docs: add Studio paid confirmation handoff

### DIFF
--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -83,7 +83,8 @@ the boundary and launcher selection. Read it before the first command of any rou
 - A completed project followed by a natural-language change → read `references/revision.md` and use
   the independent `revision_state` route. Restore the element's role in the frozen brief, edit only
   Source/Recipe/Run, invalidate the affected graph closure, and rerun deterministic gates. Revision
-  never invokes VLM/observer visual inspection; leave visual inspection for a later Studio session.
+  never invokes VLM/observer visual inspection; after the change, start Studio only when the current
+  Run has no Studio session so the author can see the updated result.
 - A syntax question about one element, or a source that already exists → read
   `references/authoring.md`, then `references/quickstart.md` and the linked authoritative
   docs/package READMEs. A whole video is `references/original-authoring/route.md`, not this file.
@@ -97,6 +98,8 @@ the boundary and launcher selection. Read it before the first command of any rou
   other route step.
 - Preview-only media realization, temporary preview Runs, mock Artifact caching, or estimated
   SemanticTake timing → read `references/preview-mock.md`.
+- Paid-build handoff, pre-payment mock confirmation, post-build Studio display, or Studio behavior
+  after a revision → read `references/studio-confirmation.md`.
 - Runtime setup, plan/build/status/inspect/get/reuse → read `references/runtime.md`.
 - Environment diagnosis or credentials → read `references/environment.md` and
   `references/credentials.md`.

--- a/.agents/skills/hypit/references/original-authoring/route.md
+++ b/.agents/skills/hypit/references/original-authoring/route.md
@@ -198,6 +198,11 @@ configured to empty its window.
 
 ### 13. The Build
 
+**Read now:** `../studio-confirmation.md`. Before the paid gate, start Studio for the complete
+preview-mock Run, show the author the mock, and obtain explicit acceptance and cost approval. If the
+author declines, enter `../revision.md` and do not submit a Build. After acceptance and paid Build
+submission, start Studio for the accepted Run while the HyperFrames/final render runs concurrently.
+
 Confirm credentials, the Runtime Profile, the installed packages, model limits, resolution and
 Endpoint prerequisites. Run `doctor`, `check` and `plan`.
 

--- a/.agents/skills/hypit/references/preview.md
+++ b/.agents/skills/hypit/references/preview.md
@@ -114,14 +114,20 @@ whether any bleed is intentional.
 
 ## Open the whole Run for a person
 
-After a meaningful Author Source change, start Hypit Studio and give the author the actual URL.
-Kill the previous server first so the user does not inspect a stale composition.
+After the route's final check, read `studio-confirmation.md`: before a paid Build, start Hypit Studio
+for the complete preview-mock Run and obtain the author's acceptance. After a revision, if Studio for
+that Run is not already running, start it and give the author the URL; an existing Studio session
+hot-reloads the changed Source. Stop the previous server before changing Studio startup parameters
+(for example, selecting a different `--run`, `--workspace` or port) to avoid port conflicts; do not
+restart merely because the same Run's SVML/SVS changed.
 
 ```bash
-pkill -f "hypit-studio" || true
 cd /path/to/project
 hypit-studio --run build.svrun --runtime hypit.runtime.json &
 ```
+
+If another Studio process is already using a different Run or startup parameters, stop that process
+before launching this command; otherwise reuse the existing process and let its Source watcher reload.
 
 Read the startup output for the chosen port. `--run` is required: Studio's unit of work is the Run
 Source, and it reads the Author SVML back out of it. Pass `--runtime` only when the Author Source

--- a/.agents/skills/hypit/references/reconstruction/route.md
+++ b/.agents/skills/hypit/references/reconstruction/route.md
@@ -11,7 +11,8 @@ no Build is submitted, and no video generation, speech synthesis, alignment or f
 Those belong to the Build the author starts deliberately, after reading what was written.
 
 Seeing the reconstruction is what that Build is for. What is settled here is that the graph traces,
-which is the part a Build cannot repair.
+which is the part a Build cannot repair. The route then pauses at the Studio confirmation handoff
+before any paid Build; after explicit acceptance it may proceed with the Runtime Build lifecycle.
 
 If the project is already complete and the author asks for a natural-language change, stop following
 this creation route and read `../revision.md`. Revision edits Source/Recipe/Run and reruns deterministic
@@ -365,6 +366,15 @@ a project-local one does, and `render_element` stands in for the speech. A proje
 drawing element passes with nothing to require.
 
 **Done when:** `"passed": true`.
+
+### 24. Studio confirmation and paid handoff
+
+**Read now:** `../studio-confirmation.md`. Before any paid Build, start Studio for the complete
+preview-mock Run, show it to the author, and obtain explicit acceptance and cost approval. If the
+author declines, enter `../revision.md` and do not Build. After acceptance, start Studio for the
+accepted Run while the HyperFrames/final render proceeds concurrently.
+
+After acceptance, continue with `../runtime.md` for the approved paid Build and retrieval lifecycle.
 
 ---
 

--- a/.agents/skills/hypit/references/revision.md
+++ b/.agents/skills/hypit/references/revision.md
@@ -33,8 +33,8 @@ request-captured → impact-assessed → intent-mapped → source-updated
 deliberately not a VLM/observer step. Revision does not call
 `review_element`, `compare_reconstruction`, Vertex, WhisperX or any other visual observer. Mark that
 stage only as an explicit mechanical checkpoint when the requested source change has been covered by
-the deterministic checks. No visual acceptance work is implied here; leave Studio untouched unless
-the user later asks to open it.
+the deterministic checks. Revision itself performs no visual judgement; after it completes, if no
+Studio session is running for the current Run, start Studio and show the author the updated result.
 
 ## Work sequence
 
@@ -48,7 +48,8 @@ the user later asks to open it.
    that later beats still fulfil its promise.
 4. Edit only Source, Recipe or Run. Re-run package/Cue gates, `hypit check`, `preview_check`, and the
    route-specific final check. Do not render, compare, review or inspect any frame during revision;
-   existing unchanged artifacts may be reused by digest.
+   existing unchanged artifacts may be reused by digest. Once the gates pass, follow
+   `studio-confirmation.md`'s conditional Studio handoff.
 5. Check the final gate. Confirm cost again only when an image/video/voice generation input changed;
    geometry and layout revisions do not trigger a paid Build. Build only after explicit approval.
 

--- a/.agents/skills/hypit/references/runtime.md
+++ b/.agents/skills/hypit/references/runtime.md
@@ -66,6 +66,11 @@ hypit get <build-id> \
   --name final.video --to output/final.mp4
 ```
 
+The paid-build handoff is defined in `studio-confirmation.md`: show the complete preview-mock Run in
+Studio and obtain acceptance before `hypit build`; after acceptance, Studio for the accepted Run and
+the HyperFrames/final render may start concurrently. The render must not be blocked on the author's
+Studio viewing.
+
 Use `check` during authoring. `plan` works without a Runtime as a graph-only operation; with the
 project's selected Runtime it performs a cheap, read-only preflight over only unsatisfied Needs and
 returns non-zero when that slice is not ready. It never installs, starts or contacts a remote Store.

--- a/.agents/skills/hypit/references/studio-confirmation.md
+++ b/.agents/skills/hypit/references/studio-confirmation.md
@@ -1,0 +1,40 @@
+# Studio confirmation and paid-build handoff
+
+This is the human handoff around both the reconstruction and original-authoring routes. It is not a
+VLM review and it does not replace the route's mechanical checks.
+
+## Before the paid gate
+
+After the route-specific final check passes, but before submitting any paid Build:
+
+1. Start Hypit Studio for the current `build.svrun` and give the author its URL.
+2. Let Studio show the complete program through the normal SVRun-native preview path:
+   `compiler-node Graph → preview-mock → mock-media → temporary preview.svrun → Studio`.
+3. Tell the author this is an estimate-timed, preview-only mock and ask whether the structure and
+   intended result are acceptable for paid generation.
+4. Do not submit `hypit build` until the author explicitly accepts and confirms the cost.
+
+If the author does not accept, do not Build. Capture the requested change and enter `revision.md`.
+Revision edits Source/Recipe/Run and reruns deterministic gates; it does not ask an agent or VLM to
+judge the picture.
+
+## After the paid Build
+
+Once the author has accepted and the paid Build is submitted/accepted, start Studio for the same Run
+to show the complete program using the accepted material. Start the HyperFrames/final render at the
+same time; the render must not wait for the author to finish looking at Studio. Studio is a live,
+read-only presentation of the current Run while the render proceeds. Report render/build status and
+the Studio URL independently.
+
+## After a revision
+
+When a user-requested revision completes its deterministic gates, preserve a running Studio session
+and let its file watcher hot-reload the updated SVML/SVS/SVRun. If the current Run has no Studio
+session, start one for that Run and give the author the URL so they can see the change. Do not invoke a
+VLM, comparison, observer or visual judgement as part of Revision. Do not restart an already-running
+Studio merely because Source changed. If the startup parameters change (for example a different Run,
+workspace or port), stop the previous Studio first so the new server cannot collide with its port.
+
+Use the existing `preview.md` startup command and `revision_state` snapshot. Studio startup is a
+display handoff, not permission to Build; a new paid generation still requires a fresh cost
+confirmation.


### PR DESCRIPTION
Adds the Studio lifecycle to Hypit reconstruction and original-authoring skills: preview-mock confirmation before paid Build, concurrent Studio display and HyperFrames rendering after Build, and conditional Studio startup after revisions. Documents hot reload and stopping Studio when startup parameters change.

Validation: skill quick_validate, route reachability, git diff --check.