### PR TITLE
Align HypiHub provider concurrency

### DIFF
--- a/packages/provider-hypihub/README.md
+++ b/packages/provider-hypihub/README.md
@@ -23,7 +23,7 @@ Runtime Profile example:
       "config": {
         "baseUrl": "https://hypit.ai",
         "apiKey": { "store": "os", "key": "hypihub.oauth" },
-        "defaultConcurrency": 4
+        "defaultConcurrency": 10
       }
     }
   }

--- a/packages/provider-hypihub/src/provider.ts
+++ b/packages/provider-hypihub/src/provider.ts
@@ -252,7 +252,7 @@ export function createHypiHubProvider(options: CreateHypiHubProviderOptions = {}
   };
   return defineEndpointPackage({
     module: hypiHubProviderModuleRef, facet: "gateway", instance: options.instance ?? "hypihub.default", pool: options.pool ?? options.instance ?? "hypihub.default",
-    credentials: { apiKey: options.apiKey ?? credentialRef("os", "hypihub.oauth") }, credentialInputs: { apiKey: { label: "HypiHub login" } }, defaultConcurrency: options.defaultConcurrency ?? 4,
+    credentials: { apiKey: options.apiKey ?? credentialRef("os", "hypihub.oauth") }, credentialInputs: { apiKey: { label: "HypiHub login" } }, defaultConcurrency: options.defaultConcurrency ?? 10,
     capabilities: [
       ...hypiHubRoutes
       // HypiHub OAuth grants do not necessarily include the MiMo audio models. Keep
@@ -268,7 +268,6 @@ export function createHypiHubProvider(options: CreateHypiHubProviderOptions = {}
         lifecycle: "immediate" as const,
         handler: geminiEndpoint,
         lane: "gemini",
-        maxConcurrency: 1,
       })),
     ],
   });


### PR DESCRIPTION
Set the HypiHub provider default pool concurrency to 10, matching KIE, and let Gemini follow the provider concurrency instead of being capped at 1.