### PR TITLE
fix: repair CI runtime and pinned run checks

### DIFF
--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -64,6 +64,9 @@ Before Source is accepted, every route must complete persisted vocabulary inspec
 directory, and
 `validate_script_cues` (maximum four visible words per Cue). `preview_check` and the route's final
 check repeat these gates even if route-state claims they were completed.
+When a Run contains accepted `build-record` pins, pass its Runtime Profile to
+`validate_local_author_packages`, `preview_check`, `layout_check` and the final check so the archive
+can resolve those Records before any graph or layout result is trusted.
 
 Agent-boundary constraint: do not read or rely on the memory of Codex, Claude Code, or any other
 coding agent.

--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -55,7 +55,9 @@ Temporary branch constraint: do not select, use or read the installed `@hypit/ra
 its declarations, README, examples or source on this branch. If a request needs a ranking-like
 visual system, choose another applicable installed capability or treat the requirement as a genuine
 gap and use the formal project-local package workflow from the visible requirement. Do not copy,
-vendor or modify `@hypit/ranking`.
+vendor or modify `@hypit/ranking`. This is an internal routing constraint: do not tell the author
+that a choice was made because of the skill or this constraint. Present the chosen alternative or
+new local component as the normal production decision, with its practical rationale when useful.
 
 Before Source is accepted, every route must complete persisted vocabulary inspection,
 `validate_local_author_packages` for every project-owned package under the project's `packages/`

--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -51,6 +51,12 @@ After any new turn, interruption, or context compaction, read
 before continuing. Never resume from chat memory alone, and never repeat a completed or paid step
 without verifying its durable evidence.
 
+Temporary branch constraint: do not select, use or read the installed `@hypit/ranking` package or
+its declarations, README, examples or source on this branch. If a request needs a ranking-like
+visual system, choose another applicable installed capability or treat the requirement as a genuine
+gap and use the formal project-local package workflow from the visible requirement. Do not copy,
+vendor or modify `@hypit/ranking`.
+
 Before Source is accepted, every route must complete persisted vocabulary inspection,
 `validate_local_author_packages` for every project-owned package under the project's `packages/`
 directory, and

--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -65,6 +65,9 @@ directory, and
 `validate_script_cues` (maximum four visible words per Cue). `preview_check` and the route's final
 check repeat these gates even if route-state claims they were completed.
 
+Agent-boundary constraint: do not read or rely on the memory of Codex, Claude Code, or any other
+coding agent.
+
 Do not create or hand-author SVG images anywhere in an author project or project-local package.
 This includes `.svg` assets, inline `<svg>` markup, and SVG data URLs.
 

--- a/.agents/skills/hypit/references/credentials.md
+++ b/.agents/skills/hypit/references/credentials.md
@@ -43,7 +43,7 @@ $env:GOOGLE_APPLICATION_CREDENTIALS_JSON = Get-Content -Raw "$HOME\.config\hypit
 
 Keep keys outside Author/Run/Runtime source and committed files. Verify presence without printing
 values with, for example,
-`node .agents/skills/hypit/scripts/check-credentials.mjs KIE_API_KEY MIMO_API_KEY`, then run
+`node <skill-root>/scripts/check-credentials.mjs KIE_API_KEY MIMO_API_KEY`, then run
 `hypit doctor` (once a Runtime Profile is selected with `hypit runtime use hypit.runtime.json`;
 doctor audits the selected profile, so it needs no profile argument of its own).
 

--- a/.agents/skills/hypit/references/environment.md
+++ b/.agents/skills/hypit/references/environment.md
@@ -59,6 +59,9 @@ them as the selected launchers above. Do not globally link the checkout, use `np
 dependencies into an author project. Run reference-video-tool commands that share reference state
 from the same working directory, even though their launcher lives in the checkout.
 
+When a reference names `<skill-root>`, substitute the installed Hypit skill directory (the directory
+containing `SKILL.md` and `scripts/`); it is not relative to the author's project or checkout.
+
 If neither an installed CLI nor a contributor checkout is available, report that no runnable Hypit
 Distribution is present and stop. A registry install is not a recovery path.
 
@@ -109,8 +112,9 @@ WhisperX, for example, lives under `programs/whisperx/`; OpenCV under
 `programs/image-opencv/`. Service process records and logs live with the program. Project Build and
 Worker state remains under `<project>/.hypit/`.
 
-Reference-video state sits beside the Distribution, at `.hypit/reference-video-tools/<reference-id>/`,
-wherever the command is run from. It is keyed by the video, so two reconstructions of one file share
+Reference-video state sits beside the Distribution, at `.hypit/reference-video-tools/<reference-id>/`.
+Commands may run from any directory; the tool locates this canonical state from the selected
+Distribution. It is keyed by the video, so two reconstructions of one file share
 the observations it cost money to make; each command reports the root it used.
 
 This split is why opening a second project cannot install WhisperX again, and why updating the npm

--- a/.agents/skills/hypit/references/environment.md
+++ b/.agents/skills/hypit/references/environment.md
@@ -52,12 +52,24 @@ Then use the checkout entrypoints directly for the rest of the route:
 ```text
 node <checkout>/bin/hypit.mjs paths --json
 node <checkout>/packages/reference-video-tools/bin/reference-video-tools.mjs <subcommand> ...
+node <checkout>/bin/hypit-studio.mjs --run <run> [--runtime <hypit.runtime.json>]
+node <checkout>/bin/hypit-preview-check.mjs <run> [<hypit.runtime.json>]
 ```
 
-In every reference that abbreviates these as `hypit` and `hypit-reference-video-tools`, interpret
-them as the selected launchers above. Do not globally link the checkout, use `npx hypit`, or install
-dependencies into an author project. Run reference-video-tool commands that share reference state
-from the same working directory, even though their launcher lives in the checkout.
+In every reference that abbreviates these as `hypit`, `hypit-reference-video-tools`,
+`hypit-studio` or `hypit-preview-check`, interpret them as the selected launchers above:
+
+| Abbreviation | Contributor checkout launcher |
+|---|---|
+| `hypit` | `node <checkout>/bin/hypit.mjs` |
+| `hypit-reference-video-tools` | `node <checkout>/packages/reference-video-tools/bin/reference-video-tools.mjs` |
+| `hypit-studio` | `node <checkout>/bin/hypit-studio.mjs` |
+| `hypit-preview-check` | `node <checkout>/bin/hypit-preview-check.mjs` |
+
+Do not interpret `hypit-studio` as a `studio` subcommand of `hypit`: Studio is a separate entrypoint.
+Do not globally link the checkout, use `npx hypit`, or install dependencies into an author project.
+Run reference-video-tool commands that share reference state from the same working directory, even
+though their launcher lives in the checkout.
 
 When a reference names `<skill-root>`, substitute the installed Hypit skill directory (the directory
 containing `SKILL.md` and `scripts/`); it is not relative to the author's project or checkout.

--- a/.agents/skills/hypit/references/layout-checks.md
+++ b/.agents/skills/hypit/references/layout-checks.md
@@ -3,8 +3,12 @@
 Run this after `preview_check` whenever Source, SVS, runtime, fonts or a package can affect layout:
 
 ```bash
-hypit-reference-video-tools layout_check --run <build.svrun>
+hypit-reference-video-tools layout_check --run <build.svrun> [--runtime <hypit.runtime.json>]
 ```
+
+Pass the project's Runtime Profile when the Run contains `build-record` pins. The checker uses it
+read-only to resolve those accepted Records; without it a pinned Run can fail before any layout is
+measured.
 
 The command does not render media, call a visual observer or invoke a paid Provider. It first realizes
 the same preview-mock Run and Producer-generated Composition that the later visual render reuses, then
