### PR TITLE
fix: hide OAuth browser launcher console

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -143,7 +143,7 @@ async function hypiHubOAuthLogin(io: CliIo): Promise<string> {
   io.write(`Opening HypiHub login: ${authorize}\n`);
   const opener = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
   const openerArgs = process.platform === "win32" ? ["/c", "start", "", authorize.toString()] : [authorize.toString()];
-  spawn(opener, openerArgs, { stdio: "ignore", detached: true }).unref();
+  spawn(opener, openerArgs, { stdio: "ignore", detached: true, windowsHide: true }).unref();
   const code = await callback;
   const tokenResponse = await fetch("https://hypit.ai/oauth/token", {
     method: "POST", headers: { "content-type": "application/x-www-form-urlencoded" },


### PR DESCRIPTION
Repository hygiene flagged the OAuth browser launcher because its detached child process did not declare `windowsHide`. Add the flag so the login flow does not open a console window on Windows and the repository check passes.

Validation: `pnpm check`, video CLI tests, repository hygiene.