### PR TITLE
fix(reference-video-tools): declare run markup dependency

### DIFF
--- a/packages/reference-video-tools/package.json
+++ b/packages/reference-video-tools/package.json
@@ -25,6 +25,7 @@
     "@hypit/package-loader-node": "workspace:*",
     "@hypit/program-space": "workspace:*",
     "@hypit/protocol": "workspace:*",
+    "@hypit/run-markup": "workspace:*",
     "@hypit/provider-whisperx-local": "workspace:*",
     "@hypit/provider-media-local": "workspace:*",
     "@hypit/script": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2288,6 +2288,9 @@ importers:
       '@hypit/provider-whisperx-local':
         specifier: workspace:*
         version: link:../provider-whisperx-local
+      '@hypit/run-markup':
+        specifier: workspace:*
+        version: link:../run-markup
       '@hypit/script':
         specifier: workspace:*
         version: link:../script


### PR DESCRIPTION
## Summary

- declare the existing @hypit/run-markup production import in reference-video-tools
- update the workspace lockfile importer

## Validation

- pnpm check
- pnpm test:release
- git diff --check

No tests were added.