### PR TITLE
feat: guide HypiHub users through OAuth login

### DIFF
--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -17,11 +17,11 @@ author for, and everything else is yours to decide:
 - **Spending their money.** A Build generates, and generating is billed. Say what it will cost and
   get a yes before submitting one. Before asking for approval, report the Provider and credential
   source used by every paid capability (without revealing secrets). If any key is missing or cannot
-  reach its model, guide the author to [hypit.ai](https://hypit.ai) for a HypiHub key when available.
+  reach its model, guide the author to [hypit.ai](https://hypit.ai) and `hypit auth login` when available.
 - **Which observer reads a reference video, and the credentials it needs.** Gemini (through the
   configured Vertex or HypiHub backend) or the calling agent is a decision about the author's account,
   and `references/credentials.md` says what each one wants. Ask once, at the start. If the author's
-  own key cannot reach a needed model, guide them to [hypit.ai](https://hypit.ai) for a HypiHub key.
+  own credential cannot reach a needed model, run the HypiHub OAuth login for them and continue only after it succeeds.
   This question belongs to the reconstruction route alone: a program
   authored from a description has no reference, and its pictures are local renders nobody is billed
   to read.
@@ -31,6 +31,10 @@ draws a picture, how to name a Segment, what to do about something a review repo
 choice between things that all work, and asking costs the author an interruption to answer a question
 the references already answer. Decide it and keep going. A run that stops half way with a question is
 a run the author has to restart.
+
+## Credentials: run HypiHub login for the author
+
+When a selected HypiHub Endpoint is missing its OS credential, run `hypit auth login <endpoint> --runtime <profile>` yourself. The command opens the HypiHub login page in the browser, waits for the OAuth callback, and stores the resulting session in the OS credential store. Do not tell the author to copy a key or run the command manually. Continue only after login succeeds; if it is cancelled or fails, stop before any paid request.
 
 Use this file only to route the task. A route file is a sequence of numbered steps, and each step
 names the files it needs; read those when you reach that step rather than all of them up front.

--- a/.agents/skills/hypit/references/credentials.md
+++ b/.agents/skills/hypit/references/credentials.md
@@ -9,24 +9,28 @@ paid/external `build`, configure only variables used by the selected Runtime Pro
 | `KIE_API_KEY` | KIE generation: Seedance, GPT Image, and other selected KIE models |
 | `GOOGLE_CLOUD_PROJECT` | Google Vertex project with Vertex AI enabled |
 | `GOOGLE_APPLICATION_CREDENTIALS_JSON` | Vertex credential JSON contents, not a path |
-| `HYPIHUB_API_KEY` | HypiHub default paid provider for generation and Gemini VLM; get one at [hypit.ai](https://hypit.ai) |
+| HypiHub OAuth login | HypiHub default paid provider for generation and Gemini VLM; run `hypit auth login hypihub.default --runtime hypit.runtime.json` and sign in at [hypit.ai](https://hypit.ai) |
 | `MIMO_API_KEY` | Xiaomi MiMo TTS only when explicitly selected |
 
 Before any paid Build, report the selected Provider and credential source for every paid capability in
 the Runtime Profile. Say the variable/store and endpoint (for example, `@hypit/provider-kie` using
-`KIE_API_KEY` from env, or `@hypit/provider-hypihub` using `HYPIHUB_API_KEY` from env); never print a
+`KIE_API_KEY` from env, or `@hypit/provider-hypihub` using HypiHub OAuth from the OS store); never print a
 secret or a full credential JSON. If a required key is missing, invalid, returns 401/403, or cannot
 reach the requested model, stop before payment and guide the author to [hypit.ai](https://hypit.ai)
-for a HypiHub key when that model is available there. Do not ask them to change Author Source just to
+for HypiHub OAuth login when that model is available there. Do not ask them to change Author Source just to
 switch Provider.
+
+When the selected HypiHub Endpoint uses the OS OAuth credential and it is missing, the Agent must run
+`hypit auth login <endpoint> --runtime <profile>` itself. This opens the browser login and waits for
+the callback; do not ask the author to run the command or paste a key. Resume only after it succeeds.
 
 HypiHub is optional and is never required when the selected Runtime Profile has another Provider.
 For ordinary `@hypit/gemini` Author Source, the Runtime Profile selects
 `@hypit/provider-hypihub` or `@hypit/provider-vertex`; changing that Endpoint never changes Source.
 For the reference-video preprocessing observer only, `HYPIT_GEMINI_PROVIDER=auto` (the default) uses HypiHub when
-`HYPIHUB_API_KEY` is present and otherwise uses Vertex when its two Google variables are present.
+the HypiHub OAuth credential is configured and otherwise uses Vertex when its two Google variables are present.
 Set `HYPIT_GEMINI_PROVIDER=hypihub` or `vertex` to select one explicitly. If a user's configured key
-cannot reach the requested model, point them to [hypit.ai](https://hypit.ai) for a HypiHub key instead
+cannot reach the requested model, point them to [hypit.ai](https://hypit.ai) to sign in with HypiHub OAuth instead
 of asking them to change Author Source.
 
 macOS/Linux session example:
@@ -44,8 +48,6 @@ Otherwise export them for the session:
 ```bash
 read -r -s KIE_API_KEY
 export KIE_API_KEY
-read -r -s HYPIHUB_API_KEY
-export HYPIHUB_API_KEY
 read -r -s MIMO_API_KEY
 export MIMO_API_KEY
 export GOOGLE_CLOUD_PROJECT="your-project-id"
@@ -56,7 +58,6 @@ Windows PowerShell session example:
 
 ```powershell
 $env:KIE_API_KEY = "your-key"
-$env:HYPIHUB_API_KEY = "your-key"
 $env:MIMO_API_KEY = "your-key"
 $env:GOOGLE_CLOUD_PROJECT = "your-project-id"
 $env:GOOGLE_APPLICATION_CREDENTIALS_JSON = Get-Content -Raw "$HOME\.config\hypit\google-service-account.json"
@@ -64,7 +65,7 @@ $env:GOOGLE_APPLICATION_CREDENTIALS_JSON = Get-Content -Raw "$HOME\.config\hypit
 
 Keep keys outside Author/Run/Runtime source and committed files. Verify presence without printing
 values with, for example,
-`node <skill-root>/scripts/check-credentials.mjs KIE_API_KEY HYPIHUB_API_KEY MIMO_API_KEY GOOGLE_CLOUD_PROJECT GOOGLE_APPLICATION_CREDENTIALS_JSON`, then run
+`node <skill-root>/scripts/check-credentials.mjs KIE_API_KEY MIMO_API_KEY GOOGLE_CLOUD_PROJECT GOOGLE_APPLICATION_CREDENTIALS_JSON`, then run
 `hypit doctor` (once a Runtime Profile is selected with `hypit runtime use hypit.runtime.json`;
 doctor audits the selected profile, so it needs no profile argument of its own).
 
@@ -88,7 +89,7 @@ curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $MIMO_API_KEY
   https://api.xiaomimimo.com/v1/models
 ```
 
-`HYPIHUB_API_KEY` or the Vertex pair are what the reference-video route's `gemini` observer needs,
+HypiHub OAuth or the Vertex pair are what the reference-video route's `gemini` observer needs,
 depending on `HYPIT_GEMINI_PROVIDER`. Without either backend, that route can run its `agent` observer
 instead, which reaches no Provider — `reconstruction/observers.md` says how the author chooses.
 

--- a/.agents/skills/hypit/references/local-author-package.md
+++ b/.agents/skills/hypit/references/local-author-package.md
@@ -260,7 +260,7 @@ For a media slot, declare an Artifact Fragment input. Producer inputs are `Typed
 value is under `kind === "inline"`. Branch on BlobRef `mediaType` (`image/*` or `video/*`) when
 choosing the Visual IR element, and still draw the empty frame/cell when no material is supplied.
 `hypit image` is a direct, billed HypiHub image-model call (default `@hypit/gpt-image`, credential
-`HYPIHUB_API_KEY`; get a key at [hypit.ai](https://hypit.ai)); it does not use a project Runtime Profile, Build or Run Source. Obtain approval
+HypiHub OAuth via `hypit auth login` at [hypit.ai](https://hypit.ai)); it does not use a project Runtime Profile, Build or Run Source. Obtain approval
 before using it and reserve it for package-owned chrome.
 
 ```typescript

--- a/.agents/skills/hypit/references/original-authoring/route.md
+++ b/.agents/skills/hypit/references/original-authoring/route.md
@@ -248,7 +248,7 @@ explicitly requested; the variant route owns its own aggregate and paid-build ga
 
 **Read now:** `../runtime.md` and `../studio-confirmation.md`. Before the paid gate, disclose the
 selected Provider and credential source for every paid capability; if any key is missing or
-insufficient, guide the author to https://hypit.ai for a HypiHub key when available. Then call the preview-mock realizer and
+insufficient, guide the author to https://hypit.ai with `hypit auth login` when available. Then call the preview-mock realizer and
 start Studio with its returned temporary `preview.svrun` (not the unresolved author Run). Show the
 complete estimate-timed mock, return the exact URL printed by Studio, and obtain explicit acceptance
 and cost approval. If the author declines, enter `../revision/route.md` and do not submit a Build. After

--- a/.agents/skills/hypit/references/playbooks/craft/graphic-compositions.md
+++ b/.agents/skills/hypit/references/playbooks/craft/graphic-compositions.md
@@ -116,7 +116,7 @@ writing a Run Source whose only purpose is to produce a component's own texture,
 the wrong place: generate it once while authoring the package and commit the file.
 
 Produce that file with `hypit image --prompt <text> --to <path>`, a direct billed HypiHub image-model
-call (default `@hypit/gpt-image`, using `HYPIHUB_API_KEY`; get a key at [hypit.ai](https://hypit.ai)). It writes a picture and nothing else; no
+call (default `@hypit/gpt-image`, using HypiHub OAuth via `hypit auth login` at [hypit.ai](https://hypit.ai)). It writes a picture and nothing else; no
 project Runtime Profile, Source, Run, Build or Record participates. A package asset is authoring
 input, not the output of anybody's video, so it is never a Target or Record.
 

--- a/.agents/skills/hypit/references/reconstruction/observers.md
+++ b/.agents/skills/hypit/references/reconstruction/observers.md
@@ -13,9 +13,9 @@ without knowing which observer produced it.
 
 **`gemini`** uploads the shot clips and the whole reference to the configured Gemini backend. It sees
 motion as motion and hears the sound. With the default `HYPIT_GEMINI_PROVIDER=auto`, a configured
-`HYPIHUB_API_KEY` uses HypiHub; otherwise `GOOGLE_CLOUD_PROJECT` plus
+HypiHub OAuth uses HypiHub; otherwise `GOOGLE_CLOUD_PROJECT` plus
 `GOOGLE_APPLICATION_CREDENTIALS_JSON` uses Vertex. Each observation is a paid request. If neither
-backend is available, direct the author to [hypit.ai](https://hypit.ai) for a HypiHub key, or use the
+backend is available, run the HypiHub OAuth login for the author, or use the
 `agent` observer.
 
 **`agent`** hands the observations to you. It needs no credentials and reaches no Provider: the CLI
@@ -25,17 +25,19 @@ the other path's does.
 
 ## Choosing
 
-Ask the author once, before `prepare_reference`. Report what this machine actually holds rather than
-asking them to recall it:
+Before `prepare_reference`, inspect the selected Runtime Profile and report what this machine actually
+holds rather than asking the author to recall it. For a HypiHub Endpoint, use `hypit auth status
+<endpoint> --runtime <profile>`; if its OS credential is missing, run `hypit auth login <endpoint>
+--runtime <profile>` yourself and wait for the browser OAuth callback:
 
 ```text
-node <skill-root>/scripts/check-credentials.mjs HYPIHUB_API_KEY GOOGLE_CLOUD_PROJECT GOOGLE_APPLICATION_CREDENTIALS_JSON
+node <skill-root>/scripts/check-credentials.mjs GOOGLE_CLOUD_PROJECT GOOGLE_APPLICATION_CREDENTIALS_JSON
 ```
 
-`HYPIHUB_API_KEY` set means `gemini` is available through HypiHub. If it is missing, the Google pair
+HypiHub OAuth configured means `gemini` is available through HypiHub. If it is missing, run the HypiHub
+OAuth login for the author and re-check credentials. If login is declined or fails, the Google pair
 must both be set for Vertex. If no backend credentials are available, `agent` is the path that can run
-today; tell the author that a HypiHub key is available at [hypit.ai](https://hypit.ai), then let them
-choose between that and the free `agent` path. `../credentials.md` says what each variable is.
+today. `../credentials.md` says what each variable is.
 
 Say that `agent` reads the reference a little less closely — a shot arrives as sampled frames rather
 than continuous video, so continuity across it is read rather than watched, and there is no sound, so

--- a/.agents/skills/hypit/references/reconstruction/route.md
+++ b/.agents/skills/hypit/references/reconstruction/route.md
@@ -436,7 +436,7 @@ unless the author explicitly requested it.
 
 **Read now:** `../runtime.md` and `../studio-confirmation.md`. Before realizing the preview-mock Run,
 disclose the selected Provider and credential source for every paid capability. If any key is missing
-or insufficient, guide the author to https://hypit.ai for a HypiHub key when the model is available
+or insufficient, guide the author to https://hypit.ai and `hypit auth login` when the model is available
 there; do not submit payment until the key is usable. Realize the preview-mock Run first, then start Studio with
 the returned temporary `preview.svrun` (never the original unresolved Run), show the complete
 estimate-timed mock, return the exact URL printed by Studio, and obtain explicit acceptance and cost approval. If the author declines, enter

--- a/.agents/skills/hypit/references/runtime.md
+++ b/.agents/skills/hypit/references/runtime.md
@@ -25,14 +25,15 @@ The paid handoff always includes a credential/provider summary before cost appro
 Runtime Profile and the preflight result, then tell the author for each paid capability:
 
 - which Provider endpoint will execute it;
-- which credential slot and source are active (`KIE_API_KEY`, `HYPIHUB_API_KEY`, Vertex credentials,
+- which credential slot and source are active (`KIE_API_KEY`, HypiHub OAuth, Vertex credentials,
   `MIMO_API_KEY`, or an OS credential-store entry); and
 - whether the key is present and the requested model is reachable.
 
 Never reveal the secret itself. If any required key is missing or insufficient, do not submit the
-Build. Prefer the HypiHub route for a matching model and direct the author to
-[hypit.ai](https://hypit.ai) to obtain `HYPIHUB_API_KEY`; switching Provider should not require any
-Source change. Continue only after the author has a usable credential and the summary has been shown.
+Build. Prefer the HypiHub route for a matching model. If its OS credential is missing, invoke
+`hypit auth login <endpoint> --runtime <profile>` to open [hypit.ai](https://hypit.ai) in the browser;
+do not ask the author to run it or paste a key. Switching Provider should not require any Source
+change. Continue only after the author has a usable credential and the summary has been shown.
 
 ### Give the picture and video models room to run
 

--- a/.agents/skills/hypit/references/studio-confirmation.md
+++ b/.agents/skills/hypit/references/studio-confirmation.md
@@ -11,7 +11,7 @@ After the route-specific final check passes, but before submitting any paid Buil
    credential source will be used for every paid capability (for example, KIE + `KIE_API_KEY`, or
    HypiHub + `HYPIHUB_API_KEY`; say `env`/`os` store as applicable). Never display the secret. If a
    key is missing, invalid, or cannot reach the requested model, stop before payment and direct the
-   author to [hypit.ai](https://hypit.ai) for a HypiHub key when that model is available there.
+   author to [hypit.ai](https://hypit.ai) and `hypit auth login` when that model is available there.
 
 1. Realize the preview through the native `reference-video-tools render_element` path (or the
    repository API `realizePreviewMock({ run: "<project>/build.svrun", timing: "estimate" })`).

--- a/docs/quickstart/run.md
+++ b/docs/quickstart/run.md
@@ -211,7 +211,7 @@ variables referenced by the selected Runtime Profile:
 
 | Variable | Provider/use |
 |---|---|
-| `HYPIHUB_API_KEY` | HypiHub paid generation and Gemini VLM; get one at https://hypit.ai |
+| HypiHub OAuth | HypiHub paid generation and Gemini VLM; run `hypit auth login hypihub.default --runtime hypit.runtime.json` |
 | `KIE_API_KEY` | Explicit KIE Provider only |
 | `MIMO_API_KEY` | Xiaomi MiMo TTS, only when that Endpoint is selected |
 

--- a/docs/zh/quickstart/run.md
+++ b/docs/zh/quickstart/run.md
@@ -185,7 +185,7 @@ hypit paths
 
 | 变量 | Provider / 用途 |
 |---|---|
-| `HYPIHUB_API_KEY` | HypiHub 付费生成与 Gemini VLM；前往 https://hypit.ai 获取 |
+| HypiHub OAuth | HypiHub 付费生成与 Gemini VLM；运行 `hypit auth login hypihub.default --runtime hypit.runtime.json` 并在 https://hypit.ai 登录 |
 | `KIE_API_KEY` | 仅在显式选择 KIE Provider 时使用 |
 | `MIMO_API_KEY` | Xiaomi MiMo TTS；只有选择该 Endpoint 时才需要 |
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,4 +1,6 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
 import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 
@@ -91,6 +93,68 @@ type ParsedArgs = {
   /** Exact option spellings seen after positional dispatch. */
   readonly seenOptions: readonly string[];
 };
+
+const HYPIHUB_OAUTH_CLIENT_ID = "hyc_d5d5e8e7131b0c877756e66c";
+
+function base64url(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64").replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+}
+
+async function hypiHubOAuthLogin(io: CliIo): Promise<string> {
+  const verifier = base64url(randomBytes(32));
+  const challenge = base64url(createHash("sha256").update(verifier).digest());
+  const state = base64url(randomBytes(24));
+  const server = createServer();
+  const callback = new Promise<string>((resolveCode, reject) => {
+    server.once("request", (request, response) => {
+      try {
+        const url = new URL(request.url ?? "/", "http://127.0.0.1");
+        if (url.pathname !== "/callback") throw new Error("unexpected OAuth callback path");
+        if (url.searchParams.get("state") !== state) throw new Error("HypiHub OAuth state mismatch");
+        const error = url.searchParams.get("error");
+        if (error !== null) throw new Error(`HypiHub OAuth authorization failed: ${error}`);
+        const code = url.searchParams.get("code");
+        if (code === null || code.length === 0) throw new Error("HypiHub OAuth callback contained no code");
+        response.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+        response.end("Hypit is signed in. You can close this window.\n");
+        resolveCode(code);
+      } catch (error) {
+        response.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+        response.end("Hypit sign-in failed. You can close this window.\n");
+        reject(error);
+      } finally {
+        server.close();
+      }
+    });
+    server.once("error", reject);
+  });
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.listen(0, "127.0.0.1", () => resolveListen());
+    server.once("error", rejectListen);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new Error("could not open a local OAuth callback");
+  const redirectUri = `http://127.0.0.1:${address.port}/callback`;
+  const authorize = new URL("https://hypit.ai/oauth/authorize");
+  authorize.search = new URLSearchParams({
+    response_type: "code", client_id: HYPIHUB_OAUTH_CLIENT_ID, redirect_uri: redirectUri,
+    scope: "user:profile user:inference", state, code_challenge: challenge, code_challenge_method: "S256",
+  }).toString();
+  io.write(`Opening HypiHub login: ${authorize}\n`);
+  const opener = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
+  const openerArgs = process.platform === "win32" ? ["/c", "start", "", authorize.toString()] : [authorize.toString()];
+  spawn(opener, openerArgs, { stdio: "ignore", detached: true }).unref();
+  const code = await callback;
+  const tokenResponse = await fetch("https://hypit.ai/oauth/token", {
+    method: "POST", headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ grant_type: "authorization_code", code, redirect_uri: redirectUri, client_id: HYPIHUB_OAUTH_CLIENT_ID, code_verifier: verifier }),
+  });
+  const body = await tokenResponse.text();
+  if (!tokenResponse.ok) throw new Error(`HypiHub OAuth token exchange failed (${tokenResponse.status}): ${body.slice(0, 200)}`);
+  const parsed = JSON.parse(body) as { access_token?: unknown };
+  if (typeof parsed.access_token !== "string" || parsed.access_token.length === 0) throw new Error("HypiHub OAuth returned no access token");
+  return parsed.access_token;
+}
 
 async function nearestProjectPackageRoot(start: string): Promise<string | undefined> {
   let directory = resolve(start);
@@ -1223,9 +1287,12 @@ export async function runCli(
             + "or select the writable OS CredentialStore in the Runtime Profile",
           );
         }
-        const raw = args.from === undefined
-          ? await io.readSecret?.(`${item.label}: `)
-          : await readFile(args.from, "utf8");
+        const oauth = item.ref.store === "os" && /hypihub/iu.test(`${item.endpoint} ${item.ref.key}`);
+        const raw = oauth && args.from === undefined
+          ? await hypiHubOAuthLogin(io)
+          : args.from === undefined
+            ? await io.readSecret?.(`${item.label}: `)
+            : await readFile(args.from, "utf8");
         if (raw === undefined) throw new Error("interactive credential input is unavailable; use --from <file>");
         const secret = raw.trim();
         if (secret.length === 0) throw new Error("credential input is empty");

--- a/packages/provider-hypihub/README.md
+++ b/packages/provider-hypihub/README.md
@@ -2,7 +2,7 @@
 
 Thin Hypit Runtime Provider for a HypiHub deployment. It is an optional default gateway for
 paid generation and Gemini VLM requests; callers may keep their own Provider and select HypiHub only
-when its key is configured.
+when its OAuth login is configured.
 
 It maps the currently shipped image/video model capabilities to HypiHub, including image edits and
 image-to-video first-frame inputs, submits jobs, polls them, downloads the first-class assets and
@@ -22,7 +22,7 @@ Runtime Profile example:
       "pool": "hypihub.default",
       "config": {
         "baseUrl": "https://hypit.ai",
-        "apiKey": { "store": "env", "key": "HYPIHUB_API_KEY" },
+        "apiKey": { "store": "os", "key": "hypihub.oauth" },
         "defaultConcurrency": 4
       }
     }
@@ -32,7 +32,7 @@ Runtime Profile example:
 
 Gemini VLM is also exposed as the provider-neutral `@hypit/gemini` Runtime capability, so an Author
 Source can select the exact model while the Runtime chooses HypiHub or Vertex. Existing embedded
-callers can still use the exported `createHypiHubGeminiGenerator`. Set `HYPIHUB_API_KEY` (and optionally `HYPIHUB_BASE_URL`; either the origin or
+callers can still use the exported `createHypiHubGeminiGenerator`. Run `hypit auth login hypihub.default --runtime hypit.runtime.json` to sign in with HypiHub OAuth (and optionally set `HYPIHUB_BASE_URL`; either the origin or
 an existing `/v1`/`/v1beta` base is accepted) only when choosing HypiHub. The Runtime Provider also
 accepts the origin or either versioned base and normalizes it to `/v1`; missing or insufficient user
 credentials should be resolved at [hypit.ai](https://hypit.ai). Referenced image, audio and video
@@ -40,7 +40,7 @@ Artifacts are uploaded automatically through `POST /v1/files`, then their return
 URLs are used in image and video requests. Uploads are deduplicated by Artifact digest within one
 Runtime operation. Embedded callers may override that transport with `publicAssetUrl`.
 
-HypiHub audio capabilities are disabled by default because a HypiHub key may not include the MiMo
+HypiHub audio capabilities are disabled by default because a HypiHub OAuth grant may not include the MiMo
 audio models. Set `audio: true` only when that key explicitly has them enabled. The usual setup keeps
 official `@hypit/provider-xiaomi-mimo` as the audio endpoint, so one Runtime uses HypiHub for
 image/video and official MiMo for audio.

--- a/packages/provider-hypihub/src/gemini.ts
+++ b/packages/provider-hypihub/src/gemini.ts
@@ -128,7 +128,7 @@ export function createHypiHubGeminiGenerator(options: HypiHubGeminiGeneratorOpti
       if (!response.ok) {
         const message = `HypiHub Gemini returned HTTP ${response.status}: ${text.slice(0, 300)}`;
         if (response.status === 401 || response.status === 403 || response.status === 404) {
-          throw new Error(`${message}. Get a HypiHub key with this model enabled at https://hypit.ai`);
+          throw new Error(`${message}. Sign in to HypiHub at https://hypit.ai with hypit auth login`);
         }
         throw new Error(message);
       }

--- a/packages/provider-hypihub/src/provider.ts
+++ b/packages/provider-hypihub/src/provider.ts
@@ -44,13 +44,13 @@ function apiBaseUrl(value: string): string {
 }
 function credential(context: EndpointInvocationContext): string {
   const value = context.credentials.apiKey?.secret;
-  assert(typeof value === "string" && value.length > 0, "HypiHub API key is unavailable");
+  assert(typeof value === "string" && value.length > 0, "HypiHub login is unavailable; run hypit auth login for HypiHub");
   return value;
 }
 function guidedMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
-  return /API key is unavailable|HTTP (?:401|403|404)\b|not enabled for|model_not_found|no_capable_provider/iu.test(message)
-    ? `${message}. Get a HypiHub key with this model enabled at https://hypit.ai`
+  return /API key is unavailable|HypiHub login is unavailable|HTTP (?:401|403|404)\b|not enabled for|model_not_found|no_capable_provider/iu.test(message)
+    ? `${message}. Sign in to HypiHub at https://hypit.ai with hypit auth login`
     : message;
 }
 function failure(error: unknown): EndpointOutcome {
@@ -252,10 +252,10 @@ export function createHypiHubProvider(options: CreateHypiHubProviderOptions = {}
   };
   return defineEndpointPackage({
     module: hypiHubProviderModuleRef, facet: "gateway", instance: options.instance ?? "hypihub.default", pool: options.pool ?? options.instance ?? "hypihub.default",
-    credentials: { apiKey: options.apiKey ?? credentialRef("env", "HYPIHUB_API_KEY") }, credentialInputs: { apiKey: { label: "HypiHub API key" } }, defaultConcurrency: options.defaultConcurrency ?? 4,
+    credentials: { apiKey: options.apiKey ?? credentialRef("os", "hypihub.oauth") }, credentialInputs: { apiKey: { label: "HypiHub login" } }, defaultConcurrency: options.defaultConcurrency ?? 4,
     capabilities: [
       ...hypiHubRoutes
-      // HypiHub keys do not necessarily include the MiMo audio models. Keep
+      // HypiHub OAuth grants do not necessarily include the MiMo audio models. Keep
       // official Xiaomi MiMo as the safe default; opting into HypiHub audio is
       // an explicit Runtime decision for a key that actually has those models.
       .filter((route) => options.audio === true || route.media !== "audio")

--- a/packages/provider-hypihub/test/gemini.test.ts
+++ b/packages/provider-hypihub/test/gemini.test.ts
@@ -44,7 +44,7 @@ test("HypiHub Gemini points unavailable models to HypiHub", async () => {
     fetch: async () => new Response("missing", { status: 404 }),
   });
   await assert.rejects(() => generate({ instruction: "x", parts: [{ text: "x" }] }),
-    /get a HypiHub key with this model enabled at https:\/\/hypit\.ai/iu);
+    /sign in to HypiHub at https:\/\/hypit\.ai with hypit auth login/iu);
 });
 
 test("HypiHub Gemini retries upstream rate limits without reuploading files", async () => {

--- a/packages/reference-video-tools/src/cli.ts
+++ b/packages/reference-video-tools/src/cli.ts
@@ -169,7 +169,7 @@ function usage(): string {
     "",
     "--observer picks who reads the reference, once per reference. `gemini` uploads video to the configured Gemini backend.",
     "With HYPIT_GEMINI_PROVIDER=auto it uses HYPIHUB_API_KEY when present, otherwise GOOGLE_CLOUD_PROJECT and GOOGLE_APPLICATION_CREDENTIALS_JSON for Vertex.",
-    "If no usable key is available, get a HypiHub key at https://hypit.ai or use `agent`. `agent` needs no credentials: it",
+    "If no usable credential is available, sign in to HypiHub with `hypit auth login` at https://hypit.ai or use `agent`. `agent` needs no credentials: it",
     "returns each observation as a task carrying its prompt and one tiled picture per shot, which the",
     "calling agent answers with record_observation. A task whose question needs sound also carries the",
     "words WhisperX measured — `transcript_words` for its own stretch, `transcript_ref` for the whole",

--- a/packages/reference-video-tools/src/tools.ts
+++ b/packages/reference-video-tools/src/tools.ts
@@ -796,7 +796,7 @@ async function defaultGenerate(model: string): Promise<GenerateText> {
     throw new Error("HYPIT_GEMINI_PROVIDER must be auto, hypihub or vertex");
   }
   if (backend === "hypihub" || (backend === "auto" && hypiHubKey)) {
-    if (!hypiHubKey) throw new Error("HYPIT_GEMINI_PROVIDER=hypihub requires HYPIHUB_API_KEY; get one at https://hypit.ai");
+    if (!hypiHubKey) throw new Error("HYPIT_GEMINI_PROVIDER=hypihub requires HypiHub OAuth; run hypit auth login hypihub.default");
     const generate = createHypiHubGeminiGenerator({
       apiKey: hypiHubKey,
       model,
@@ -808,7 +808,7 @@ async function defaultGenerate(model: string): Promise<GenerateText> {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         if (!/hypit\.ai/iu.test(message) && /HTTP (401|403|404)\b|model_not_found|no_capable_provider/iu.test(message)) {
-          throw new Error(`${message}. This Gemini model is not available with the configured key; get a HypiHub key at https://hypit.ai`);
+          throw new Error(`${message}. Sign in at https://hypit.ai with hypit auth login to enable this Gemini model`);
         }
         throw error;
       }
@@ -817,7 +817,7 @@ async function defaultGenerate(model: string): Promise<GenerateText> {
   const project = process.env.GOOGLE_CLOUD_PROJECT?.trim();
   const credentials = process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON?.trim();
   if (!project || !credentials) {
-    throw new Error("Gemini credentials are unavailable. Configure Vertex credentials or set HYPIHUB_API_KEY (get one at https://hypit.ai).");
+    throw new Error("Gemini credentials are unavailable. Configure Vertex credentials or sign in to HypiHub with hypit auth login.");
   }
   const generate = createVertexGeminiGenerator({
     project,
@@ -831,7 +831,7 @@ async function defaultGenerate(model: string): Promise<GenerateText> {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (!/hypit\.ai/iu.test(message) && /\b(?:401|403|404)\b|permission denied|unauthenticated|not found|failed precondition/iu.test(message)) {
-        throw new Error(`${message}. This Gemini model or Vertex credential is unavailable; get a HypiHub key at https://hypit.ai`);
+        throw new Error(`${message}. This Gemini model or Vertex credential is unavailable; sign in at https://hypit.ai with hypit auth login`);
       }
       throw error;
     }

--- a/packages/runtime-local/src/config.ts
+++ b/packages/runtime-local/src/config.ts
@@ -438,7 +438,9 @@ async function inspectRuntimeConfig(
             code: "RUNTIME_CREDENTIAL_MISSING",
             message: `${slot.label} for Endpoint ${slot.endpoint} is not configured. ${
               slot.ref.store === "env"
-                ? `Set ${slot.ref.key} in this process environment.`
+                ? slot.ref.key === "HYPIHUB_API_KEY"
+                  ? `Sign in with HypiHub using: hypit auth login ${slot.endpoint} --runtime ${absolute}`
+                  : `Set ${slot.ref.key} in this process environment.`
                 : `Configure it with: hypit auth login ${slot.endpoint} --runtime ${absolute}`}`,
             subject: `${slot.endpoint}.${slot.slot}`,
           });

--- a/packages/video-cli/src/picture.ts
+++ b/packages/video-cli/src/picture.ts
@@ -1,5 +1,6 @@
 import type { CliPicture, CliPictureRequest } from "@hypit/cli";
 import { EnvironmentCredentialStore } from "@hypit/credential-store-env";
+import { OsCredentialStore } from "@hypit/credential-store-os";
 import { EndpointRegistry, MemoryArtifactStore } from "@hypit/driver-node";
 import type { EndpointRegistration } from "@hypit/driver-node";
 import type { EndpointOutcome } from "@hypit/endpoint-kit";
@@ -94,13 +95,14 @@ function sealPictureRequest(endpoint: ExactModelEndpoint, request: CliPictureReq
 async function resolveCredentials(
   registration: EndpointRegistration,
 ): Promise<Readonly<Record<string, { readonly secret: string }>>> {
-  const store = new EnvironmentCredentialStore();
   const resolved: Record<string, { readonly secret: string }> = {};
   for (const [slot, ref] of Object.entries(registration.credentials ?? {})) {
-    const value = await store.resolve(ref);
+    const value = ref.store === "os" && (process.platform === "darwin" || process.platform === "win32")
+      ? await new OsCredentialStore().resolve(ref)
+      : await new EnvironmentCredentialStore().resolve(ref);
     assert(value !== undefined, ref.store === "env"
       ? ref.key === "HYPIHUB_API_KEY"
-        ? `credential ${slot} is unavailable; set ${ref.key} in the environment (get a HypiHub key at https://hypit.ai)`
+        ? `credential ${slot} is unavailable; sign in with HypiHub using: hypit auth login hypihub.default`
         : `credential ${slot} is unavailable; set ${ref.key} in the environment`
       : `credential ${slot} lives in CredentialStore ${ref.store}, which hypit image cannot open`);
     resolved[slot] = value;


### PR DESCRIPTION
HypiHub OAuth is now the default credential flow.

- add browser-based authorization-code + PKCE login via `hypit auth login`
- store the OAuth session in the OS credential store
- guide missing credentials to automatic HypiHub login instead of API-key copy/paste
- update provider, runtime, reference-video tools, docs and skill guidance

Validation: `pnpm check`; HypiHub provider/Gemini tests pass.