### PR TITLE
docs: report skill gaps after route completion

### DIFF
--- a/.agents/skills/hypit/references/authoring.md
+++ b/.agents/skills/hypit/references/authoring.md
@@ -15,6 +15,12 @@ Never invent a
 component, attribute, child, port, Recipe property or literal value. Do not infer one package's
 syntax from a neighboring package.
 
+An admitted declaration value is not a promise that every Provider endpoint accepts it. Before a
+paid Build, run the Runtime preflight and read the selected Provider README for endpoint limits; a
+Provider may reject a value that the model-neutral package declares. For example, KIE's GPT Image 2
+endpoint rejects `4:3`, `3:4` and `4:5` even though the model contract admits those ratios. Resolve
+such a mismatch before submission, never after the first paid generation has completed.
+
 Install dependencies after package selections change. Validate with one command:
 
 ```bash
@@ -65,6 +71,14 @@ For a Run opened in Studio, add `--exclude-targets` and keep every declared Targ
 Target satisfied by its accepted media Record is an opaque finished file, so Studio cannot trace it
 to the current Film graph. The accepted-material Studio handoff is defined in
 `studio-confirmation.md`.
+
+Pinning accepted `build-record` Candidates does not invalidate the gates, but the archive must be
+opened with the Runtime Profile so those Records can be resolved. Pass the profile to every gate that
+supports it: `validate_local_author_packages --runtime <profile>`, `layout_check --runtime <profile>`,
+`reconstruction_check --runtime <profile>` and `authoring_check --runtime <profile>`; for
+`preview_check`, pass the profile as its optional second operand:
+`preview_check <run> <profile>`. Never remove accepted pins or rerun a paid Build just to make a gate
+read an archived Record.
 
 **Pin what a Provider was paid to make, and nothing the Source computes.** `--pin` emits a line for
 every accepted output, including the ones the Script's own structure produced: `speech.semantic`,

--- a/.agents/skills/hypit/references/local-author-package.md
+++ b/.agents/skills/hypit/references/local-author-package.md
@@ -74,8 +74,13 @@ themselves, so it says what will be accepted rather than what one package happen
 When `inspect_svml_vocabulary` finds no close structural sibling, write from these documents and the
 minimal fixture at `examples/minimal-author-package/packages/example-component/`. Do not read an
 unrelated business package to discover generic API shapes. If the public contract still leaves a
-required shape undefined, report a repository documentation defect instead of continuing package
-archaeology.
+required shape undefined, record the missing shape and its effect in route state, then continue with
+the closest bounded interpretation supported by the visible contract. Do not invent an undeclared
+binding or silently treat the gap as resolved. After the route has finished, report the
+Skill/documentation gap with the package/module and version, exact command and checkout commit,
+missing Type/Surface/Producer field, complete inspection output, expected authoring shape, and the
+smallest Source demonstrating the gap. A binding such as `<id>.audio` absent from both the README and
+inspection output is reported this way.
 
 There is one deliberate exception. If vocabulary inspection proves that an installed package has the
 same input/output Types, timing contract, terminal Track and Surface ports, and only the Style,
@@ -350,8 +355,8 @@ Checkpoint that evidence as a controlled waiver (or use `blocked` when no mainta
 available):
 
 ```bash
-hypit-reference-video-tools route_state checkpoint --project-root <project> --route <route> \
-  --step package-ready --status complete --artifacts '{"package_ready":".hypit/evidence/gate-waiver.json"}' \
+hypit-reference-video-tools route_state --action checkpoint --project-root <project> --route <route> \
+  --state package-ready --status complete --artifacts '{"package_ready":".hypit/evidence/gate-waiver.json"}' \
   --error "<exact gate error>" --decision "gate waiver recorded with reproducible diagnosis"
 ```
 

--- a/.agents/skills/hypit/references/preview.md
+++ b/.agents/skills/hypit/references/preview.md
@@ -35,6 +35,10 @@ The same check is also a bin of its own:
 hypit-preview-check /path/to/project/build.svrun
 ```
 
+When running from a contributor checkout, the exact launcher is
+`node <checkout>/bin/hypit-preview-check.mjs /path/to/project/build.svrun`. The bare command above
+is only the documented abbreviation; it is not a subcommand of `hypit`.
+
 Prefer the subcommand. `--package-root <dir>` is needed only when the project has no `package.json`
 or when an explicit package root is desired; it changes Host package lookup, not Source Workspace.
 With a project-root `package.json`, omit it. The bare bin fixes the package root to the Run file's own

