### PR TITLE
docs: require functional fit for component reuse

### DIFF
--- a/.agents/skills/hypit/references/vocabulary.md
+++ b/.agents/skills/hypit/references/vocabulary.md
@@ -80,6 +80,12 @@ and chooses one of three outcomes:
 - `project-local-package`: the difference materially changes the component's core look, function,
   structure or behaviour.
 
+Visual resemblance alone never qualifies a package for reuse. The candidate must also provide the
+required function and contract — its input/output Types, timing behavior, ports and role in the
+composition. A package that looks similar but performs a different job, exposes incompatible data,
+or has a different temporal contract is a `project-local-package`, even when its rendered shape is
+close. Do not force the Source through a visually similar tag just to avoid a package gap.
+
 Original authoring does not turn silence into a hidden specification. If the author asks for a
 ranking board without defining every icon, shadow or radius, those details remain the Agent's design
 space and an installed ranking component normally qualifies as `reuse-existing`. Reconstruction has


### PR DESCRIPTION
补充共享 vocabulary 判断边界：视觉外形相似不代表可复用；必须同时满足功能、输入输出类型、时序行为、端口和组合角色。功能不同的相似外观组件必须走 project-local-package。按要求未运行测试。