@@ -30,7 +34,7 @@ real problem or accept the intentional geometry:
 ```bash
 hypit-reference-video-tools layout_accept --run <build.svrun> \
   --finding <id> --reason '<why this measured relationship is correct here>'
-hypit-reference-video-tools layout_check --run <build.svrun>
+hypit-reference-video-tools layout_check --run <build.svrun> [--runtime <hypit.runtime.json>]
 ```
 
 Several candidates from the same report can be accepted atomically with a JSON array (or an object

--- a/.agents/skills/hypit/references/local-author-package.md
+++ b/.agents/skills/hypit/references/local-author-package.md
@@ -100,6 +100,22 @@ A filled media slot arrives in `inputs` as the `BlobRef` itself, not wrapped inl
 authored value is, so read its `mediaType` off the Artifact rather than assuming what the slot's name
 suggests.
 
+## Decoder and runtime value shapes
+
+The Style decoder receives a decoded recipe as `{ path, properties }`: `path` is the authored recipe
+id and `properties` is the canonical property map. A resolved authored reference may expose its
+record; only read an inline value after checking `record.value.kind === "inline"`, then use
+`record.value.value`. Never infer a value from the reference path.
+
+The temporal-markup helpers take one object `{ id, subjectId?, element, semantic, resolveReference }`
+and return `records`, `components` and `fragments` collections to append to the Surface result. The resulting
+`TemporalInstant` carries `frame`; a `TemporalWindow` carries `span` with `startFrame` and
+`endFrameExclusive`.
+
+`SpatialFrame` uses `xPx`, `yPx`, `widthPx` and `heightPx`; `ProgramSpace` provides `id`,
+`narrativeId`, `durationSec` and `frameRate` (`numerator` and `denominator`). A `fonts:Stack` Surface publishes a
+`FontStackRef`; pass that same record to a Visual IR text element's `fonts` field.
+
 ## Package boundary
 
 Place the package at `<project>/packages/<slug>/`, named in the project's own scope such as
@@ -159,6 +175,11 @@ Implement the parts required by the behavior, including:
 Choose raw versus structured Surface, timing dependencies, ProgramSpace, Frame, SemanticTrack,
 Artifact, Recipe and output Types from the observed behavior and the anatomy the guide states. A
 declaration-only or Surface-only package is incomplete.
+
+For variable child counts, emit one Fragment operation per child and pass those fixed-port results
+to an append/merge Producer (for example `head`, `item`, `tail`). Do not add an undeclared
+`items[]` input or let a handler consume arbitrary children; every child must be represented by a
+sealed operation.
 
 ## The package draws itself
 
@@ -223,6 +244,12 @@ nothing.
   middle frame of the target Present's longest stable interval in the fixed local browser. It does
   not render a complete PNG sequence; when no interval is stable for two frames, it uses the middle
   frame of the longest Present.
+
+For a media slot, declare an Artifact Fragment input and read the BlobRef from `inputs`. Branch on
+its `mediaType` (`image/*` or `video/*`) when choosing the Visual IR element, and still draw the
+empty frame/cell when no material is supplied. `hypit image` uses the selected Runtime Profile's
+image endpoint and is billed; obtain approval before using it and reserve it for package-owned
+chrome, never video content or previews.
 
 ## Freeze the Types before writing in parallel
 

--- a/.agents/skills/hypit/references/local-author-package.md
+++ b/.agents/skills/hypit/references/local-author-package.md
@@ -108,9 +108,10 @@ record; only read an inline value after checking `record.value.kind === "inline"
 `record.value.value`. Never infer a value from the reference path.
 
 The temporal-markup helpers take one object `{ id, subjectId?, element, semantic, resolveReference }`
-and return `records`, `components` and `fragments` collections to append to the Surface result. The resulting
-`TemporalInstant` carries `frame`; a `TemporalWindow` carries `span` with `startFrame` and
-`endFrameExclusive`.
+and return `records`, `components`, `fragments` and a component-output `ref`. The resulting
+`TemporalInstant` has `{ id, subjectId, source, projection, authority, frame }`; a
+`TemporalWindow` has `{ id, subjectId, start, end, span }`, where each endpoint is a
+`TemporalInstant` and `span` has `startFrame` and `endFrameExclusive`.
 
 `SpatialFrame` uses `xPx`, `yPx`, `widthPx` and `heightPx`; `ProgramSpace` provides `id`,
 `narrativeId`, `durationSec` and `frameRate` (`numerator` and `denominator`). A `fonts:Stack` Surface publishes a
@@ -176,26 +177,14 @@ Choose raw versus structured Surface, timing dependencies, ProgramSpace, Frame, 
 Artifact, Recipe and output Types from the observed behavior and the anatomy the guide states. A
 declaration-only or Surface-only package is incomplete.
 
-For variable child counts, emit one Fragment operation per child and pass those fixed-port results
-to an append/merge Producer (for example `head`, `item`, `tail`). Do not add an undeclared
-`items[]` input or let a handler consume arbitrary children; every child must be represented by a
-sealed operation.
+For variable child counts, emit one child operation per child and chain those fixed-port results
+through an append Producer (`previous`, `item` → `set`). Do not add an undeclared `items[]` input or
+let a handler consume arbitrary children; every child must be represented by a sealed operation.
 
-```typescript
-const childOps = children.map((child, index) => ({
-  id: `child-${index}`, producer: childProducer,
-  inputs: { value: childInput(child) },
-  result: { kind: "output", name: `child-${index}` },
-}));
-const merge = {
-  id: "merge", producer: appendProducer,
-  inputs: { head: childOps[0]!, item: childOps[1]!, tail: childOps[2]! },
-  result: { kind: "output", name: "items" },
-};
-```
-
-The real implementation repeats the fixed operation shape for the actual child count and uses the
-package's documented empty/one/many merge forms; the handler never accepts undeclared variadic input.
+The fixture's `exampleAppendFragment` and `append-example-items` Producer are the runnable reference:
+each operation has exactly `previous` and `item` inputs and returns `set`, so the returned set can be
+fed into the next operation. The empty set is an ordinary typed Record. The handler never accepts
+undeclared variadic input.
 
 ## The package draws itself
 
@@ -261,15 +250,17 @@ nothing.
   not render a complete PNG sequence; when no interval is stable for two frames, it uses the middle
   frame of the longest Present.
 
-For a media slot, declare an Artifact Fragment input and read the BlobRef from `inputs`. Branch on
-its `mediaType` (`image/*` or `video/*`) when choosing the Visual IR element, and still draw the
-empty frame/cell when no material is supplied. `hypit image` uses the selected Runtime Profile's
-image endpoint and is billed; obtain approval before using it and reserve it for package-owned
-chrome, never video content or previews.
+For a media slot, declare an Artifact Fragment input. Producer inputs are `TypedRecord`s: inspect
+`inputs.media.value`; a filled slot is a BlobRef (`kind === "blob"`), while an authored structured
+value is under `kind === "inline"`. Branch on BlobRef `mediaType` (`image/*` or `video/*`) when
+choosing the Visual IR element, and still draw the empty frame/cell when no material is supplied.
+`hypit image` is a direct, billed KIE image-model call (default `@hypit/gpt-image`, credential
+`KIE_API_KEY`); it does not use a project Runtime Profile, Build or Run Source. Obtain approval
+before using it and reserve it for package-owned chrome.
 
 ```typescript
 handler: ({ inputs }) => {
-  const media = inputs.media?.kind === "blob" ? inputs.media : undefined;
+  const media = inputs.media?.value.kind === "blob" ? inputs.media.value : undefined;
   const kind = media?.mediaType.startsWith("video/") ? "video" : "image";
   return { outputs: { track: output(renderSlot(kind, media)) }, needs: {} };
 }

--- a/.agents/skills/hypit/references/local-author-package.md
+++ b/.agents/skills/hypit/references/local-author-package.md
@@ -181,6 +181,22 @@ to an append/merge Producer (for example `head`, `item`, `tail`). Do not add an 
 `items[]` input or let a handler consume arbitrary children; every child must be represented by a
 sealed operation.
 
+```typescript
+const childOps = children.map((child, index) => ({
+  id: `child-${index}`, producer: childProducer,
+  inputs: { value: childInput(child) },
+  result: { kind: "output", name: `child-${index}` },
+}));
+const merge = {
+  id: "merge", producer: appendProducer,
+  inputs: { head: childOps[0]!, item: childOps[1]!, tail: childOps[2]! },
+  result: { kind: "output", name: "items" },
+};
+```
+
+The real implementation repeats the fixed operation shape for the actual child count and uses the
+package's documented empty/one/many merge forms; the handler never accepts undeclared variadic input.
+
 ## The package draws itself
 
 A package is installed vocabulary. `.svml`, `.svs` and `.svrun` are documents that use it. A package
@@ -250,6 +266,14 @@ its `mediaType` (`image/*` or `video/*`) when choosing the Visual IR element, an
 empty frame/cell when no material is supplied. `hypit image` uses the selected Runtime Profile's
 image endpoint and is billed; obtain approval before using it and reserve it for package-owned
 chrome, never video content or previews.
+
+```typescript
+handler: ({ inputs }) => {
+  const media = inputs.media?.kind === "blob" ? inputs.media : undefined;
+  const kind = media?.mediaType.startsWith("video/") ? "video" : "image";
+  return { outputs: { track: output(renderSlot(kind, media)) }, needs: {} };
+}
+```
 
 ## Freeze the Types before writing in parallel
 

--- a/.agents/skills/hypit/references/local-author-package.md
+++ b/.agents/skills/hypit/references/local-author-package.md
@@ -284,8 +284,12 @@ is expensive to read.
 Before Source can be considered authored, run:
 
 ```bash
-hypit-reference-video-tools validate_local_author_packages --run <path/to/build.svrun>
+hypit-reference-video-tools validate_local_author_packages --run <path/to/build.svrun> [--runtime <hypit.runtime.json>]
 ```
+
+When the Run contains `build-record` pins, pass the same Runtime Profile used by the Build. The
+validator opens that profile read-only so it can resolve accepted Records while compiling the Run;
+otherwise a valid project package may be reported as imported but unused.
 
 Every project-owned author package under `<project>/packages/` must expose a non-empty Manifest, at least one
 Markup Surface and at least one Producer. Its Surface decoder must expand to a real Graph Fragment with

--- a/.agents/skills/hypit/references/original-authoring/route.md
+++ b/.agents/skills/hypit/references/original-authoring/route.md
@@ -47,9 +47,9 @@ interruption or context compaction, read `../recovery.md`, run `route_state --ac
 | `environment` | explicit checkpoint after Distribution, project and credentials are selected | `hypit paths --json` |
 | `brief-frozen` | explicit checkpoint naming the frozen brief, audience, format and claims | return to the brief checkpoint |
 | `vocabulary-checked` | Run-scoped vocabulary inspection and the frozen `.hypit/component-fit.json` are both persisted | `inspect_svml_vocabulary --run <run>` |
+| `source-authored` | explicit checkpoint naming `main.svml` (and Recipe/Run when available) | `hypit check <run>` |
 | `package-ready` | every project-owned package under `packages/` has a real Surface/Producer/Fragment and is used by the compiled Graph | `validate_local_author_packages --run <run>` |
 | `script-checked` | every caption Cue has at most four visible words | `validate_script_cues --run <run>` |
-| `source-authored` | explicit checkpoint naming `main.svml` (and Recipe/Run when available) | `hypit check <run>` |
 | `graph-checked` | `preview_check` returns `sound: true` after package and Cue gates | `preview_check <run>` |
 | `layout-checked` | `layout_check` executed and every candidate was repaired or explicitly accepted | `layout_check --run <run>` / `layout_accept` |
 | `review-planned` | `authoring_check` writes a plan | `authoring_check <run>` |
@@ -173,7 +173,9 @@ of them; the Runtime Profile is part of the deliverable.
 **Read now:** `../authoring.md` — the syntax authority, the check set, and how an accepted Record is
 reused in the Run Source. `../runtime.md` — how to author a Profile.
 
-Now run the persisted, Run-scoped gates before `hypit check`:
+Author the Source before validating project-local packages: `package-ready` can only be completed
+after `main.svml` and `build.svrun` compile a Graph that actually uses each package. Run the persisted,
+Run-scoped gates before `hypit check`:
 
 ```bash
 hypit-reference-video-tools inspect_svml_vocabulary --package <name> [--package …] --run build.svrun

--- a/.agents/skills/hypit/references/playbooks/craft/captions.md
+++ b/.agents/skills/hypit/references/playbooks/craft/captions.md
@@ -83,9 +83,8 @@ Recipe padding must be a string* while `radius: 0` beside it is correct, and the
 and twelve horizontal — which no JSON number can carry, so it travels as text and is split on the
 space. A single value is still written as one: `padding: "0"`.
 
-`cue-min-words` and `cue-max-words` are not read. `docs/quickstart/styles.md` and
-`docs/quickstart/composition.md` still show them; a Recipe carrying either is refused as an unknown
-property, since the Style admits exactly the required keys plus the documented optional ones.
+`cue-min-words` and `cue-max-words` are not Recipe properties. Cue length belongs to Script `||`
+boundaries and the route's `validate_script_cues` gate.
 
 ## Cue boundaries are marked in the Script, with `||`
 

--- a/.agents/skills/hypit/references/playbooks/craft/graphic-compositions.md
+++ b/.agents/skills/hypit/references/playbooks/craft/graphic-compositions.md
@@ -115,9 +115,10 @@ project that installs it to obtain a picture that was never theirs to choose. If
 writing a Run Source whose only purpose is to produce a component's own texture, the texture is in
 the wrong place: generate it once while authoring the package and commit the file.
 
-Produce that file with `hypit image --prompt <text> --to <path>`, which writes a picture and nothing
-else. A package asset is authoring input, not the output of anybody's video, so it is never a Target
-and never a Record.
+Produce that file with `hypit image --prompt <text> --to <path>`, a direct billed KIE image-model
+call (default `@hypit/gpt-image`, using `KIE_API_KEY`). It writes a picture and nothing else; no
+project Runtime Profile, Source, Run, Build or Record participates. A package asset is authoring
+input, not the output of anybody's video, so it is never a Target or Record.
 
 A package is installed vocabulary. `.svml`, `.svs` and `.svrun` are documents that use it. A package
 that needs one of those documents in order to draw itself has inverted that relationship.

--- a/.agents/skills/hypit/references/playbooks/formats/ranking-listicle.md
+++ b/.agents/skills/hypit/references/playbooks/formats/ranking-listicle.md
@@ -1,55 +1,30 @@
 # Ranking-listicle format
 
-Use one progressive Ranking component to reveal a stable ordered set while speech and evidence
-explain why every item belongs where it is placed.
+Use a progressive ranking or list to reveal an ordered set while speech and evidence explain why
+each item belongs where it is placed. The format is a narrative pattern; the concrete visual board
+comes from the vocabulary/component-fit decision, not from a required package or tag.
 
-## Author the Script schedule
+## Plan the story
 
-- Write one outer Script Selection covering the complete ranking window.
-- `ranking:TierBoard` and `ranking:TopThree` are driven by item-owned Moments: give every item its own
-  `at={story.moment.NAME}` and declare one terminal Moment for the completed board. Reveal order comes
-  from the Moments' real frame order, not from a repeated marker id.
-- `ranking:Column` is driven by its items: give each item that is not `preset` its own Script
-  Selection, and declare no Moments for it.
-- Give every item a stable id, its rank or tier, its icon or image, and one evidence beat. Copy
-  belongs to the item only where the component carries it: `ColumnItem` and `TopThreeItem` require a
-  `label`, while a `TierItem` requires an `icon` and carries no copy of its own.
+- Open with a clear question, claim or ranking criterion.
+- Give every item a stable id, an explicit order or tier, one evidence beat and a concise reveal.
+- Keep order, labels, icon/image treatment and evidence relationships stable across the list.
+- Build toward a decisive top-ranked reveal and close with the implication or CTA.
 
-## Author the SVML program
+## Author the sources
 
-1. Normalize each accepted speaking or audio-only source, create its `whisperx:SemanticTake`, then
-   assemble those Takes with `speech:Track` so Selections and Moments resolve against real audio.
-2. Declare exact font bytes and the variant's package-owned Style.
-3. Choose exactly one primary component: `ranking:TierBoard`, `ranking:Column`, or
-   `ranking:TopThree`.
-4. Connect `semantic={speech.semantic}`, the outer `during`, an explicit `frame`, the Style, and the
-   complete ordered item list. `TierBoard` and `TopThree` also take the repeated `triggers` Moment
-   and the `terminal` Moment; `Column` takes a required `canvas` instead and reads its timing from
-   each item's own `during`.
-5. Add the component's `.visual` output to `film:Film`; add its optional `.audio` output only when
-   authored sound is present.
-6. Put screenshots, demonstrations, or proof clips on a separate `media-track:Track`. Use
-   `deck:DepthStack` only as an intentional evidence treatment, not as a second ranking system.
-7. Add the full Caption pipeline when spoken words should be captioned, then render and target the
-   delivery through `.svrun`.
-
-## Write and design the list
-
-- Use setup → concrete evidence or cost → punchline for each spoken item.
-- Give higher-ranked entries stronger proof and a more decisive close, not merely a brighter color.
-- Keep row/tier vocabulary stable. Do not change layout grammar, label style, or icon logic halfway
-  through the list.
-- Keep claims verifiable. Do not invent performance numbers, votes, comparisons, or product facts.
-- Separate ranking copy from captions: item labels belong to the Ranking component; spoken dialogue
-  belongs to Script and Caption; supporting proof belongs to Media Track.
+1. Create the semantic speech chain and one outer ranking window.
+2. Declare exact fonts and the package-owned Style selected during vocabulary inspection.
+3. Use the selected ranking/list component and its documented timing/placement vocabulary; do not
+   invent attributes or copy a removed component's timing model.
+4. Connect semantic timing, the outer window, explicit placement, Style and the complete ordered
+   item set. Reveal timing must come from the component's admitted Moment/Selection inputs.
+5. Add the visual output to `film:Film`; keep proof clips or screenshots on a separate media track.
+6. Add the Caption pipeline when spoken words should be captioned, then route the delivery through
+   `.svrun`.
 
 ## Review and reuse
 
-Review the resolved trigger count and order and the terminal timing where the component uses them,
-item identity, rank/tier, labels, icon assets,
-evidence alignment, safe zones, stack order, and optional sounds. Pin accepted generated evidence
-media through `.svrun` before the final ranking Build.
-
-Read `../craft/captions.md`, `../craft/overlays.md`, `../craft/b-roll.md`, and `../craft/sfx.md`.
-
-That list is complete, and the always-read craft in `../index.md` applies regardless of format.
+Check item identity and order, reveal timing, labels, icon assets, evidence alignment, safe zones,
+stack order and optional sounds. Read `../craft/captions.md`, `../craft/overlays.md`,
+`../craft/b-roll.md` and `../craft/sfx.md`; the always-read craft in `../index.md` applies too.

--- a/.agents/skills/hypit/references/preview.md
+++ b/.agents/skills/hypit/references/preview.md
@@ -130,6 +130,9 @@ cd /path/to/project
 hypit-studio --run .hypit/preview/<digest>/preview.svrun --runtime hypit.runtime.json &
 ```
 
+`hypit-studio` is the standalone Studio launcher (`node <checkout>/bin/hypit-studio.mjs` in a
+contributor checkout), not a `studio` subcommand of `hypit`.
+
 If another Studio process is already using a different Run or startup parameters, stop that process
 before launching this command; otherwise reuse the existing process and let its Source watcher reload.
 

--- a/.agents/skills/hypit/references/preview.md
+++ b/.agents/skills/hypit/references/preview.md
@@ -35,12 +35,10 @@ The same check is also a bin of its own:
 hypit-preview-check /path/to/project/build.svrun
 ```
 
-Prefer the subcommand. It takes `--package-root <dir>`, which is where the packages the Source
-imports are resolved from — a project's own packages under `packages/<slug>/` are installed against the
-project root, so name it there and the check reaches them from wherever you are standing. Without
-the flag the working directory is used. The bare bin fixes the package root to the Run file's own
-directory and takes no flags, so reach for it when the Run sits at the project root and you want the
-prose summary rather than a JSON result.
+Prefer the subcommand. `--package-root <dir>` is needed only when the project has no `package.json`
+or when an explicit package root is desired; it changes Host package lookup, not Source Workspace.
+With a project-root `package.json`, omit it. The bare bin fixes the package root to the Run file's own
+directory and takes no flags.
 
 Either one refuses when the graph itself is wrong, and names what refused — a target that is not a
 Film or Render output of the current SVML, a Film with no traceable composition, a Film with no

--- a/.agents/skills/hypit/references/reconstruction/evidence.md
+++ b/.agents/skills/hypit/references/reconstruction/evidence.md
@@ -25,9 +25,9 @@ whole-reference observations under `observations.people_and_product`, `observati
 for compatibility. Do not mix `.text`, `.answer.text` and `.result.text` as competing conventions.
 
 A reference is found from the Distribution rather than from where you are standing, so these commands
-may be run from anywhere. What does depend on where you are is which packages resolve: name the
-project with `--package-root` when the command is not run from inside it. `paths` reports both roots
-and every prepared reference, which is what to run when a command reports something it cannot see.
+may be run from anywhere. `--package-root` only affects project package discovery when a project has
+no `package.json` of its own; it never changes the reference-state location. `paths` reports both
+roots and every prepared reference.
 
 Defaults are sufficient for normal use. Each also accepts `--input <json>`.
 

--- a/.agents/skills/hypit/references/reconstruction/observers.md
+++ b/.agents/skills/hypit/references/reconstruction/observers.md
@@ -26,7 +26,7 @@ Ask the author once, before `prepare_reference`. Report what this machine actual
 asking them to recall it:
 
 ```text
-node .agents/skills/hypit/scripts/check-credentials.mjs GOOGLE_CLOUD_PROJECT GOOGLE_APPLICATION_CREDENTIALS_JSON
+node <skill-root>/scripts/check-credentials.mjs GOOGLE_CLOUD_PROJECT GOOGLE_APPLICATION_CREDENTIALS_JSON
 ```
 
 Both variables `set` means `gemini` is available and the author chooses between the two. Either one

--- a/.agents/skills/hypit/references/reconstruction/route.md
+++ b/.agents/skills/hypit/references/reconstruction/route.md
@@ -87,9 +87,9 @@ of intent; files and check results remain the authority.
 | `reference-prepared` | checkpoint after `prepare_reference` reports ready `state.json` | `prepare_reference` or `route_state reconcile` |
 | `reference-observed` | explicit observer checkpoint; all required observation answers are complete | `observe_reference` / `record_observation` |
 | `vocabulary-checked` | Run-scoped vocabulary inspection and the frozen `.hypit/component-fit.json` are both persisted | `inspect_svml_vocabulary --run <run>` |
+| `source-authored` | explicit checkpoint naming `main.svml` (and Recipe/Run when available) | `hypit check <run>` |
 | `package-ready` | every project-owned package under `packages/` has a real Surface/Producer/Fragment and is used by the compiled Graph | `validate_local_author_packages --run <run>` |
 | `script-checked` | every caption Cue has at most four visible words | `validate_script_cues --run <run>` |
-| `source-authored` | explicit checkpoint naming `main.svml` (and Recipe/Run when available) | `hypit check <run>` |
 | `graph-checked` | `preview_check` returns `sound: true` after package and Cue gates | `preview_check <run>` |
 | `layout-checked` | `layout_check` executed and every candidate was repaired or explicitly accepted | `layout_check --run <run>` / `layout_accept` |
 | `review-planned` | `reconstruction_check` writes a plan | `reconstruction_check <run>` |
@@ -297,7 +297,9 @@ Write `main.svml`, `recipes.svs` and `build.svrun`, then extend the existing `hy
 every capability those Sources reach. The Runtime Profile is part of the deliverable: without it the
 first thing the author meets is `RUNTIME_CAPABILITY_UNBOUND`.
 
-Now persist the Run-scoped half of the frozen vocabulary decision. This completes
+Author the Source before validating project-local packages: `package-ready` can only be completed
+after `main.svml` and `build.svrun` compile a Graph that actually uses each package. Now persist the
+Run-scoped half of the frozen vocabulary decision. This completes
 `vocabulary-checked` only when `.hypit/component-fit.json` remains valid:
 
 ```bash

--- a/.agents/skills/hypit/references/reconstruction/route.md
+++ b/.agents/skills/hypit/references/reconstruction/route.md
@@ -31,7 +31,7 @@ as a generation:
 
 ```svml
 <copy:Value id="meme-look">A screenshot of a vertical social-media post…</copy:Value>
-<gpt:Image id="meme-shot" prompt={meme-look} aspect-ratio="4:5" resolution="2K"/>
+<gpt:Image id="meme-shot" prompt={meme-look} aspect-ratio="9:16" resolution="2K"/>
 ```
 
 Writing `<media:Image src="./assets/meme.png"/>` instead spends money this route does not spend, and

--- a/.agents/skills/hypit/references/runtime.md
+++ b/.agents/skills/hypit/references/runtime.md
@@ -43,6 +43,9 @@ lanes or the lane numbers are a ceiling nothing reaches. Name the lane by the ex
 Source reaches — `seedance-2-mini` and `gpt-image-2` above — since a lane key that matches no
 capability is silently inert. Read the Provider's README for the lane names it admits.
 
+Provider-specific input limits are also part of preflight. For the KIE GPT Image 2 route, do not
+submit `4:3`, `3:4` or `4:5`; the route rejects those aspect ratios before upload or paid submission.
+
 The local Providers stay small: `media`, `whisperx` and `hyperframes` are bounded by this machine's
 cores rather than by a remote queue, and raising them buys contention.
 

--- a/.agents/skills/hypit/references/runtime.md
+++ b/.agents/skills/hypit/references/runtime.md
@@ -180,10 +180,8 @@ Relative Author Sources and assets stay inside the independently resolved Source
 
 - `--workspace` explicitly selects the Source Workspace boundary.
 - `--package-root` only changes where the Host locates installed packages. It does not widen Source
-  access. Reach for it when a project you did not create has no `package.json` of its own: `check`,
-  `plan` and `build` walk up from the project until one appears, so a project without one resolves
-  its packages against an ancestor directory, and a project package resolves to nothing. Run those
-  commands with `--package-root .` from the project, or write the project the `package.json`
-  `environment.md` describes and drop the flag.
+  access. With a `package.json` at the project root, omit it. Use it when a project has no own
+  `package.json` or when explicitly selecting another package root; this never changes Source
+  Workspace resolution.
 - Do not symlink an external project into the Distribution. The external directory is the intended
   workspace, not an escape from one.

--- a/.agents/skills/hypit/references/vocabulary.md
+++ b/.agents/skills/hypit/references/vocabulary.md
@@ -94,9 +94,11 @@ it may not move an element into the wrong semantic role merely because another t
 shape. Never invent a component, attribute, child, port, Recipe property or literal value.
 
 Installed packages are immutable dependencies. Do not modify them, copy or vendor their source into
-the project, or read implementation source to discover undeclared syntax. When the fit is not good
-enough, use the project-local package route and author it from the visible requirement, inspect
-contract, README and `local-author-package.md`.
+the project, or read implementation source to discover undeclared syntax. If the author explicitly
+chooses to copy a named package as a close structural sibling, that package's README and required
+role files may be read as the bounded implementation skeleton; this is the only source-reading
+exception. When the fit is not good enough, use the project-local package route and author it from
+the visible requirement, inspect contract, README and `local-author-package.md`.
 
 ## Freeze the judgement
 

--- a/docs/guide/author-packages.md
+++ b/docs/guide/author-packages.md
@@ -19,7 +19,7 @@ must not be added to the Style record merely to describe its role.
 ## 1. Create the package
 
 ```bash
-mkdir -p packages/my-component/src packages/my-component/test
+mkdir -p packages/my-component/src
 ```
 
 ## 2. Write package.json

--- a/docs/guide/component-anatomy.md
+++ b/docs/guide/component-anatomy.md
@@ -43,9 +43,9 @@ it. A Producer that receives an unsealed value has no way to tell a mistake from
 met. The fixture's value layer is the minimal pattern; a close sibling may be used as a bounded
 implementation skeleton only after vocabulary inspection.
 
-**The Style decoder reads a Recipe, not a stylesheet.** It takes one `SvsRecipe` and the exact fonts,
-validates the keys it admits, and produces a Style value. Unknown keys fail; defaults are declared,
-not implied. Use the fixture's decoder for the generic boundary, or the selected close sibling when
+**The Style decoder reads a Recipe, not a stylesheet.** It takes one decoded `SvsRecipe` shaped as
+`{ path, properties }` and the exact fonts, validates the keys it admits, and produces a Style value.
+Unknown keys fail; defaults are declared, not implied. Use the fixture's decoder for the generic boundary, or the selected close sibling when
 the new package intentionally extends that sibling's domain contract.
 
 **The renderer turns a Program into elements and nothing else.** It resolves no timing of its own and

--- a/docs/guide/skill.md
+++ b/docs/guide/skill.md
@@ -203,8 +203,8 @@ spending. `hypit build` is submitted only after explicit cost approval.
 
 ```text
 environment → brief-frozen → examples/format/craft decisions
-→ vocabulary/component-fit → package-ready → Script and four sources
-→ script-checked → source-authored → graph-checked → layout-checked
+→ vocabulary/component-fit → Script and four sources → source-authored
+→ package-ready → script-checked → graph-checked → layout-checked
 → review-planned → preview-rendered → review-complete → repairs-complete
 → final-checked → Studio confirmation → optional Build
 ```
@@ -231,8 +231,8 @@ edge needed by the Film. It has no reference video, so `brief.json` is the autho
 
 ```text
 environment → reference-prepared → reference-observed
-→ examples/format/craft decisions → vocabulary/component-fit → package-ready
-→ Script and four sources → script-checked → source-authored → graph-checked
+→ examples/format/craft decisions → vocabulary/component-fit
+→ Script and four sources → source-authored → package-ready → script-checked → graph-checked
 → layout-checked → review-planned → preview-rendered → comparison-complete
 → repairs-complete → final-checked → initial-adaptation → final check again
 → Studio confirmation → optional Build

--- a/docs/quickstart/styles.md
+++ b/docs/quickstart/styles.md
@@ -103,7 +103,7 @@ For reproducible rendering, select an exact installed face in the `.svml` source
 Record to the Fine Style. Family, weight and style have one source of truth on this exact font edge:
 
 ```svml
-<fonts:Face id="caption-font" family="inter" weight="600" style="normal"/>
+<fonts:Stack id="caption-font" family="inter" weight="600" style="normal"/>
 <caption-fine:Style id="primary-caption" recipe={recipes.caption.dialogue}
   font={caption-font}/>
 ```
@@ -117,6 +117,8 @@ caption.alice {
   stack-order: 70;
   x: 0.08; y: 0.76; width: 0.84;
   size: 58;
+  line-height: 0.96;
+  align: center;
   fill: #73FBD3;
   background: #09090BCC;
   padding: 16 24; radius: 18;
@@ -126,6 +128,8 @@ caption.bob {
   stack-order: 70;
   x: 0.08; y: 0.76; width: 0.84;
   size: 58;
+  line-height: 0.96;
+  align: center;
   fill: #FFD166;
   background: #09090BCC;
   padding: 16 24; radius: 18;

--- a/docs/quickstart/tracks.md
+++ b/docs/quickstart/tracks.md
@@ -330,13 +330,11 @@ placement, timing, style and motion. Use inline `P`/`Span`/`Break` when the auth
 
 ## Ranking boards
 
-A board animates an ordered list against the Script: it enters on a Selection, moves on Moments, and
-settles on a Moment that ends it. Three variants share one shape — a container, its own item tag,
-and its own style tag.
+A ranking board animates an ordered list against the Script. The concrete container, item and Style
+vocabulary is package-owned; inspect the installed package before authoring it.
 
 | Container | Item | Style |
 |---|---|---|
-| `ranking:TierBoard` | `ranking:TierItem` | `ranking:TierBoardStyle` |
 | `ranking:Column` | `ranking:ColumnItem` | `ranking:ColumnStyle` |
 | `ranking:TopThree` | `ranking:TopThreeItem` | `ranking:TopThreeStyle` |
 
@@ -362,9 +360,8 @@ against the variant, so a Column recipe on a TierBoard is refused by name.
 | `terminal` | the Moment where the completed board settles. `TopThree` only |
 | `canvas` | a `space:Canvas` — the independent reveal stage. TierBoard/Column |
 
-`TierBoard` and `Column` take no `terminal`: every non-preset item carries an explicit reveal
-Selection. Sibling windows must already be non-overlapping and inside the container's `during`
-span.
+Use only the timing forms admitted by the selected package; do not infer a terminal or reveal model
+from another component family.
 
 `move-sound` is refused on `TopThree`, which has no move phase. On a `TierBoard` it needs at least
 one item with `entry="drop"`. A drop Item appears in place on the independent Canvas stage when its

--- a/docs/quickstart/tracks.md
+++ b/docs/quickstart/tracks.md
@@ -345,39 +345,30 @@ vocabulary is package-owned; inspect the installed package before authoring it.
 ### The style tag
 
 Empty, and all three attributes required: `id`, `recipe` (an SVS Recipe) and `font` (a Font Stack or
-Font artifact). The recipe carries the board's own keys — rows, colours, motion — and is validated
-against the variant, so a Column recipe on a TierBoard is refused by name.
+Font artifact). The recipe is validated against the selected component variant; a Recipe from another
+family is refused by name.
 
 ### The container tag
 
 | Attribute | Takes |
 |---|---|
 | `semantic` | the SemanticTrack the board is timed against |
-| `frame` | a `space:Frame` — the compact board itself for TierBoard/Column |
-| `during` | a Segment or Selection for TierBoard/Column; a Selection for TopThree |
+| `frame` | a `space:Frame` — the board's declared placement |
+| `during` | the timing form declared by the selected component |
 | `style` | the matching style record, and only that variant's |
 | `appear-sound`, `move-sound` | optional Synchronized Media |
 | `terminal` | the Moment where the completed board settles. `TopThree` only |
-| `canvas` | a `space:Canvas` — the independent reveal stage. TierBoard/Column |
+| `canvas` | an optional `space:Canvas` declared by the selected component |
 
 Use only the timing forms admitted by the selected package; do not infer a terminal or reveal model
 from another component family.
 
-`move-sound` is refused on `TopThree`, which has no move phase. On a `TierBoard` it needs at least
-one item with `entry="drop"`. A drop Item appears in place on the independent Canvas stage when its
-Selection starts, stays still while that Item is discussed, and only follows an eased curved glide
-into its tier during the final `move-frames` ending at the Selection boundary. The move sound starts
-with that final glide.
+Optional sounds and reveal phases are valid only when the selected package declares them.
 
 ### The item tags
 
 Each variant takes its own, at least one, and ids must be unique within a board.
 
-- **`TierItem`** — `tier` and `icon` are required. A non-preset item owns a `during` Selection and
-  must choose `entry="direct" | "drop"`; `preset="true"` has neither. Presets occupy inner cells
-  first, then reveal-window order fills each tier outward. Both modes use a quick in-place overshoot;
-  direct appears in its final cell, while drop uses the independent stage for the complete
-  explanation window before settling. Row labels come from the recipe.
 - **`TopThreeItem`** — `label` and item-owned Moment `at` are required; `icon` and `stack` are optional.
   At most three. TopThree reveal order comes from these Moments' actual frame order.
 - **`ColumnItem`** — `label` (required) and `rank` (required, a positive integer that decides the

--- a/docs/zh/quickstart/styles.md
+++ b/docs/zh/quickstart/styles.md
@@ -99,7 +99,7 @@ caption.dialogue {
 Style。字体家族、字重和字形只在这条精确字体边上声明一次：
 
 ```svml
-<fonts:Face id="caption-font" family="inter" weight="600" style="normal"/>
+<fonts:Stack id="caption-font" family="inter" weight="600" style="normal"/>
 <caption-fine:Style id="primary-caption" recipe={recipes.caption.dialogue}
   font={caption-font}/>
 ```
@@ -113,6 +113,8 @@ caption.alice {
   stack-order: 70;
   x: 0.08; y: 0.76; width: 0.84;
   size: 58;
+  line-height: 0.96;
+  align: center;
   fill: #73FBD3;
   background: #09090BCC;
   padding: 16 24; radius: 18;
@@ -122,6 +124,8 @@ caption.bob {
   stack-order: 70;
   x: 0.08; y: 0.76; width: 0.84;
   size: 58;
+  line-height: 0.96;
+  align: center;
   fill: #FFD166;
   background: #09090BCC;
   padding: 16 24; radius: 18;

--- a/docs/zh/quickstart/tracks.md
+++ b/docs/zh/quickstart/tracks.md
@@ -270,11 +270,10 @@ Run 时，继续使用内联 `P`/`Span`/`Break`。
 
 ## 榜单板
 
-榜单板让一份有序列表跟着 Script 动起来：在某个 Selection 期间出现，在 Moment 上移动，在另一个 Moment 上定格。三个变体共用同一套形状——一个容器、它专属的条目标签、以及它专属的样式标签。
+榜单板让一份有序列表跟着 Script 动起来。具体的容器、条目和 Style 词汇由包声明；写作前先检查已安装包的词汇。
 
 | 容器 | 条目 | 样式 |
 |---|---|---|
-| `ranking:TierBoard` | `ranking:TierItem` | `ranking:TierBoardStyle` |
 | `ranking:Column` | `ranking:ColumnItem` | `ranking:ColumnStyle` |
 | `ranking:TopThree` | `ranking:TopThreeItem` | `ranking:TopThreeStyle` |
 
@@ -298,7 +297,7 @@ Run 时，继续使用内联 `P`/`Span`/`Break`。
 | `canvas` | 一个 `space:Canvas`——独立揭示舞台。TierBoard/Column |
 | `appear-sound`、`move-sound` | 可选，Synchronized Media |
 
-TierBoard 与 Column 都不使用 `terminal`：每个非 preset item 直接消费一个 `during` Selection，所有窗口必须位于外层区间内且互不相交。`move-sound` 在 `TopThree` 上会被拒绝；在 `TierBoard` 上它要求至少有一个 `entry="drop"` 的条目。drop 条目会在 Selection 开始时原地弹入独立的 Canvas 舞台，整段讲解期间保持静止，只在窗口末尾的 `move-frames` 内沿缓动弧线滑入 tier；移动音效也从这里开始。
+只使用所选包明确声明的时间形式；不要从另一个组件族推断 terminal 或 reveal 规则。
 
 ### 条目标签
 

--- a/docs/zh/quickstart/tracks.md
+++ b/docs/zh/quickstart/tracks.md
@@ -283,18 +283,18 @@ Run 时，继续使用内联 `P`/`Span`/`Break`。
 
 ### 样式标签
 
-标签必须为空，三个属性全部必填：`id`、`recipe`（一份 SVS Recipe）与 `font`（Font Stack 或字体产物）。Recipe 承载这块板自己的键——行、配色、动效——并且会按变体校验，把 Column 的 recipe 给 TierBoard 会被指名拒绝。
+标签必须为空，三个属性全部必填：`id`、`recipe`（一份 SVS Recipe）与 `font`（Font Stack 或字体产物）。Recipe 由选中的组件变体定义，其他组件族的 Recipe 会被指名拒绝。
 
 ### 容器标签
 
 | 属性 | 取值 |
 |---|---|
 | `semantic` | 板据以计时的 SemanticTrack |
-| `frame` | 一个 `space:Frame`——TierBoard/Column 自己的紧凑板子 |
-| `during` | TierBoard/Column 接 Segment 或 Selection；TopThree 接 Selection |
+| `frame` | 一个 `space:Frame`——选中组件声明的板面位置 |
+| `during` | 选中组件声明的时间形式 |
 | `style` | 对应的样式记录，且只接受本变体的 |
 | `terminal` | 完整板定格的 Moment。仅 `TopThree` |
-| `canvas` | 一个 `space:Canvas`——独立揭示舞台。TierBoard/Column |
+| `canvas` | 选中组件可声明的 `space:Canvas` |
 | `appear-sound`、`move-sound` | 可选，Synchronized Media |
 
 只使用所选包明确声明的时间形式；不要从另一个组件族推断 terminal 或 reveal 规则。
@@ -303,7 +303,6 @@ Run 时，继续使用内联 `P`/`Span`/`Break`。
 
 每个变体只接受自己的那一种，至少一个，且 id 在同一块板内不可重复。
 
-- **`TierItem`** —— `tier` 与 `icon` 必填。非 preset item 用自己的 `during` Selection，并必须显式选择 `entry="direct" | "drop"`；`preset="true"` 不写 `during` 和 `entry`。preset 先占内侧，随后严格按窗口顺序向外填充。两种模式都用快速的原地放大回弹入场；direct 在最终格出现，drop 在独立舞台讲解完整窗口后才归入 tier。行文字来自 recipe。
 - **`TopThreeItem`** —— `label` 与 item 自己的 `at={story.moment...}` 必填，可选 `icon` 与 `stack`，最多三条。揭示顺序由这些 Moment 的真实帧顺序决定。
 - **`ColumnItem`** —— `label` 与 `rank` 必填，可选 `icon` 与 `stack`。非 preset item 用自己的 `during` Selection；`preset="true"` 的 item 开场已在位且不写 `during`。
 

--- a/examples/minimal-author-package/README.md
+++ b/examples/minimal-author-package/README.md
@@ -3,3 +3,8 @@
 Use this directory only as the generic author-package fixture. It is deliberately not a complete video
 project: the `packages/example-component` package is the authoritative small implementation, while
 the package's `preview/` asset demonstrates a Surface preview.
+
+The fixture's Surface decoder also demonstrates the public value boundary: Style-like values consume
+a decoded recipe shaped as `{ path, properties }`, exact `FontStackRef` records and inline values
+only after checking `record.value.kind === "inline"`. Media slots remain graph inputs rather than
+package files.

--- a/examples/minimal-author-package/README.md
+++ b/examples/minimal-author-package/README.md
@@ -2,7 +2,8 @@
 
 Use this directory only as the generic author-package fixture. It is deliberately not a complete video
 project: the `packages/example-component` package is the authoritative small implementation, while
-the package's `preview/` asset demonstrates a Surface preview.
+the package's `preview/` asset demonstrates a Surface preview. The fixture also includes a Style
+Surface that reads an SVS Recipe and exact FontStackRef.
 
 The fixture's Surface decoder also demonstrates the public value boundary: Style-like values consume
 a decoded recipe shaped as `{ path, properties }`, exact `FontStackRef` records and inline values

--- a/examples/minimal-author-package/packages/example-component/README.md
+++ b/examples/minimal-author-package/packages/example-component/README.md
@@ -9,6 +9,7 @@ literal `fragment-input`, `fragment-operation` and `output` references. `src/tem
 Surface-side `@hypit/temporal-markup` Window/Moment projections; that package is distinct from the
 graph-side `@hypit/temporal` Producers.
 
-The three Surfaces demonstrate a box, a text surface and a media slot. The slot is a graph input; it is
-not a file bundled by the package. `preview/Box.png` is a real catalogue frame supplied by the
-package's vocabulary.
+The Surfaces demonstrate a box, a text surface, a media slot and a Style decoder. The slot is a graph
+input; it is not a file bundled by the package. `preview/Box.png` is a real catalogue frame supplied
+by the package's vocabulary. `exampleAppendFragment` and `append-example-items` show a fixed-port
+append that can be chained once per child.

--- a/examples/minimal-author-package/packages/example-component/package.json
+++ b/examples/minimal-author-package/packages/example-component/package.json
@@ -9,10 +9,12 @@
     "@hypit/component-kit": "workspace:*",
     "@hypit/composition": "workspace:*",
     "@hypit/elaborator": "workspace:*",
+    "@hypit/media": "workspace:*",
     "@hypit/markup": "workspace:*",
     "@hypit/protocol": "workspace:*",
     "@hypit/program-space": "workspace:*",
     "@hypit/semantic-track": "workspace:*",
+    "@hypit/svs": "workspace:*",
     "@hypit/temporal": "workspace:*",
     "@hypit/temporal-markup": "workspace:*",
     "@hypit/visual-ir": "workspace:*"

--- a/examples/minimal-author-package/packages/example-component/package.json
+++ b/examples/minimal-author-package/packages/example-component/package.json
@@ -6,6 +6,7 @@
   "exports": { ".": "./src/index.ts" },
   "hypit": { "activation": "./src/activation.ts" },
   "dependencies": {
+    "@hypit/artifact": "workspace:*",
     "@hypit/component-kit": "workspace:*",
     "@hypit/composition": "workspace:*",
     "@hypit/elaborator": "workspace:*",

--- a/examples/minimal-author-package/packages/example-component/src/component.ts
+++ b/examples/minimal-author-package/packages/example-component/src/component.ts
@@ -2,6 +2,7 @@ import { sealVisualTrack } from "@hypit/composition";
 import type { ProgramSpace } from "@hypit/program-space";
 import type { ComponentPackage, ProducerHandler } from "@hypit/component-kit";
 import { canonicalize } from "@hypit/protocol";
+import type { BlobRef, TypedRecord } from "@hypit/protocol";
 import { VISUAL_IR_V1 } from "@hypit/visual-ir";
 import { exampleProducers, exampleTypes } from "./manifest.js";
 
@@ -10,7 +11,10 @@ const inline = <T>(record: { readonly value: { readonly kind: string; readonly v
   return record.value.value as T;
 };
 const output = (value: unknown) => ({ kind: "inline" as const, value: canonicalize(value) });
-function render(kind: string, space: ProgramSpace) {
+function blob(record: TypedRecord | undefined): BlobRef | undefined {
+  return record?.value.kind === "blob" ? record.value : undefined;
+}
+function render(kind: string, space: ProgramSpace, media?: BlobRef) {
   const frames = Math.max(1, Math.round(space.durationSec * space.frameRate.numerator / space.frameRate.denominator));
   return sealVisualTrack({
     programSpaceId: space.id,
@@ -19,16 +23,19 @@ function render(kind: string, space: ProgramSpace) {
     presents: [{ id: `present-${kind}`, span: { startFrame: 0, endFrameExclusive: frames }, stacking: { order: 0, tieBreak: kind }, elements: [{
       id: `${kind}-root`, kind: "box", order: 0,
       style: [{ name: "background-color", value: "#6b7280" }],
-    }] }],
+    }, ...(kind === "media" && media !== undefined ? [{ id: `${kind}-content`, parent: `${kind}-root`, kind: media.mediaType.startsWith("video/") ? "video" as const : "image" as const, artifact: media, order: 1, style: [{ name: "position", value: "absolute" }, { name: "left", value: 0 }, { name: "top", value: 0 }, { name: "width", value: "100%" }, { name: "height", value: "100%" }, { name: "object-fit", value: "contain" }] }] : []),
+    ] }],
   });
 }
-const producer = (kind: string): { readonly handler: ProducerHandler } => ({ handler: ({ inputs }) => ({ outputs: { track: output(render(kind, inline<ProgramSpace>(inputs.space))) }, needs: {} }) });
+const producer = (kind: string): { readonly handler: ProducerHandler } => ({ handler: ({ inputs }) => ({ outputs: { track: output(render(kind, inline<ProgramSpace>(inputs.space), blob(inputs.media))) }, needs: {} }) });
+const appendItems: { readonly handler: ProducerHandler } = { handler: ({ inputs }) => ({ outputs: { set: output({ items: [inline<{ items: readonly unknown[] }>(inputs.previous).items, inline<{ items: readonly unknown[] }>(inputs.item).items].flat() }) }, needs: {} }) };
 
 export const exampleComponent = {
   producers: [
     { producer: exampleProducers.renderBox, ...producer("box") },
     { producer: exampleProducers.renderText, ...producer("text") },
     { producer: exampleProducers.renderMedia, ...producer("media") },
+    { producer: exampleProducers.appendItems, ...appendItems },
   ],
   validators: [
     { type: exampleTypes.box, handler: () => {} },

--- a/examples/minimal-author-package/packages/example-component/src/fragment.ts
+++ b/examples/minimal-author-package/packages/example-component/src/fragment.ts
@@ -1,18 +1,22 @@
 import { compositionTypes } from "@hypit/composition";
+import { artifactTypes } from "@hypit/artifact";
 import { sealGraphFragment } from "@hypit/elaborator";
 import { semanticTrackProducers, semanticTrackTypes } from "@hypit/semantic-track";
 import { programSpaceTypes } from "@hypit/program-space";
 import { exampleProducers } from "./manifest.js";
+import { exampleTypes } from "./manifest.js";
 
 const input = (name: string) => ({ kind: "fragment-input" as const, name });
 const operation = (id: string) => ({ kind: "fragment-operation" as const, operation: id });
 
-export function createExampleFragment(producer: typeof exampleProducers[keyof typeof exampleProducers], id: string) {
+export function createExampleFragment(producer: typeof exampleProducers[keyof typeof exampleProducers], id: string, media = false) {
+  const inputs = [{ name: "semantic", type: semanticTrackTypes.track }, ...(media ? [{ name: "media", type: artifactTypes.blob }] : [])];
+  const renderInputs = { space: operation("space"), ...(media ? { media: input("media") } : {}) };
   return sealGraphFragment({
-    inputs: [{ name: "semantic", type: semanticTrackTypes.track }],
+    inputs,
     operations: [
       { id: "space", producer: semanticTrackProducers.projectProgramSpace, inputs: { track: input("semantic") }, result: { kind: "output", name: "space" } },
-      { id, producer, inputs: { space: operation("space") }, result: { kind: "output", name: "track" } },
+      { id, producer, inputs: renderInputs, result: { kind: "output", name: "track" } },
     ],
     exports: [{ name: "track", type: compositionTypes.visualTrack, root: operation(id) }],
   });
@@ -20,4 +24,9 @@ export function createExampleFragment(producer: typeof exampleProducers[keyof ty
 
 export const exampleBoxFragment = createExampleFragment(exampleProducers.renderBox, "render-box");
 export const exampleTextFragment = createExampleFragment(exampleProducers.renderText, "render-text");
-export const exampleMediaFragment = createExampleFragment(exampleProducers.renderMedia, "render-media-slot");
+export const exampleMediaFragment = createExampleFragment(exampleProducers.renderMedia, "render-media-slot", true);
+export const exampleAppendFragment = sealGraphFragment({
+  inputs: [{ name: "previous", type: exampleTypes.itemSet }, { name: "item", type: exampleTypes.itemSet }],
+  operations: [{ id: "append-items", producer: exampleProducers.appendItems, inputs: { previous: input("previous"), item: input("item") }, result: { kind: "output", name: "set" } }],
+  exports: [{ name: "set", type: exampleTypes.itemSet, root: operation("append-items") }],
+});

--- a/examples/minimal-author-package/packages/example-component/src/index.ts
+++ b/examples/minimal-author-package/packages/example-component/src/index.ts
@@ -1,5 +1,5 @@
 export { exampleComponent } from "./component.js";
-export { exampleBoxFragment, exampleMediaFragment, exampleTextFragment } from "./fragment.js";
+export { exampleAppendFragment, exampleBoxFragment, exampleMediaFragment, exampleTextFragment } from "./fragment.js";
 export { exampleManifest, exampleMarkupSurfaces, exampleModuleRef, exampleProducers, exampleTypes } from "./manifest.js";
 export { decodeExampleSurface } from "./surface.js";
 export { decodeExampleStyle } from "./style.js";

--- a/examples/minimal-author-package/packages/example-component/src/index.ts
+++ b/examples/minimal-author-package/packages/example-component/src/index.ts
@@ -2,4 +2,5 @@ export { exampleComponent } from "./component.js";
 export { exampleBoxFragment, exampleMediaFragment, exampleTextFragment } from "./fragment.js";
 export { exampleManifest, exampleMarkupSurfaces, exampleModuleRef, exampleProducers, exampleTypes } from "./manifest.js";
 export { decodeExampleSurface } from "./surface.js";
+export { decodeExampleStyle } from "./style.js";
 export { projectExampleMoment, projectExampleWindow, temporalInstantAttributeNames, temporalWindowAttributeNames } from "./temporal.js";

--- a/examples/minimal-author-package/packages/example-component/src/manifest.ts
+++ b/examples/minimal-author-package/packages/example-component/src/manifest.ts
@@ -4,6 +4,8 @@ import type { ModuleManifest, ProducerRef, TypeRef } from "@hypit/protocol";
 import { programSpaceTypes } from "@hypit/program-space";
 import { semanticTrackTypes } from "@hypit/semantic-track";
 import { temporalTypes } from "@hypit/temporal";
+import { mediaTypes } from "@hypit/media";
+import { svsRecipeType } from "@hypit/svs";
 
 const previewImage = (file: string) => ({
   mediaType: "image/png",
@@ -16,6 +18,7 @@ export const exampleTypes = {
   box: { module: exampleModuleRef, name: "ExampleBox" },
   text: { module: exampleModuleRef, name: "ExampleText" },
   mediaSlot: { module: exampleModuleRef, name: "ExampleMediaSlot" },
+  style: { module: exampleModuleRef, name: "ExampleStyle" },
 } satisfies Record<string, TypeRef>;
 export const exampleProducers = {
   renderBox: { module: exampleModuleRef, name: "render-example-box" },
@@ -58,4 +61,12 @@ export const exampleMarkupSurfaces = [
   { name: "box", tag: "Box", mode: "structured", outputs: [exampleTypes.box, compositionTypes.visualTrack], vocabulary: { ...vocabulary("A framed box surface.", "<example:Box id=\"box\" semantic={speech.semantic}/>") , preview: previewImage("Box.png") } },
   { name: "text", tag: "Text", mode: "structured", outputs: [exampleTypes.text, temporalTypes.instantSpec, temporalTypes.windowSpec, temporalTypes.instant, temporalTypes.window, compositionTypes.visualTrack], vocabulary: { ...vocabulary("A text-bearing surface.", "<example:Text id=\"title\" semantic={speech.semantic}>Hello</example:Text>"), preview: previewImage("Box.png") } },
   { name: "media-slot", tag: "MediaSlot", mode: "structured", outputs: [exampleTypes.mediaSlot, compositionTypes.visualTrack], vocabulary: { ...vocabulary("A media slot whose content is a graph input.", "<example:MediaSlot id=\"shot\" semantic={speech.semantic}/>") , preview: previewImage("Box.png") } },
+  { name: "style", tag: "Style", mode: "structured", outputs: [exampleTypes.style], vocabulary: {
+    summary: "Decodes one SVS Recipe and exact FontStackRef into a Style value.",
+    attributes: [
+      { name: "id", kind: "identifier", required: true, summary: "Names this Style." },
+      { name: "recipe", kind: "reference", required: true, accepts: [svsRecipeType], summary: "The decoded recipe with path and properties." },
+      { name: "font", kind: "reference", required: true, accepts: [mediaTypes.fontStack], summary: "An exact FontStackRef." },
+    ], example: "<example:Style id=\"card\" recipe={recipes.card} font={caption-font}/>",
+  } },
 ] as const;

--- a/examples/minimal-author-package/packages/example-component/src/manifest.ts
+++ b/examples/minimal-author-package/packages/example-component/src/manifest.ts
@@ -6,6 +6,7 @@ import { semanticTrackTypes } from "@hypit/semantic-track";
 import { temporalTypes } from "@hypit/temporal";
 import { mediaTypes } from "@hypit/media";
 import { svsRecipeType } from "@hypit/svs";
+import { artifactTypes } from "@hypit/artifact";
 
 const previewImage = (file: string) => ({
   mediaType: "image/png",
@@ -19,27 +20,35 @@ export const exampleTypes = {
   text: { module: exampleModuleRef, name: "ExampleText" },
   mediaSlot: { module: exampleModuleRef, name: "ExampleMediaSlot" },
   style: { module: exampleModuleRef, name: "ExampleStyle" },
+  itemSet: { module: exampleModuleRef, name: "ExampleItemSet" },
 } satisfies Record<string, TypeRef>;
 export const exampleProducers = {
   renderBox: { module: exampleModuleRef, name: "render-example-box" },
   renderText: { module: exampleModuleRef, name: "render-example-text" },
   renderMedia: { module: exampleModuleRef, name: "render-example-media-slot" },
+  appendItems: { module: exampleModuleRef, name: "append-example-items" },
 } satisfies Record<string, ProducerRef>;
 
 export const exampleManifest: ModuleManifest = {
   format: "hypit.module@1", name: exampleModuleRef.name, version: exampleModuleRef.version,
   dependencies: [
     { module: compositionTypes.visualTrack.module },
+    { module: mediaTypes.fontStack.module },
     { module: programSpaceTypes.programSpace.module },
     { module: semanticTrackTypes.track.module },
+    { module: svsRecipeType.module },
     { module: temporalTypes.window.module },
   ],
   types: Object.values(exampleTypes).map(({ name }) => ({ name })),
   capabilities: [],
   producers: Object.values(exampleProducers).map((producer) => ({
     name: producer.name,
-    inputs: [{ name: "space", type: programSpaceTypes.programSpace }],
-    outputs: [{ name: "track", type: compositionTypes.visualTrack }],
+    inputs: producer === exampleProducers.appendItems
+      ? [{ name: "previous", type: exampleTypes.itemSet }, { name: "item", type: exampleTypes.itemSet }]
+      : [{ name: "space", type: programSpaceTypes.programSpace }, ...(producer === exampleProducers.renderMedia ? [{ name: "media", type: artifactTypes.blob }] : [])],
+    outputs: producer === exampleProducers.appendItems
+      ? [{ name: "set", type: exampleTypes.itemSet }]
+      : [{ name: "track", type: compositionTypes.visualTrack }],
     needs: [],
   })),
 };
@@ -60,7 +69,7 @@ const vocabulary = (summary: string, example: string) => ({
 export const exampleMarkupSurfaces = [
   { name: "box", tag: "Box", mode: "structured", outputs: [exampleTypes.box, compositionTypes.visualTrack], vocabulary: { ...vocabulary("A framed box surface.", "<example:Box id=\"box\" semantic={speech.semantic}/>") , preview: previewImage("Box.png") } },
   { name: "text", tag: "Text", mode: "structured", outputs: [exampleTypes.text, temporalTypes.instantSpec, temporalTypes.windowSpec, temporalTypes.instant, temporalTypes.window, compositionTypes.visualTrack], vocabulary: { ...vocabulary("A text-bearing surface.", "<example:Text id=\"title\" semantic={speech.semantic}>Hello</example:Text>"), preview: previewImage("Box.png") } },
-  { name: "media-slot", tag: "MediaSlot", mode: "structured", outputs: [exampleTypes.mediaSlot, compositionTypes.visualTrack], vocabulary: { ...vocabulary("A media slot whose content is a graph input.", "<example:MediaSlot id=\"shot\" semantic={speech.semantic}/>") , preview: previewImage("Box.png") } },
+  { name: "media-slot", tag: "MediaSlot", mode: "structured", outputs: [exampleTypes.mediaSlot, compositionTypes.visualTrack], vocabulary: { ...vocabulary("A media slot whose content is a graph input.", "<example:MediaSlot id=\"shot\" semantic={speech.semantic} media={shot-media}/>") , attributes: [...vocabulary("", "").attributes, { name: "media", kind: "reference" as const, required: false, accepts: [artifactTypes.blob], summary: "Optional image or video Blob Artifact." }], preview: previewImage("Box.png") } },
   { name: "style", tag: "Style", mode: "structured", outputs: [exampleTypes.style], vocabulary: {
     summary: "Decodes one SVS Recipe and exact FontStackRef into a Style value.",
     attributes: [

--- a/examples/minimal-author-package/packages/example-component/src/manifest.ts
+++ b/examples/minimal-author-package/packages/example-component/src/manifest.ts
@@ -32,6 +32,7 @@ export const exampleProducers = {
 export const exampleManifest: ModuleManifest = {
   format: "hypit.module@1", name: exampleModuleRef.name, version: exampleModuleRef.version,
   dependencies: [
+    { module: artifactTypes.blob.module },
     { module: compositionTypes.visualTrack.module },
     { module: mediaTypes.fontStack.module },
     { module: programSpaceTypes.programSpace.module },

--- a/examples/minimal-author-package/packages/example-component/src/style.ts
+++ b/examples/minimal-author-package/packages/example-component/src/style.ts
@@ -1,0 +1,13 @@
+import type { FontStackRef } from "@hypit/media";
+import type { SvsRecipe } from "@hypit/svs";
+
+/** The two values a Style decoder receives after author references are resolved. */
+export type ExampleStyleInput = {
+  readonly recipe: { readonly path: string; readonly properties: SvsRecipe["properties"] };
+  readonly fonts: FontStackRef;
+};
+
+/** A deliberately small, runnable Style boundary for the fixture. */
+export function decodeExampleStyle(input: ExampleStyleInput): { readonly recipe: ExampleStyleInput["recipe"]; readonly fonts: FontStackRef } {
+  return { recipe: { path: input.recipe.path, properties: { ...input.recipe.properties } }, fonts: input.fonts };
+}

--- a/examples/minimal-author-package/packages/example-component/src/surface.ts
+++ b/examples/minimal-author-package/packages/example-component/src/surface.ts
@@ -3,6 +3,7 @@ import { exampleBoxFragment, exampleMediaFragment, exampleTextFragment } from ".
 import { exampleMarkupSurfaces, exampleTypes } from "./manifest.js";
 import { mediaTypes } from "@hypit/media";
 import { svsRecipeType } from "@hypit/svs";
+import { artifactTypes } from "@hypit/artifact";
 
 function text(element: StructuredElement, name: string): string {
   const value = element.attributes[name];
@@ -33,6 +34,8 @@ export const decodeExampleSurface: StructuredSurfaceHandler = ({ element, resolv
   const fragment = surface.name === "box" ? exampleBoxFragment : surface.name === "text" ? exampleTextFragment : exampleMediaFragment;
   const type = surface.name === "box" ? exampleTypes.box : surface.name === "text" ? exampleTypes.text : exampleTypes.mediaSlot;
   const record: SurfaceRecordDraft = { id: `${id}.value`, type, value: { kind: "inline", value: { id } }, range: element.range };
-  const component: SurfaceComponentDraft = { id, fragment: fragment.id, inputs: { semantic: semantic.ref }, outputs: { track: `${id}.track` }, range: element.range };
+  const media = element.attributes.media === undefined ? undefined : reference(element, "media", resolveReference);
+  if (media !== undefined && (media.type.module.name !== artifactTypes.blob.module.name || media.type.name !== artifactTypes.blob.name)) throw new Error(`${element.name}.media must be a Blob Artifact.`);
+  const component: SurfaceComponentDraft = { id, fragment: fragment.id, inputs: { semantic: semantic.ref, ...(media === undefined ? {} : { media: media.ref }) }, outputs: { track: `${id}.track` }, range: element.range };
   return { records: [record], components: [component], fragments: [fragment], exports: [`${id}.value`, `${id}.track`] };
 };

--- a/examples/minimal-author-package/packages/example-component/src/surface.ts
+++ b/examples/minimal-author-package/packages/example-component/src/surface.ts
@@ -1,6 +1,8 @@
 import type { StructuredElement, StructuredSurfaceHandler, SurfaceComponentDraft, SurfaceRecordDraft, SurfaceResolvedReference } from "@hypit/markup";
 import { exampleBoxFragment, exampleMediaFragment, exampleTextFragment } from "./fragment.js";
 import { exampleMarkupSurfaces, exampleTypes } from "./manifest.js";
+import { mediaTypes } from "@hypit/media";
+import { svsRecipeType } from "@hypit/svs";
 
 function text(element: StructuredElement, name: string): string {
   const value = element.attributes[name];
@@ -17,6 +19,14 @@ function reference(element: StructuredElement, name: string, resolve: (path: str
 
 export const decodeExampleSurface: StructuredSurfaceHandler = ({ element, resolveReference }) => {
   const id = text(element, "id");
+  if (element.name.endsWith(":Style")) {
+    const recipe = reference(element, "recipe", resolveReference);
+    const font = reference(element, "font", resolveReference);
+    if (recipe.type.module.name !== svsRecipeType.module.name || recipe.type.name !== svsRecipeType.name) throw new Error("Style.recipe must be an SVS Recipe.");
+    if (font.type.module.name !== mediaTypes.fontStack.module.name || font.type.name !== mediaTypes.fontStack.name) throw new Error("Style.font must be a FontStackRef.");
+    if (recipe.record?.value.kind !== "inline" || font.record?.value.kind !== "inline") throw new Error("Style references must resolve to inline records.");
+    return { records: [{ id, type: exampleTypes.style, value: { kind: "inline", value: { recipe: recipe.record.value.value, fonts: font.record.value.value } }, range: element.range }], components: [], fragments: [], exports: [id] };
+  }
   const semantic = reference(element, "semantic", resolveReference);
   const surface = exampleMarkupSurfaces.find((item) => item.tag === element.name.split(":").at(-1));
   if (surface === undefined) throw new Error(`Unknown example surface ${element.name}`);

--- a/packages/gpt-image/README.md
+++ b/packages/gpt-image/README.md
@@ -8,6 +8,10 @@ then finalized into the only `GenerationRequest` a Provider can receive. The pac
 semantics but no API key, Provider selection, queue or network code. `@hypit/provider-kie` is
 one optional Runtime implementation.
 
+Provider limits are checked by the Provider before any paid operation. In particular, KIE's GPT
+Image 2 endpoints reject `4:3`, `3:4` and `4:5`; those values remain in this model contract because
+the model Surface is Provider-neutral, but a KIE Runtime must use one of its accepted ratios.
+
 The one physical package exposes two independently importable logical modules:
 
 - `@hypit/gpt-image@1`: the raw exact model;

--- a/packages/media-execution/src/execute.ts
+++ b/packages/media-execution/src/execute.ts
@@ -462,7 +462,8 @@ function mockColor(value: string): [number, number, number] {
 // outline survives both still-image and video materialization, so an agent can distinguish mock
 // media from authored assets at a glance.
 const MOCK_BORDER_COLOR = "#d946ef";
-const MOCK_BORDER_WIDTH = 4;
+// The border occupies pixels inside the mock bounds; it never expands or clips the media.
+const MOCK_BORDER_WIDTH = 8;
 
 function crc32(bytes: Uint8Array): number {
   let crc = 0xFFFFFFFF;

--- a/packages/provider-kie/README.md
+++ b/packages/provider-kie/README.md
@@ -28,6 +28,10 @@ routes rather than extra Capabilities.
 | `@hypit/seedream` | `seedream-5-lite` | `seedream/5-lite-{text,image}-to-image` |
 | `@hypit/background-removal` | `remove-background` | `recraft/remove-background` |
 
+KIE's GPT Image 2 endpoints do not accept `4:3`, `3:4` or `4:5`, even though those values are part
+of the model package's general vocabulary. The KIE route rejects those combinations before upload
+or paid submission; use `auto`, `1:1`, `3:2`, `2:3`, `16:9`, `9:16` or `21:9` for this Provider.
+
 There is deliberately no Grok image capability and no MiMo capability in this release. Seedream's
 `nsfwCheck` is explicit author request content; KIE cannot silently enable or disable it. A
 customer-specific “spicy” treatment belongs in a Recipe that selects and parameterizes exact model

--- a/packages/provider-kie/src/provider.ts
+++ b/packages/provider-kie/src/provider.ts
@@ -11,7 +11,9 @@ import type {
   BlobRef,
   CanonicalValue,
   Digest,
+  Need,
 } from "@hypit/protocol";
+import type { GenerationRequest } from "@hypit/generation";
 import {
   defineEndpointPackage,
   wakeAfter,
@@ -22,6 +24,7 @@ import type { ArtifactStore, CredentialRef } from "@hypit/runtime";
 import {
   kieRouteForCapability,
   kieRoutes,
+  supportsKieGptImageRequest,
   verifyKieRoutes,
 } from "./routes.js";
 import type { KieTaskRequest } from "./routes.js";
@@ -589,6 +592,9 @@ export function createKieProvider(config: CreateKieProviderOptions) {
         : { maxConcurrency: laneConcurrency[route.capability.name] }),
       lifecycle: "asynchronous" as const,
       endpoint: providerEndpoint,
+      ...(route.capability.module.name === "@hypit/gpt-image" ? {
+        supports: (need: Need) => supportsKieGptImageRequest(need.constraints as unknown as GenerationRequest),
+      } : {}),
     })),
   });
 }

--- a/packages/provider-kie/src/routes.ts
+++ b/packages/provider-kie/src/routes.ts
@@ -38,6 +38,24 @@ function capabilityKey(ref: CapabilityRef): string {
   return `${ref.module.name}@${ref.module.version}#${ref.name}`;
 }
 
+export function supportsKieGptImageRequest(request: GenerationRequest): boolean {
+  if (request.ports.aspectRatio === undefined) return true;
+  const ratio = request.ports.aspectRatio[0];
+  // KIE's GPT Image 2 endpoints reject these ratios even though the model
+  // vocabulary advertises them. Refuse before upload or paid submission.
+  if (ratio === "4:3" || ratio === "3:4" || ratio === "4:5") {
+    return false;
+  }
+  return true;
+}
+
+function validateKieGptImageRequest(request: GenerationRequest): void {
+  if (!supportsKieGptImageRequest(request)) {
+    const ratio = request.ports.aspectRatio?.[0];
+    throw new Error(`KIE GPT Image 2 does not accept aspect ratio ${String(ratio)}; use auto, 1:1, 3:2, 2:3, 16:9, 9:16 or 21:9`);
+  }
+}
+
 const kieGenerationMappings = kieModelCatalog.map((mapping) => {
   if (mapping.result === "audio") {
     throw new Error(`KIE route ${mapping.capability.name} declares unsupported audio output`);
@@ -51,11 +69,11 @@ const generationRoutes: readonly KieRoute[] = kieGenerationMappings.map((mapping
   returns: mapping.result === "image" ? generationTypes.imageSet : generationTypes.videoSet,
   media: mapping.result,
   maxResults: mapping.result === "image" ? 16 : 8,
-  compile: async (constraints, resolve) => await compileWireRequest(
-    mapping,
-    constraints as unknown as GenerationRequest,
-    resolve,
-  ),
+  compile: async (constraints, resolve) => {
+    const request = constraints as unknown as GenerationRequest;
+    if (mapping.capability.module.name === "@hypit/gpt-image") validateKieGptImageRequest(request);
+    return await compileWireRequest(mapping, request, resolve);
+  },
   packageResult: (artifacts) => ({
     kind: "inline",
     value: canonicalize(mapping.result === "image"

--- a/packages/reference-video-tools/src/authoring.ts
+++ b/packages/reference-video-tools/src/authoring.ts
@@ -560,6 +560,7 @@ export type RealizedAuthoringPreview = {
  */
 export async function realizeAuthoringPreview(input: {
   readonly run: string;
+  readonly runtime?: string;
   readonly package_root?: string;
 }): Promise<RealizedAuthoringPreview> {
   const cwd = invokedFrom();
@@ -581,7 +582,8 @@ export async function realizeAuthoringPreview(input: {
   if (distributionPackageRoot === undefined) throw new Error("active Hypit Distribution has no package root");
   const registry = await loadStudioCompanionRegistry({ workspaceRoot: projectRoot, packageRoot, distributionPackageRoot });
   const domain = await loadStudioDomain({ run: runPath, workspaceRoot: projectRoot, packageRoot });
-  const archive = await openStudioArchive(undefined, packageRoot, projectRoot, distributionPackageRoot);
+  const runtimePath = input.runtime === undefined ? undefined : resolve(cwd, input.runtime);
+  const archive = await openStudioArchive(runtimePath, packageRoot, projectRoot, distributionPackageRoot);
   try {
     const original = await loadStudioRun({ run: runPath, domain, registry, ...(archive === undefined ? {} : { archive }) });
     const graph: CompiledGraph = {
@@ -602,7 +604,7 @@ export async function realizeAuthoringPreview(input: {
     });
     const previewRegistry = await loadStudioCompanionRegistry({ workspaceRoot: projectRoot, packageRoot, distributionPackageRoot });
     const previewDomain = await loadStudioDomain({ run: previewMock.previewRun, workspaceRoot: projectRoot, packageRoot });
-    const previewArchive = await openStudioArchive(undefined, packageRoot, projectRoot, distributionPackageRoot);
+    const previewArchive = await openStudioArchive(runtimePath, packageRoot, projectRoot, distributionPackageRoot);
     try {
       const loadedPreview = await loadStudioRun({
         run: previewMock.previewRun, domain: previewDomain, registry: previewRegistry,

--- a/packages/reference-video-tools/src/checks.ts
+++ b/packages/reference-video-tools/src/checks.ts
@@ -256,6 +256,8 @@ export async function previewCheck(
 export type ReconstructionCheckInput = {
   readonly run: string;
   readonly reference_id?: string;
+  /** Runtime Profile used to resolve accepted Build Records in a pinned Run. */
+  readonly runtime?: string;
 };
 
 /**

--- a/packages/reference-video-tools/src/cli.ts
+++ b/packages/reference-video-tools/src/cli.ts
@@ -42,7 +42,7 @@ function usage(): string {
     "  hypit-reference-video-tools record_observation --reference-id <id> [--run <build.svrun>] --key <key> --text <text>|--text-file <path>",
     "  hypit-reference-video-tools record_observation --reference-id <id> [--run <build.svrun>] --batch <answers.json>",
     "  hypit-reference-video-tools inspect_svml_vocabulary --package <name> [--package <name> ...] [--tag <tag> ...] [--without-previews] [--run <build.svrun>]",
-    "  hypit-reference-video-tools validate_local_author_packages --run <build.svrun> [--expected-package <name> ...]",
+    "  hypit-reference-video-tools validate_local_author_packages --run <build.svrun> [--runtime <hypit.runtime.json>] [--expected-package <name> ...]",
     "  hypit-reference-video-tools validate_script_cues --run <build.svrun>",
     "  hypit-reference-video-tools inspect_visual_contract [--shape visual-track|visual-element|box|mask|text|image|video|surface|text-flow|text-typography|text-paint|text-document|path-command] [--producers-of <package> ...]",
     "  hypit-reference-video-tools paths",
@@ -56,11 +56,11 @@ function usage(): string {
     "  hypit-reference-video-tools render_element <build.svrun> --batch <renders.json> [--reference-id <id>]",
     "  hypit-reference-video-tools render_previews <package-dir> [...]",
     "  hypit-reference-video-tools preview_check <build.svrun> [<hypit.runtime.json>]",
-    "  hypit-reference-video-tools layout_check --run <build.svrun>",
+    "  hypit-reference-video-tools layout_check --run <build.svrun> [--runtime <hypit.runtime.json>]",
     "  hypit-reference-video-tools layout_accept --run <build.svrun> --finding <id> --reason <text>",
     "  hypit-reference-video-tools layout_accept --run <build.svrun> --batch <acceptances.json>",
-    "  hypit-reference-video-tools reconstruction_check <build.svrun> [--reference-id <id>]",
-    "  hypit-reference-video-tools authoring_check <build.svrun>",
+    "  hypit-reference-video-tools reconstruction_check <build.svrun> [--reference-id <id>] [--runtime <hypit.runtime.json>]",
+    "  hypit-reference-video-tools authoring_check <build.svrun> [--runtime <hypit.runtime.json>]",
     "",
     "preview_check opens the Run the way Studio does and reports whether the graph traces. `sound` is",
     "true when every Track resolved, and also when the only thing missing is capabilities a Provider has",
@@ -607,7 +607,12 @@ async function main(): Promise<void> {
     };
     result = await tools.inspect_svml_vocabulary(input as { package_names: readonly string[]; tags?: readonly string[]; include_previews?: boolean; run?: string });
   } else if (command === "validate_local_author_packages") {
-    result = await tools.validate_local_author_packages({ run: required(flags, "run"), ...(many(flags, "expected-package").length === 0 ? {} : { expected_packages: many(flags, "expected-package") }) });
+    const runtime = one(flags, "runtime");
+    result = await tools.validate_local_author_packages({
+      run: required(flags, "run"),
+      ...(runtime === undefined ? {} : { runtime }),
+      ...(many(flags, "expected-package").length === 0 ? {} : { expected_packages: many(flags, "expected-package") }),
+    });
   } else if (command === "validate_script_cues") {
     result = await tools.validate_script_cues({ run: required(flags, "run") });
   } else if (command === "render_element") {
@@ -651,7 +656,10 @@ async function main(): Promise<void> {
     };
     result = await tools.preview_check(input as { run: string; runtime?: string });
   } else if (command === "layout_check") {
-    result = await tools.layout_check((supplied ?? { run: required(flags, "run") }) as { run: string });
+    result = await tools.layout_check((supplied ?? {
+      run: required(flags, "run"),
+      ...(one(flags, "runtime") === undefined ? {} : { runtime: one(flags, "runtime") }),
+    }) as { run: string; runtime?: string });
   } else if (command === "layout_accept") {
     if (supplied !== undefined) result = await tools.layout_accept(supplied as never);
     else {
@@ -672,13 +680,17 @@ async function main(): Promise<void> {
     if (supplied === undefined && run === undefined) throw new Error(`a <build.svrun> is required\n\n${usage()}`);
     const input = supplied ?? {
       run,
+      ...(one(flags, "runtime") === undefined ? {} : { runtime: one(flags, "runtime") }),
       ...(one(flags, "reference-id") === undefined ? {} : { reference_id: one(flags, "reference-id") }),
     };
-    result = await tools.reconstruction_check(input as { run: string; reference_id?: string });
+    result = await tools.reconstruction_check(input as { run: string; reference_id?: string; runtime?: string });
   } else if (command === "authoring_check") {
     const run = operands[0];
     if (supplied === undefined && run === undefined) throw new Error(`a <build.svrun> is required\n\n${usage()}`);
-    result = await tools.authoring_check((supplied ?? { run }) as { run: string });
+    result = await tools.authoring_check((supplied ?? {
+      run,
+      ...(one(flags, "runtime") === undefined ? {} : { runtime: one(flags, "runtime") }),
+    }) as { run: string; runtime?: string });
   } else {
     throw new Error(`unknown command ${command}\n\n${usage()}`);
   }

--- a/packages/reference-video-tools/src/layout.ts
+++ b/packages/reference-video-tools/src/layout.ts
@@ -11,7 +11,11 @@ import puppeteer from "puppeteer-core";
 import { authorSource, invokedFrom, realizeAuthoringPreview, repositoryRoot, stageAuthoringPreview } from "./authoring.js";
 import { atomicJson } from "./state-files.js";
 
-export type LayoutCheckInput = { readonly run: string; readonly package_root?: string };
+export type LayoutCheckInput = {
+  readonly run: string;
+  readonly runtime?: string;
+  readonly package_root?: string;
+};
 export type LayoutAcceptance = { readonly finding: string; readonly reason: string };
 export type LayoutAcceptInput = {
   readonly run: string;

--- a/packages/reference-video-tools/src/tools.ts
+++ b/packages/reference-video-tools/src/tools.ts
@@ -142,6 +142,8 @@ export type InspectVocabularyInput = {
 };
 export type ValidateLocalAuthorPackagesInput = {
   readonly run: string;
+  /** Runtime Profile used to resolve accepted Build Records in a pinned Run. */
+  readonly runtime?: string;
   readonly expected_packages?: readonly string[];
 };
 export type CompareReconstructionInput = {
@@ -1277,12 +1279,17 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
       if (distributionPackageRoot !== undefined) {
         const registry = await loadStudioCompanionRegistry({ workspaceRoot: projectRoot, packageRoot: projectRoot, distributionPackageRoot });
         const domain = await loadStudioDomain({ run: runPath, workspaceRoot: projectRoot, packageRoot: projectRoot });
-        const archive = await openStudioArchive(undefined, projectRoot, projectRoot, distributionPackageRoot);
-        const loaded = await loadStudioRun({ run: runPath, domain, registry, ...(archive === undefined ? {} : { archive }) });
-        graphModules = new Set([
-          ...loaded.source.compiled.graph.operations.map((operation) => `${operation.producer.module.name}@${operation.producer.module.version}`),
-          ...loaded.run.graph.operations.map((operation) => `${operation.producer.module.name}@${operation.producer.module.version}`),
-        ]);
+        const runtimePath = input.runtime === undefined ? undefined : resolve(invokedFrom(), input.runtime);
+        const archive = await openStudioArchive(runtimePath, projectRoot, projectRoot, distributionPackageRoot);
+        try {
+          const loaded = await loadStudioRun({ run: runPath, domain, registry, ...(archive === undefined ? {} : { archive }) });
+          graphModules = new Set([
+            ...loaded.source.compiled.graph.operations.map((operation) => `${operation.producer.module.name}@${operation.producer.module.version}`),
+            ...loaded.run.graph.operations.map((operation) => `${operation.producer.module.name}@${operation.producer.module.version}`),
+          ]);
+        } finally {
+          await archive?.close();
+        }
       }
     } catch {
       // The normal check reports the compiler failure; package validation still returns precise
@@ -2547,7 +2554,7 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
     async preview_check(input): Promise<Record<string, unknown>> {
       const runPath = resolve(invokedFrom(), input.run);
       try {
-        const packageGate = await validateLocalAuthorPackages({ run: input.run });
+        const packageGate = await validateLocalAuthorPackages({ run: input.run, ...(input.runtime === undefined ? {} : { runtime: input.runtime }) });
         const cueGate = await scriptCueCheck({ run: input.run });
         if (packageGate.passed !== true || cueGate.passed !== true) {
           const refused = { run: runPath, sound: false, package_gate: packageGate, script_cue_gate: cueGate, refused: "package or Script Cue gate failed" };
@@ -2621,7 +2628,7 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
     async reconstruction_check(input): Promise<Record<string, unknown>> {
       const runPath = resolve(invokedFrom(), input.run);
       try {
-        const packageGate = await validateLocalAuthorPackages({ run: input.run });
+        const packageGate = await validateLocalAuthorPackages({ run: input.run, ...(input.runtime === undefined ? {} : { runtime: input.runtime }) });
         const cueGate = await scriptCueCheck({ run: input.run });
         if (packageGate.passed !== true || cueGate.passed !== true) {
           const refused = { run: runPath, passed: false, package_gate: packageGate, script_cue_gate: cueGate, issues: ["package or Script Cue gate failed"] };
@@ -2651,7 +2658,7 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
     async authoring_check(input): Promise<Record<string, unknown>> {
       const runPath = resolve(invokedFrom(), input.run);
       try {
-        const packageGate = await validateLocalAuthorPackages({ run: input.run });
+        const packageGate = await validateLocalAuthorPackages({ run: input.run, ...(input.runtime === undefined ? {} : { runtime: input.runtime }) });
         const cueGate = await scriptCueCheck({ run: input.run });
         if (packageGate.passed !== true || cueGate.passed !== true) {
           const refused = { run: runPath, passed: false, package_gate: packageGate, script_cue_gate: cueGate, issues: ["package or Script Cue gate failed"] };
@@ -2826,7 +2833,7 @@ export function createReferenceVideoTools(options: ToolOptions = {}): ReferenceV
       const packageBindingsPassed = packageBindings.every((binding) => binding.current_digest === binding.digest);
       const vocabularyPassed = stateBindingPassed && evidenceShapePassed && packageBindingsPassed
         && (inheritedContractPassed || inspectedContractPassed);
-      const packageGate = await validateLocalAuthorPackages({ run: runPath });
+      const packageGate = await validateLocalAuthorPackages({ run: runPath, ...(input.runtime === undefined ? {} : { runtime: input.runtime }) });
       const cueGate = await scriptCueCheck({ run: runPath });
       const graphGate = packageGate.passed === true && cueGate.passed === true
         ? await previewCheck({ run: runPath, ...(input.runtime === undefined ? {} : { runtime: input.runtime }) }, { packageRoot })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ importers:
 
   examples/minimal-author-package/packages/example-component:
     dependencies:
+      '@hypit/artifact':
+        specifier: workspace:*
+        version: link:../../../../packages/artifact
       '@hypit/component-kit':
         specifier: workspace:*
         version: link:../../../../packages/component-kit
@@ -273,6 +276,9 @@ importers:
       '@hypit/markup':
         specifier: workspace:*
         version: link:../../../../packages/markup
+      '@hypit/media':
+        specifier: workspace:*
+        version: link:../../../../packages/media
       '@hypit/program-space':
         specifier: workspace:*
         version: link:../../../../packages/program-space
@@ -282,6 +288,9 @@ importers:
       '@hypit/semantic-track':
         specifier: workspace:*
         version: link:../../../../packages/semantic-track
+      '@hypit/svs':
+        specifier: workspace:*
+        version: link:../../../../packages/svs
       '@hypit/temporal':
         specifier: workspace:*
         version: link:../../../../packages/temporal


### PR DESCRIPTION
修复当前 CI 阻塞：同步 minimal-author-package 示例的 workspace 依赖到 pnpm-lock.yaml，并完善带 build-record pin 的 Run 在各检查阶段传递 Runtime Profile；同时修正 KIE GPT Image 不支持比例的提前校验及 launcher 文档映射。\n\n验证：pnpm install --frozen-lockfile --offline；pnpm check；git diff --check。