### PR TITLE
Fix spatial test manifest closures

### DIFF
--- a/packages/audio-track/test/audio-track.test.ts
+++ b/packages/audio-track/test/audio-track.test.ts
@@ -37,6 +37,7 @@ import { temporalProducers } from "@hypit/temporal";
 import { speechEvidenceManifest } from "@hypit/speech-evidence";
 import { speechManifest } from "@hypit/speech";
 import { spatialManifest } from "@hypit/spatial";
+import { svsManifest } from "@hypit/svs";
 import { temporalManifest } from "@hypit/temporal";
 import { MarkupSurfaceRegistry, createMarkupAuthorFrontend } from "@hypit/markup";
 import { createRecordAdmitter, TypeValidatorRegistry } from "@hypit/validation";
@@ -278,6 +279,7 @@ test("the self-described Audio Surface parses into the same finite Producer grap
     narrativeManifest,
     programSpaceManifest,
     speechManifest,
+    svsManifest,
     spatialManifest,
     speechEvidenceManifest,
     semanticTrackManifest,

--- a/packages/composition/test/track.test.ts
+++ b/packages/composition/test/track.test.ts
@@ -15,6 +15,7 @@ import { programSpaceManifest, sealProgramSpace } from "@hypit/program-space";
 import { speechManifest } from "@hypit/speech";
 import { speechEvidenceManifest } from "@hypit/speech-evidence";
 import { spatialManifest } from "@hypit/spatial";
+import { svsManifest } from "@hypit/svs";
 import { VISUAL_IR_V1, visualIrManifest } from "@hypit/visual-ir";
 
 import {
@@ -30,7 +31,7 @@ import {
 import type { VisualTrack } from "../src/index.js";
 
 const videoContractManifests = [artifactManifest, narrativeManifest, mediaManifest, programSpaceManifest,
-  speechManifest, speechEvidenceManifest, spatialManifest, visualIrManifest, compositionManifest] as const;
+  speechManifest, speechEvidenceManifest, svsManifest, spatialManifest, visualIrManifest, compositionManifest] as const;
 
 const font: FontArtifactRef = {
   sources: [{ artifact: { kind: "blob", digest: fixtureDigest("track:test-font"), size: 1_024, mediaType: "font/woff2" } }],

--- a/packages/film/test/surface.test.ts
+++ b/packages/film/test/surface.test.ts
@@ -25,7 +25,7 @@ import {
   filmTypes,
 } from "@hypit/film";
 import type { ModuleManifest } from "@hypit/protocol";
-import { svsFrontend, svsManifest } from "@hypit/svs";
+import { svsFrontend } from "@hypit/svs";
 import {
   decodeCanvasSurface,
   spatialManifest,
@@ -74,7 +74,6 @@ const audio = sealAudioTrack({ programSpaceId: "test-space",
 
 const closure = createResolvedClosure([
   ...videoContractManifests,
-  svsManifest,
   fixtureManifest,
   filmManifest,
 ]);

--- a/packages/gpt-image/test/broll-graph.test.ts
+++ b/packages/gpt-image/test/broll-graph.test.ts
@@ -41,6 +41,7 @@ import {
 } from "@hypit/seedance";
 import { speechManifest } from "@hypit/speech";
 import { spatialManifest } from "@hypit/spatial";
+import { svsManifest } from "@hypit/svs";
 import { textManifest } from "@hypit/text";
 
 const image = (name: string) => ({
@@ -63,6 +64,7 @@ function fixture() {
     mediaManifest,
     programSpaceManifest,
     spatialManifest,
+    svsManifest,
     speechManifest,
     seedanceManifest,
   ];

--- a/packages/screen-overlay/test/screen-overlay.test.ts
+++ b/packages/screen-overlay/test/screen-overlay.test.ts
@@ -33,6 +33,7 @@ import { semanticTrackDependency, semanticTrackManifest, semanticTrackProducers,
 import { speechEvidenceManifest } from "@hypit/speech-evidence";
 import { speechManifest } from "@hypit/speech";
 import { sealCanvasSpace, spatialComponent, spatialDependency, spatialManifest, spatialTypes } from "@hypit/spatial";
+import { svsManifest } from "@hypit/svs";
 import { temporalManifest, temporalProducers } from "@hypit/temporal";
 import { MarkupSurfaceRegistry, createMarkupAuthorFrontend } from "@hypit/markup";
 import { createRecordAdmitter, TypeValidatorRegistry } from "@hypit/validation";
@@ -158,6 +159,7 @@ test("the self-described Screen Surface parses into a finite peer-Track graph", 
     speechEvidenceManifest,
     semanticTrackManifest,
     spatialManifest,
+    svsManifest,
     temporalManifest,
     visualIrManifest,
     compositionManifest,

--- a/test/support/video-domain.ts
+++ b/test/support/video-domain.ts
@@ -7,6 +7,7 @@ import { semanticTrackManifest } from "@hypit/semantic-track";
 import { spatialComponent, spatialManifest } from "@hypit/spatial";
 import { speechManifest } from "@hypit/speech";
 import { speechEvidenceManifest } from "@hypit/speech-evidence";
+import { svsManifest } from "@hypit/svs";
 import { temporalManifest } from "@hypit/temporal";
 import { visualIrManifest } from "@hypit/visual-ir";
 
@@ -18,6 +19,7 @@ export const videoContractManifests = [
   programSpaceManifest,
   speechManifest,
   speechEvidenceManifest,
+  svsManifest,
   semanticTrackManifest,
   spatialManifest,
   temporalManifest,


### PR DESCRIPTION
## Summary\n- include the newly required SVS manifest in existing spatial test closures\n- avoid duplicate SVS registration in the Film fixture\n\n## Verification\n- targeted tests: 28 passed\n- git diff --check\n\nThis is a minimal CI repair; no new tests were added.