### PR TITLE
docs: make examples and playbook intake mandatory

### DIFF
--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -90,10 +90,10 @@ invalid. Never commit `.env` or copy its secret values into route state, Source,
   given at all. What it is for, who is in it and what it says are the author's; the working
   directory, the project location, the packages and the generators are yours to decide rather than to
   ask for.
-- A sparse or ambiguous original request → read `references/brief-intake.md`. Discover complete
-  projects under the checkout's `examples/` directory and analyze their author intent when relevant;
-  otherwise use the document's general, open-ended fallback. Do not hard-code video types or skip
-  the brief-sufficiency gate.
+- Every original-authoring request → read `references/brief-intake.md` and inspect complete projects
+  under the checkout's `examples/` directory when it exists. Analyze a semantically matching
+  project's author intent; otherwise use the document's general, open-ended fallback. Do not
+  hard-code video types or skip the brief-sufficiency gate.
 - A completed project followed by a natural-language change → read `references/revision.md` and use
   the independent `revision_state` route. Restore the element's role in the frozen brief, edit only
   Source/Recipe/Run, invalidate the affected graph closure, and rerun deterministic gates. Revision

--- a/.agents/skills/hypit/references/brief-intake.md
+++ b/.agents/skills/hypit/references/brief-intake.md
@@ -30,6 +30,13 @@ for the high-impact decisions the request leaves unresolved. Never turn an examp
 a hard-coded type-specific questionnaire; an opening provocation is evidence of that author's Hook,
 not a rule for a purported format.
 
+After the intent comparison, use `../playbooks/index.md` to determine whether a format playbook
+matches the requested program. Read the matching format playbook completely, including its craft
+notes and footer, and then read every additional craft file that footer names. The match is based on
+the recovered intent and the user's goal, never on an example directory name, component count or a
+fixed list of video types. If no format playbook matches, keep the general craft guidance and intent
+analysis as the route's authority.
+
 ## General fallback when no example matches
 
 If `examples/` is absent, empty, or semantically unlike the request, do not start Source and do not

--- a/.agents/skills/hypit/references/original-authoring/route.md
+++ b/.agents/skills/hypit/references/original-authoring/route.md
@@ -93,9 +93,9 @@ again. Ask only for a credential that is absent or invalid after both `.env` fil
 
 ### 3. Make the brief sufficient before writing Source
 
-**Read now:** `../brief-intake.md`. If this is a sparse or ambiguous request, inspect complete
-projects under the checkout root's `examples/` directory and compare their recovered author intent,
-Hook and narrative to the request. If no example is semantically relevant, use the document's
+**Read now:** `../brief-intake.md`. Always inspect the checkout root's `examples/` directory when it
+exists, enumerate complete projects, and compare any semantically relevant project's recovered author
+intent, Hook and narrative to the request. If no example is semantically relevant, use the document's
 general fallback; absence of an example is not permission to guess or skip intake.
 
 Ask only for unresolved, high-impact creative decisions. Freeze a concise `.hypit/brief` recording
@@ -105,12 +105,15 @@ implementation details are yours; core facts, claims, Hook and audience promise 
 Do not enter `brief-frozen` or write paid-generation prompts until no unresolved answer can change the
 Graph, Script, visual semantics, timing or generation inputs.
 
-### 4. Read the craft this program needs
+### 4. Read the craft and format guidance this program needs
 
 1. Every craft file named in the first item of `../playbooks/index.md`'s required load order, in the
    order it gives them.
-2. The format. `../playbooks/index.md` lists them; read the one that fits and only the additional
-   craft files its own footer names.
+2. Determine the format from the frozen intent, not from an example's directory name or a fixed type
+   list. If `../playbooks/index.md` has a matching format playbook, read it completely, including its
+   notes and footer, then read every additional craft file that footer names. If no format playbook
+   matches, follow the shared craft guidance and the open-ended intent analysis; do not invent a
+   type-specific checklist.
 
 ### 5. Choose the packages
 


### PR DESCRIPTION
## Summary\n- require every original-authoring request to inspect checkout examples\n- route matching requests through semantic intent analysis before source authoring\n- read the matching format playbook, notes, footer, and referenced craft guidance\n- keep a general fallback when no format playbook matches\n\n## Validation\n- quick_validate.py .agents/skills/hypit\n- description skill reachability\n- git diff --check