### PR TITLE
fix(cli): exclude targets from Studio pins

### DIFF
--- a/.agents/skills/hypit/references/authoring.md
+++ b/.agents/skills/hypit/references/authoring.md
@@ -61,6 +61,11 @@ without pinning them buys the same bytes again. Run `--pin` against the failed B
 the cause. `hypit history --source <author.svml> --pin` emits the pairs for the newest accepted
 Record of each output; do not transcribe Build ids by hand.
 
+For a Run opened in Studio, add `--exclude-targets` and keep every declared Target unresolved. A
+Target satisfied by its accepted media Record is an opaque finished file, so Studio cannot trace it
+to the current Film graph. The accepted-material Studio handoff is defined in
+`studio-confirmation.md`.
+
 **Pin what a Provider was paid to make, and nothing the Source computes.** `--pin` emits a line for
 every accepted output, including the ones the Script's own structure produced: `speech.semantic`,
 `speech.visual`, `speech.audio`, and the Caption Track's deterministic projection. Those are

--- a/.agents/skills/hypit/references/studio-confirmation.md
+++ b/.agents/skills/hypit/references/studio-confirmation.md
@@ -31,10 +31,14 @@ judge the picture.
 
 Once the author has accepted and the paid Build is submitted/accepted, create/persist a derived Run
 that selects the accepted Build Records (the same `<build-record>`/`<satisfy>` mechanism documented in
-`runtime.md`), then start Studio for that accepted-material Run. Start the HyperFrames/final render at
-the same time; the render must not wait for the author to finish looking at Studio. Studio is a live,
-read-only presentation of the current Run while the render proceeds. Report render/build status and
-the Studio URL independently.
+`runtime.md`), but never satisfy a Run Target such as `final.video`: Studio needs that Target to remain
+connected to the current Film graph, not replaced by an opaque finished-media Candidate. Generate the
+markup with `hypit history --source <author.svml> --pin --exclude-targets`, persist it in a separate
+Studio Run, then start Studio for that accepted-material Run. The Build Run may retain the narrower set
+of paid upstream pins it needs for reuse; neither Run pins its own Target. Start the HyperFrames/final
+render at the same time; the render must not wait for the author to finish looking at Studio. Studio is
+a live, read-only presentation of the current Run while the render proceeds. Report render/build status
+and the Studio URL independently.
 
 After that full video is delivered, any new natural-language change is routed to
 `revision_state start --run <accepted-material-run>` and `revision/route.md`. It is not a second visual

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -62,6 +62,8 @@ type ParsedArgs = {
   readonly follow: boolean;
   /** Emit the Run Source markup that reuses these Records instead of listing them. */
   readonly pin: boolean;
+  /** Omit this Build's requested Targets from history and generated pin markup. */
+  readonly excludeTargets: boolean;
   readonly maxWaitMs: number | undefined;
   readonly record: string | undefined;
   readonly output: string | undefined;
@@ -127,6 +129,7 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
   let runtime: string | undefined;
   let follow = false;
   let pin = false;
+  let excludeTargets = false;
   let maxWaitMs: number | undefined;
   let record: string | undefined;
   let output: string | undefined;
@@ -292,6 +295,10 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
       pin = true;
       continue;
     }
