### PR TITLE
Expose only HypiHub MiMo VoiceDesign

### DIFF
--- a/packages/provider-hypihub/src/mapping.ts
+++ b/packages/provider-hypihub/src/mapping.ts
@@ -109,26 +109,10 @@ export const hypiHubMappings: readonly GenerationWireMapping[] = [
     },
   },
   {
-    capability: { module: MIMO_TTS, name: "mimo-v2.5-tts" }, result: "audio", routes: [{ model: "mimo-v2.5-tts" }],
-    fields: {
-      text: { as: "value", field: "input" },
-      instruction: { as: "value", field: "prompt" },
-      voice: { as: "value", field: "voice" },
-    },
-  },
-  {
     capability: { module: MIMO_TTS, name: "mimo-v2.5-tts-voicedesign" }, result: "audio", routes: [{ model: "mimo-v2.5-tts-voicedesign" }],
     fields: {
       text: { as: "value", field: "input" },
       voiceDescription: { as: "value", field: "voice_description" },
-    },
-  },
-  {
-    capability: { module: MIMO_TTS, name: "mimo-v2.5-tts-voiceclone" }, result: "audio", routes: [{ model: "mimo-v2.5-tts-voiceclone" }],
-    fields: {
-      text: { as: "value", field: "input" },
-      instruction: { as: "value", field: "prompt" },
-      sample: { as: "url", field: "voice" },
     },
   },
 ];

--- a/packages/provider-hypihub/src/routes.ts
+++ b/packages/provider-hypihub/src/routes.ts
@@ -53,15 +53,7 @@ function normalizeHypiHubRequest(
   }
 
   // Audio mappings already use HypiHub's public /audio/speech vocabulary.
-  // MiMo voice-clone is the one exception: its upstream adaptor expects the
-  // sample as bare base64 in `audio.voice`, while the provider's artifact
-  // resolver quite correctly returns a data URL. Strip only that transport
-  // prefix here so the provider stays decoupled from the upstream wire shape.
   if (mapping.result === "audio") {
-    if (mapping.capability.name === "mimo-v2.5-tts-voiceclone" && typeof input.voice === "string") {
-      const match = /^data:[^;,]+(?:;[^;,]+)*;base64,(.*)$/su.exec(input.voice);
-      if (match !== null) input.voice = match[1];
-    }
     return { model: request.model, input: canonicalize(input) };
   }
 

--- a/packages/provider-hypihub/test/provider.test.ts
+++ b/packages/provider-hypihub/test/provider.test.ts
@@ -30,13 +30,13 @@ async function endpointFor(request: Need, fetch: typeof globalThis.fetch): Promi
   return resolution.registration.endpoint;
 }
 
-test("HypiHub keeps audio opt-in so official MiMo can own the default audio routes", async () => {
+test("HypiHub keeps MiMo VoiceDesign audio opt-in so official MiMo can own the default audio routes", async () => {
   const registry = new EndpointRegistry();
   await createHypiHubProvider({ fetch: async () => { throw new Error("audio must not call fetch"); } }).install(registry);
   assert.equal(registry.resolve({
     id: "need:hypihub-audio-default",
-    capability: mimoTtsEndpoints.preset.capability,
-    returns: mimoTtsEndpoints.preset.returns,
+    capability: mimoTtsEndpoints.voiceDesign.capability,
+    returns: mimoTtsEndpoints.voiceDesign.returns,
     constraints: { ports: {} },
     result: "record:hypihub-audio-default",
   }).status, "missing");
@@ -45,8 +45,8 @@ test("HypiHub keeps audio opt-in so official MiMo can own the default audio rout
   await createHypiHubProvider({ audio: true, fetch: async () => { throw new Error("not reached"); } }).install(optedIn);
   assert.equal(optedIn.resolve({
     id: "need:hypihub-audio-opt-in",
-    capability: mimoTtsEndpoints.preset.capability,
-    returns: mimoTtsEndpoints.preset.returns,
+    capability: mimoTtsEndpoints.voiceDesign.capability,
+    returns: mimoTtsEndpoints.voiceDesign.returns,
     constraints: { ports: {} },
     result: "record:hypihub-audio-opt-in",
   }).status, "resolved");

--- a/packages/provider-hypihub/test/routes.test.ts
+++ b/packages/provider-hypihub/test/routes.test.ts
@@ -149,16 +149,3 @@ test("HypiHub MiMo TTS mappings use the public audio speech fields", async () =>
   assert.equal(result.model, "mimo-v2.5-tts-voicedesign");
   assert.deepEqual(result.input, { input: "hello", voice_description: "warm and calm" });
 });
-
-test("HypiHub MiMo voice clone sends the upstream-required bare base64 sample", async () => {
-  const voiceClone = hypiHubRoutes.find((item) => item.capability.name === "mimo-v2.5-tts-voiceclone");
-  assert.ok(voiceClone);
-  const result = await voiceClone.compile({
-    ports: {
-      text: ["hello"],
-      sample: [{ role: "audio", artifact: { ...image, mediaType: "audio/wav" } }],
-    },
-  }, resolveAudio);
-  assert.equal(result.model, "mimo-v2.5-tts-voiceclone");
-  assert.deepEqual(result.input, { input: "hello", voice: "AQID" });
-});


### PR DESCRIPTION
HypiHub production currently exposes only mimo-v2.5-tts-voicedesign. Remove the unsupported MiMo TTS and VoiceClone mappings from provider-hypihub and clean the stale route handling/tests.