--- a/.agents/skills/hypit/references/reconstruction/comparison-round.md
+++ b/.agents/skills/hypit/references/reconstruction/comparison-round.md
@@ -102,11 +102,22 @@ It paces the requests itself, keeps each comparison's derived cuts apart, and re
 only itself down. Do not write a shell script to fan these out: the pacing, the per-comparison result
 and the isolation are what the batch is for, and a hand-rolled loop has none of them.
 
-`--image` is available for one case only: the reference's own `visual:` observation states in words
-that the element is completely still. The judgement comes from the reference's observation, never
-from looking at your own render and concluding it does not move — deciding that from the
-reconstruction is how the wrong frame got chosen in the first place. Where the observation does not
-say still, compare the clip.
+`--image` is available when the reference's own `visual:` observation states in words that the
+element is completely still. It is also the deterministic fallback for an observer-rejected short
+window: if a token range contains only one word or its derived stretch is under one second, do not
+retry the clip. Render a still for that exact range and compare it with the same `--tokens` range:
+
+```bash
+hypit-reference-video-tools render_element <run> --element <id> --tokens <from:to> --out <still>.png
+hypit-reference-video-tools compare_reconstruction --reference-id <id> --run <run> \
+  --tokens <from:to> --image <still>.png --element <id>
+```
+
+This fallback compares the visible state at the range midpoint and does not claim anything about
+motion. The judgement for a normal window still comes from the reference observation, never from
+looking at your own render and deciding that it does not move. If a longer clip returns
+`INVALID_ARGUMENT`, record the complete error and treat it as a gate/provider defect rather than
+silently switching evidence modes.
 
 Pass `--element <id>` every time so the gate credits the comparison to that element.
 

--- a/.agents/skills/hypit/references/revision/route.md
+++ b/.agents/skills/hypit/references/revision/route.md
@@ -65,6 +65,32 @@ request-captured → impact-assessed → intent-mapped → source-updated
 → revision-complete → build-complete (only if paid generation changed)
 ```
 
+`revision_state` checkpoints use the numeric `--step` flag, not a stage name. The mapping is:
+
+| Step | Stage |
+|---:|---|
+| 1 | request-captured |
+| 2 | impact-assessed |
+| 3 | intent-mapped |
+| 4 | source-updated |
+| 5 | gates-checked |
+| 6 | preview-rendered |
+| 7 | review-complete |
+| 8 | final-checked |
+| 9 | revision-complete |
+| 10 | build-complete |
+
+For example, after editing Source, record step 4 with:
+
+```bash
+hypit-reference-video-tools revision_state --action checkpoint \
+  --project-root <project> --step 4 --status complete \
+  --decision "source update recorded"
+```
+
+Use the same numeric mapping for every later checkpoint; `--state` is not accepted by
+`revision_state`.
+
 `preview-rendered` and `review-complete` are not required work in this route. `review-complete` is
 deliberately not a VLM/observer step. Revision does not call
 `review_element`, `compare_reconstruction`, Vertex, WhisperX or any other visual observer. Mark that

--- a/.agents/skills/hypit/references/studio-confirmation.md
+++ b/.agents/skills/hypit/references/studio-confirmation.md
@@ -58,6 +58,8 @@ VLM, comparison, observer or visual judgement as part of Revision. Do not restar
 Studio merely because Source changed. If the startup parameters change (for example a different Run,
 workspace or port), stop the previous Studio first so the new server cannot collide with its port.
 
-Use the existing `preview.md` startup command and `revision_state` snapshot. Studio startup is a
+Use the existing `preview.md` startup command and `revision_state` snapshot. In a contributor
+checkout, `hypit-studio` means `node <checkout>/bin/hypit-studio.mjs` and is a standalone entrypoint,
+not `hypit studio`. Studio startup is a
 display handoff, not permission to Build; a new paid generation still requires a fresh cost
 confirmation.

--- a/.agents/skills/hypit/references/vocabulary.md
+++ b/.agents/skills/hypit/references/vocabulary.md
@@ -137,8 +137,8 @@ resuming package work, Source authoring or visual repair.
 
 ## A real gap
 
-For a real gap, stop authoring sources and read `local-author-package.md` completely. Implement and
-install the new project-local package, then run
+For a real gap, read `local-author-package.md` completely. Implement and install the new
+project-local package, then run
 `hypit-reference-video-tools inspect_svml_vocabulary` against it before using its tag. That call is
 not redundant with having just written the package: it proves the specifier
 resolves, the activation contribution is wired, and the loader can decode the Surface. `pnpm check`


### PR DESCRIPTION
更新 Hypit Skill 文档：契约缺口记录为路由状态，流程完成后再报告 Skill/文档缺陷；移除提交 GitHub Issue 和强制中断流程的要求。同时保留 launcher、pin Runtime、短比较窗口、Provider 限制及 revision checkpoint 文档修复。\n\n按要求未运行测试。