+    if (item === "--exclude-targets") {
+      excludeTargets = true;
+      continue;
+    }
     if (item === "--max-wait-ms") {
       const value = rest[index + 1];
       if (value === undefined || value.startsWith("--")) throw new Error("--max-wait-ms requires milliseconds");
@@ -349,6 +356,7 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
     runtime,
     follow,
     pin,
+    excludeTargets,
     maxWaitMs,
     record,
     output,
@@ -417,7 +425,7 @@ function assertCommandOptions(args: ParsedArgs): void {
     case "history":
     case "inspect":
       add("--runtime");
-      if (args.command === "history") add("--source", "--pin");
+      if (args.command === "history") add("--source", "--pin", "--exclude-targets");
       break;
     case "check":
     case "plan":
@@ -456,7 +464,7 @@ function usage(): string {
     "  hypit build <run-source> [--runtime profile.json] [--workspace workspace] [--asset-root directory] [--follow]",
     "  hypit status <build-id> [--runtime profile.json] [--watch]",
     "  hypit builds [--runtime profile.json]",
-    "  hypit history [source-output-name] [--runtime profile.json] [--source author.svml] [--pin]",
+    "  hypit history [source-output-name] [--runtime profile.json] [--source author.svml] [--pin] [--exclude-targets]",
     "  hypit inspect <build-id> [--runtime profile.json]",
     "  hypit get <build-id> [--runtime profile.json] [--name source-name|--record record-id|--output logical-output-id|--artifact digest] [--to path]",
     "  hypit cancel <build-id> [--runtime profile.json] [--reason text]",
@@ -900,6 +908,9 @@ export async function runCli(
     throw new Error("history requires an output name or --source path");
   }
   assertCommandOptions(args);
+  if (args.excludeTargets && !args.pin) {
+    throw new Error("--exclude-targets requires history --pin");
+  }
   const runtimeController = async (profile: string, source?: string): Promise<CliRuntimeController> => {
     const workspaceRoot = args.workspaceRoot
       ?? selectedRuntimeProjectRoot
@@ -1338,24 +1349,37 @@ export async function runCli(
           }));
       } else if (args.command === "history") {
         const catalogs = await runtime.builds();
-        const entries = (await Promise.all(catalogs.map(async (catalog) => {
-          if (args.source !== undefined && catalog.source.path !== args.source) return [];
-          if (args.file !== undefined && !catalog.aliases.some((alias) => alias.name === args.file)) return [];
+        const history = await Promise.all(catalogs.map(async (catalog) => {
+          if (args.source !== undefined && catalog.source.path !== args.source) {
+            return { entries: [], targetNames: [] };
+          }
+          if (args.file !== undefined && !catalog.aliases.some((alias) => alias.name === args.file)) {
+            return { entries: [], targetNames: [] };
+          }
           const status = await runtime.status(catalog.build);
-          if (status.build === undefined) return [];
-          return acceptedArchivedOutputs(status.build.state, catalog)
-            .filter((output) => args.file === undefined || output.name === args.file)
-            .map((output) => ({
-              build: catalog.build,
-              createdAt: catalog.createdAt,
-              status: status.dispatch === undefined
-                ? status.build!.state.status
-                : submissionStatus(status.dispatch),
-              source: catalog.source,
-              ...(catalog.run === undefined ? {} : { run: catalog.run }),
-              output,
-            }));
-        }))).flat()
+          if (status.build === undefined) return { entries: [], targetNames: [] };
+          const targetOutputs = new Set(status.build.state.request.targets.map((target) => target.output));
+          return {
+            targetNames: catalog.aliases
+              .filter((alias) => alias.ref.kind === "logical-output" && targetOutputs.has(alias.ref.id))
+              .map((alias) => alias.name),
+            entries: acceptedArchivedOutputs(status.build.state, catalog)
+              .filter((output) => args.file === undefined || output.name === args.file)
+              .map((output) => ({
+                build: catalog.build,
+                createdAt: catalog.createdAt,
+                status: status.dispatch === undefined
+                  ? status.build!.state.status
+                  : submissionStatus(status.dispatch),
+                source: catalog.source,
+                ...(catalog.run === undefined ? {} : { run: catalog.run }),
+                output,
+              })),
+          };
+        }));
+        const targetNames = new Set(history.flatMap((item) => item.targetNames));
+        const entries = history.flatMap((item) => item.entries)
+          .filter((entry) => !args.excludeTargets || !targetNames.has(entry.output.name))
           .sort((left, right) => right.createdAt - left.createdAt
             || left.output.name.localeCompare(right.output.name)
             || left.build.localeCompare(right.build));

--- a/packages/video-cli/README.md
+++ b/packages/video-cli/README.md
@@ -17,7 +17,7 @@ hypit plan build.svrun
 hypit build build.svrun --follow
 hypit status <build-id> --watch
 hypit builds
-hypit history [source-output-name] [--source ./main.svml]
+hypit history [source-output-name] [--source ./main.svml] [--pin] [--exclude-targets]
 hypit inspect <build-id>
 hypit get <build-id> --name final.video --to ./final.mp4
 hypit cancel <build-id>


### PR DESCRIPTION
## Summary
- add `history --pin --exclude-targets` for Studio-safe accepted Record markup
- exclude Target names across matching Build history so older records cannot reintroduce an opaque final media Target
- document separate Build and Studio Run responsibilities

## Validation
- `pnpm check`
- `node --import tsx --test packages/cli/test/pin.test.ts`
- `git diff --check`

No new tests were added.