### PR TITLE
fix: align ranking test with removed tier surface

### DIFF
--- a/packages/ranking/test/ranking.test.ts
+++ b/packages/ranking/test/ranking.test.ts
@@ -633,7 +633,7 @@ test("all three author Surfaces preserve explicit semantic, spatial, font, image
 });
 
 test("Ranking Surfaces declare their sealed Records and icon Producers consume Blob values", async () => {
-  for (const name of ["tier", "column", "top-three"]) {
+  for (const name of ["column", "top-three"]) {
     const surface = rankingMarkupSurfaces.find((item) => item.name === name);
     assert.ok(surface?.outputs.some((type) => type.name === rankingTypes.header.name), `${name} header output`);
     assert.ok(surface?.outputs.some((type) => type.name === rankingTypes.itemSpec.name), `${name} item output`);


### PR DESCRIPTION
修复 CI 在 Ubuntu 和 Windows 上共同失败的旧断言：TierBoard 公共 surface 已移除，测试仍要求它出现在 rankingMarkupSurfaces 中。仅同步现有测试预期，不新增测试。\n\n验证：ranking 定向测试 12/12 通过；git diff --check 通过。