### PR TITLE
fix: keep image CLI credential fallback

### DIFF
--- a/packages/video-cli/src/picture.ts
+++ b/packages/video-cli/src/picture.ts
@@ -98,13 +98,13 @@ async function resolveCredentials(
   const resolved: Record<string, { readonly secret: string }> = {};
   for (const [slot, ref] of Object.entries(registration.credentials ?? {})) {
     const value = ref.store === "os" && (process.platform === "darwin" || process.platform === "win32")
-      ? await new OsCredentialStore().resolve(ref)
+      ? await new OsCredentialStore().resolve(ref) ?? await new EnvironmentCredentialStore().resolve({ store: "env", key: "HYPIHUB_API_KEY" })
       : await new EnvironmentCredentialStore().resolve(ref);
-    assert(value !== undefined, ref.store === "env"
-      ? ref.key === "HYPIHUB_API_KEY"
-        ? `credential ${slot} is unavailable; sign in with HypiHub using: hypit auth login hypihub.default`
-        : `credential ${slot} is unavailable; set ${ref.key} in the environment`
-      : `credential ${slot} lives in CredentialStore ${ref.store}, which hypit image cannot open`);
+    assert(value !== undefined, ref.key === "HYPIHUB_API_KEY"
+      ? `credential ${slot} is unavailable; sign in with HypiHub using: hypit auth login hypihub.default`
+      : ref.store === "env"
+        ? `credential ${slot} is unavailable; set ${ref.key} in the environment`
+        : `credential ${slot} lives in CredentialStore ${ref.store}, which hypit image cannot open`);
     resolved[slot] = value;
   }
   return resolved;


### PR DESCRIPTION
Fix CI failure introduced by the OAuth default credential reference.

The standalone `hypit image` path has no Runtime CredentialStore, so it now tries the OS HypiHub OAuth credential where supported and falls back to `HYPIHUB_API_KEY` for the legacy lightweight path and CI. Runtime/Profile builds continue using the OS OAuth flow.

Validation: `pnpm check`; `packages/video-cli/test/cli.test.ts`.