### PR TITLE
Remove duplicate SVS test manifests

### DIFF
--- a/packages/film/test/film.test.ts
+++ b/packages/film/test/film.test.ts
@@ -29,7 +29,6 @@ import {
 import { appendFilmAudioTrack, appendFilmVisualTrack, compileFilmComposition, createFilmAssemblyFragment, createFilmTrackSet, filmManifest, filmProducers, filmTypes, sealFilmProgram } from "@hypit/film";
 import { compileHyperframesDocument, hyperframesDocumentFragment, hyperframesManifest, hyperframesProducers, hyperframesTypes } from "@hypit/hyperframes";
 import type { CanonicalValue, CompiledGraph, StoredValue, TypedRecord } from "@hypit/protocol";
-import { svsManifest } from "@hypit/svs";
 import { textManifest } from "@hypit/text";
 import { renderTypographyTrack, sealTypographyTrackProgram, stillTextMotion, typographyTrackFragment, typographyTrackManifest, typographyTrackProducers, typographyTrackTypes } from "@hypit/typography-track";
 import type { TextStyle } from "@hypit/typography-track";
@@ -129,7 +128,6 @@ function stored(value: CanonicalValue): StoredValue {
 
 const closure = createResolvedClosure([
   ...videoContractManifests,
-  svsManifest,
   hyperframesManifest,
   textManifest,
   filmManifest,

--- a/packages/render-hyperframes/test/render.test.ts
+++ b/packages/render-hyperframes/test/render.test.ts
@@ -82,7 +82,6 @@ import {
   semanticTrackDependency,
   semanticTrackTypes,
 } from "@hypit/semantic-track";
-import { svsManifest } from "@hypit/svs";
 
 const space = sealProgramSpace({ id: "test-space", narrativeId: "test-narrative",
   durationSec: 2,
@@ -107,7 +106,6 @@ const closure = createResolvedClosure([
   hyperframesManifest,
   mediaPipelineManifest,
   renderHyperframesManifest,
-  svsManifest,
 ]);
 const compositionRecord = await admitRecord(closure, sealRecord({
   id: "composition",
@@ -341,7 +339,6 @@ test("the final rendered video is an ordinary BlobArtifact that can feed another
     mediaPipelineManifest,
     renderHyperframesManifest,
     fixtureManifest,
-    svsManifest,
   ]);
   const surfaces = new MarkupSurfaceRegistry();
   surfaces.registerStructured({ module: fixtureModule, declaration: fixtureSurface, handler: ({ element }) => ({

--- a/packages/typography-track/test/typography-track.test.ts
+++ b/packages/typography-track/test/typography-track.test.ts
@@ -341,7 +341,6 @@ test("the self-described Markup Surfaces compile Style, Motion and all three spa
   };
   const closure = createResolvedClosure([
     ...videoContractManifests,
-    svsManifest,
     textManifest,
     typographyTrackManifest,
     fixtureManifest,
@@ -620,7 +619,7 @@ test("a paragraph's source indentation is not part of its words", async () => {
     types: [], capabilities: [], producers: [],
   };
   const closure = createResolvedClosure([
-    ...videoContractManifests, svsManifest, textManifest, typographyTrackManifest, fixtureManifest,
+    ...videoContractManifests, textManifest, typographyTrackManifest, fixtureManifest,
   ]);
   const surfaces = new MarkupSurfaceRegistry();
   surfaces.registerStructured({ module: fixtureModule, declaration: fixtureSurface, handler: ({ element }) => ({


### PR DESCRIPTION
## Summary\n- remove duplicate SVS manifest entries now covered by the shared video test fixture\n- fix Film, HyperFrames, and Typography test closures\n\n## Verification\n- targeted tests: 14 passed\n- git diff --check\n\nMinimal CI repair; no new tests added.