### PR TITLE
Keep only MiMo VoiceDesign

### DIFF
--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -67,6 +67,15 @@ and `auth login`; never add discovery, help, diagnostics, or source inspection b
 
 ## Credentials: run HypiHub login for the author
 
+Before any step that would call a HypiHub-backed API, check the selected HypiHub Endpoint's
+credential with `hypit auth status <endpoint> --runtime <profile>`. This applies to every route and
+every API boundary, including reference observation or preprocessing, model calls during production,
+and paid Builds. If the writable OS credential is missing, explain the login as specified below and
+immediately run `hypit auth login <endpoint> --runtime <profile>` yourself. Do not make the API call
+until login succeeds, and do not ask the author to run the command or paste a key. A configured
+credential needs no repeated login. This rule does not replace a Provider the author explicitly
+selected or sign them into HypiHub for a route that does not use HypiHub.
+
 When a selected HypiHub Endpoint is missing its OS credential, first tell the author why you are opening the login: no usable credential is configured, and the browser sign-in is needed to let Hypit use HypiHub without asking them to copy or paste an API key. If the account has no active Hypit subscription, they can purchase one on hypit.ai after signing in. The session is stored in the OS credential store, and opening login does not itself submit a paid generation. Then run `hypit auth login <endpoint> --runtime <profile>` yourself. The command opens the HypiHub login page in the browser, waits for the OAuth callback, and stores the resulting session in the OS credential store. Do not tell the author to copy a key or run the command manually. Continue only after login succeeds; if it is cancelled or fails, stop before any paid request.
 
 Use this file only to route the task. A route file is a sequence of numbered steps, and each step

--- a/.agents/skills/hypit/references/credentials.md
+++ b/.agents/skills/hypit/references/credentials.md
@@ -10,7 +10,7 @@ paid/external `build`, configure only variables used by the selected Runtime Pro
 | `GOOGLE_CLOUD_PROJECT` | Google Vertex project with Vertex AI enabled |
 | `GOOGLE_APPLICATION_CREDENTIALS_JSON` | Vertex credential JSON contents, not a path |
 | HypiHub OAuth login | HypiHub default paid provider for generation and Gemini VLM; run `hypit auth login hypihub.default --runtime hypit.runtime.json` and sign in at [hypit.ai](https://hypit.ai) |
-| `MIMO_API_KEY` | Xiaomi MiMo TTS only when explicitly selected |
+| `MIMO_API_KEY` | Xiaomi MiMo VoiceDesign only when the user explicitly selects the official Provider |
 
 Before any paid Build, report the selected Provider and credential source for every paid capability in
 the Runtime Profile. Say the variable/store and endpoint (for example, `@hypit/provider-kie` using

--- a/.agents/skills/hypit/references/playbooks/craft/persona-and-audio.md
+++ b/.agents/skills/hypit/references/playbooks/craft/persona-and-audio.md
@@ -22,8 +22,7 @@ Connect only the references a component actually needs.
 
 - Use `gpt:Image` with ordered `gpt:Reference` children when a new character/scene image must preserve
   supplied identity or product facts.
-- Use `mimo:Preset` for a selected built-in voice or `mimo:VoiceDesign` for an English voice
-  description. Either one produces the sample, once per person.
+- Use `mimo:VoiceDesign` with a written voice description. Generate the sample once per person.
 - That sample is a reference on every take the person appears in, and the take speaks the Segment.
   `generated-dependencies.md` holds the rule and what it costs: one generation carries the speech and
   the picture, so the Segment's length and its picture's length are one number.

--- a/.agents/skills/hypit/references/playbooks/formats/mass-tarot.md
+++ b/.agents/skills/hypit/references/playbooks/formats/mass-tarot.md
@@ -7,7 +7,7 @@ ordered reveals and interpretations.
 
 - Write one authoritative Script with Selections/Moments for the question, choice window, each reveal,
   and the close.
-- Take the voice sample once with `mimo:Preset` or `mimo:VoiceDesign`. The reading is spoken by a
+- Take the voice sample once with `mimo:VoiceDesign`. The reading is spoken by a
   take, and that take is the base under the whole Segment — the cards and the spread cover it, and
   the speech and the picture stay one generation. `../craft/generated-dependencies.md` says why.
   Cut the Segment to fit one generation.

--- a/.agents/skills/hypit/references/playbooks/formats/voiceover-desk-demo.md
+++ b/.agents/skills/hypit/references/playbooks/formats/voiceover-desk-demo.md
@@ -6,7 +6,7 @@ screen, product, hand, or proof changes.
 ## Author the SVML program
 
 1. Write one narration Script Segment with Selections/Moments for every visual proof beat.
-2. Take the voice sample once, with `mimo:Preset` or `mimo:VoiceDesign`.
+2. Take the voice sample once with `mimo:VoiceDesign`.
 3. The narration is spoken by a take, and that take is the base. It is under the whole Segment and
    the B-roll covers it; the viewer sees the desk only where nothing is over it, and the speech and
    the picture are one generation either way — `../craft/generated-dependencies.md` says why that

--- a/.agents/skills/hypit/references/runtime.md
+++ b/.agents/skills/hypit/references/runtime.md
@@ -45,7 +45,7 @@ gateway, so a typical profile looks like this:
 "hypihub.<project>": {
   "use": "@hypit/provider-hypihub",
   "config": {
-    "apiKey": { "store": "env", "key": "HYPIHUB_API_KEY" },
+    "apiKey": { "store": "os", "key": "hypihub.oauth" },
     "defaultConcurrency": 20
   }
 }
@@ -53,9 +53,9 @@ gateway, so a typical profile looks like this:
 
 `defaultConcurrency` is the total HypiHub pool shared by its model capabilities. Tune it to the
 quota behind the key; image/video capabilities keep exact-model lanes while Gemini requests share
-one conservative lane. An explicit KIE
-profile remains valid when a project deliberately chooses `@hypit/provider-kie`, but it is not the
-default route.
+one conservative lane. Bind every paid capability HypiHub supports to this Endpoint by default,
+including MiMo VoiceDesign. Select KIE, Vertex, official MiMo or another BYOK Provider only when the
+author explicitly asks not to use HypiHub or explicitly selects that Provider.
 
 An Author Source importing `@hypit/gemini` remains Provider-neutral. Bind those capabilities to
 `@hypit/provider-hypihub` for HypiHub's upload-backed Gemini endpoint, or to

--- a/docs/guide/packages.md
+++ b/docs/guide/packages.md
@@ -90,7 +90,7 @@ specific Provider deployment.
 @hypit/gpt-image             GPT Image model family
 @hypit/nano-banana           Nano Banana model family
 @hypit/seedream              Seedream model family
-@hypit/mimo-tts              three exact Xiaomi MiMo TTS models + author Surfaces
+@hypit/mimo-tts              Xiaomi MiMo VoiceDesign model + author Surface
 @hypit/estimate              duration estimation
 @hypit/speech                shared speech products
 @hypit/speech-evidence       acoustic evidence products
@@ -131,7 +131,7 @@ never on exact-model packages or the CLI.
 @hypit/provider-hyperframes-aws-lambda asynchronous distributed rendering
 @hypit/provider-image-opencv-local   local OpenCV Raster execution
 @hypit/provider-media-aws-lambda     synchronous AWS media execution
-@hypit/provider-xiaomi-mimo           official Xiaomi MiMo TTS API
+@hypit/provider-xiaomi-mimo           official Xiaomi MiMo VoiceDesign API
 ```
 
 ### Layer 6: Runtime

--- a/docs/guide/providers.md
+++ b/docs/guide/providers.md
@@ -84,7 +84,7 @@ Look at existing Providers for reference:
 - `packages/provider-hyperframes-local/` — local Chrome rendering
 - `packages/provider-hyperframes-aws-lambda/` — asynchronous Step Functions/Lambda rendering
 - `packages/provider-media-aws-lambda/` — synchronous Lambda media execution over the shared ffmpeg body
-- `packages/provider-xiaomi-mimo/` — immediate official TTS API without importing the MiMo model package
+- `packages/provider-xiaomi-mimo/` — immediate official VoiceDesign API without importing the MiMo model package
 
 ## 4. Write the activation descriptor
 
@@ -222,4 +222,4 @@ hypit doctor hypit.runtime.json
 | `provider-hyperframes-aws-lambda` | Remote asynchronous job: Step Functions submission, polling and S3 streaming |
 | `provider-image-opencv-local` | Local Python: bounded OpenCV/NumPy with locked Python environment |
 | `provider-media-aws-lambda` | Remote synchronous Lambda: the same nine capabilities as local media |
-| `provider-xiaomi-mimo` | Remote immediate API: exact MiMo TTS requests to persisted audio Artifacts |
+| `provider-xiaomi-mimo` | Remote immediate API: exact MiMo VoiceDesign requests to persisted audio Artifacts |

--- a/docs/quickstart/run.md
+++ b/docs/quickstart/run.md
@@ -213,7 +213,7 @@ variables referenced by the selected Runtime Profile:
 |---|---|
 | HypiHub OAuth | HypiHub paid generation and Gemini VLM; run `hypit auth login hypihub.default --runtime hypit.runtime.json` |
 | `KIE_API_KEY` | Explicit KIE Provider only |
-| `MIMO_API_KEY` | Xiaomi MiMo TTS, only when that Endpoint is selected |
+| `MIMO_API_KEY` | Xiaomi MiMo VoiceDesign, only when the official Endpoint is explicitly selected |
 
 Run only the lines for the Endpoints in your Profile. In macOS/Linux shells:
 

--- a/docs/zh/guide/packages.md
+++ b/docs/zh/guide/packages.md
@@ -83,7 +83,7 @@ Frontend；不存在一个认识全部语法的中央解析器。
 @hypit/gpt-image             GPT Image model family
 @hypit/nano-banana           Nano Banana model family
 @hypit/seedream              Seedream model family
-@hypit/mimo-tts              三个精确 Xiaomi MiMo TTS 模型及作者 Surface
+@hypit/mimo-tts              Xiaomi MiMo VoiceDesign 模型及作者 Surface
 @hypit/estimate              duration estimation
 @hypit/speech                shared speech products
 @hypit/speech-evidence       acoustic evidence products
@@ -123,7 +123,7 @@ Frontend；不存在一个认识全部语法的中央解析器。
 @hypit/provider-hyperframes-aws-lambda asynchronous distributed rendering
 @hypit/provider-image-opencv-local   本地 OpenCV 光栅执行
 @hypit/provider-media-aws-lambda     synchronous AWS media execution
-@hypit/provider-xiaomi-mimo           Xiaomi 官方 MiMo TTS API
+@hypit/provider-xiaomi-mimo           Xiaomi 官方 MiMo VoiceDesign API
 ```
 
 ### Layer 6：Runtime

--- a/docs/zh/guide/providers.md
+++ b/docs/zh/guide/providers.md
@@ -81,7 +81,7 @@ export function createMyServiceProvider(options: {
 - `packages/provider-hyperframes-local/` — 本地 Chrome 渲染
 - `packages/provider-hyperframes-aws-lambda/` — 异步 Step Functions/Lambda 渲染
 - `packages/provider-media-aws-lambda/` — 通过共享 ffmpeg 执行体完成同步 Lambda 媒体操作
-- `packages/provider-xiaomi-mimo/` — 不依赖 MiMo 模型包的官方即时 TTS API
+- `packages/provider-xiaomi-mimo/` — 不依赖 MiMo 模型包的官方即时 VoiceDesign API
 
 ## 4. 编写 activation 描述符
 
@@ -214,4 +214,4 @@ hypit doctor hypit.runtime.json
 | `provider-hyperframes-aws-lambda` | 远程可恢复任务：确定性 Step Functions 提交、轮询与 S3 流式落库 |
 | `provider-image-opencv-local` | 本地 Python：有界的 OpenCV/NumPy，配合锁定的 Python 环境 |
 | `provider-media-aws-lambda` | 远程同步 Lambda：与本地媒体相同的九项能力 |
-| `provider-xiaomi-mimo` | 远程即时 API：把精确 MiMo TTS 请求落成持久化音频 Artifact |
+| `provider-xiaomi-mimo` | 远程即时 API：把精确 MiMo VoiceDesign 请求落成持久化音频 Artifact |

--- a/docs/zh/quickstart/run.md
+++ b/docs/zh/quickstart/run.md
@@ -187,7 +187,7 @@ hypit paths
 |---|---|
 | HypiHub OAuth | HypiHub 付费生成与 Gemini VLM；运行 `hypit auth login hypihub.default --runtime hypit.runtime.json` 并在 https://hypit.ai 登录 |
 | `KIE_API_KEY` | 仅在显式选择 KIE Provider 时使用 |
-| `MIMO_API_KEY` | Xiaomi MiMo TTS；只有选择该 Endpoint 时才需要 |
+| `MIMO_API_KEY` | Xiaomi MiMo VoiceDesign；只有明确选择官方 Endpoint 时才需要 |
 
 只执行 Profile 中所选 Endpoint 对应的行。在 macOS/Linux Shell 中：
 

--- a/packages/mimo-tts/README.md
+++ b/packages/mimo-tts/README.md
@@ -1,15 +1,12 @@
 # `@hypit/mimo-tts`
 
-Exact model contracts and author Surfaces for Xiaomi MiMo V2.5 speech synthesis.
+Exact model contract and author Surface for Xiaomi MiMo V2.5 VoiceDesign.
 
-The package owns the three distinct model shapes:
-
-- `mimo-v2.5-tts`: explicit built-in voice;
-- `mimo-v2.5-tts-voicedesign`: text-described voice;
-- `mimo-v2.5-tts-voiceclone`: one explicit audio sample.
+The package owns only `mimo-v2.5-tts-voicedesign`: exact speech text plus a
+natural-language voice description.
 
 It contains no API URL, credential, retry, queue or Xiaomi wire encoding. Those belong to a Runtime
-Endpoint such as `@hypit/provider-xiaomi-mimo`. Every model returns the shared
+Endpoint such as `@hypit/provider-xiaomi-mimo`. The model returns the shared
 `GeneratedAudioSet`; author Surfaces expose its primary member as an ordinary `BlobArtifact`.
 The `speech` attribute is an ordinary `Text` edge attached through the exact model's `text` port at
 execution time; the Frontend never copies Script words into a request draft.
@@ -19,17 +16,9 @@ execution time; the Frontend never copies Script words into a request draft.
 ```xml
 <import as="mimo" from="@hypit/mimo-tts@1"/>
 
-<mimo:Preset id="narration" speech={story.segment.opening.speech} voice="Chloe">
-  Warm, direct and conversational.
-</mimo:Preset>
-
 <mimo:VoiceDesign id="designed" speech={story.segment.answer.speech}>
   A clear young woman with a grounded, confident delivery.
 </mimo:VoiceDesign>
-
-<mimo:VoiceClone id="cloned" speech={story.segment.payoff.speech} sample={presenter-voice}>
-  Calm and restrained.
-</mimo:VoiceClone>
 ```
 
 Official API reference: <https://mimo.mi.com/docs/zh-CN/quick-start/usage-guide/audio/speech-synthesis-v2.5>

--- a/packages/mimo-tts/src/activation.ts
+++ b/packages/mimo-tts/src/activation.ts
@@ -1,8 +1,6 @@
 import { createMarkupSurfaceHostFacet } from "@hypit/markup";
 
 import {
-  decodeMimoPresetSurface,
-  decodeMimoVoiceCloneSurface,
   decodeMimoVoiceDesignSurface,
   mimoTtsComponent,
   mimoTtsDefinition,
@@ -19,15 +17,7 @@ export const hypitPackage = {
     mimoTtsDefinition.hostFacet,
     createMarkupSurfaceHostFacet({
       module: mimoTtsModuleRef,
-    declaration: mimoTtsMarkupSurfaces.find((item) => item.name === "preset")!, handler: decodeMimoPresetSurface,
-    }),
-    createMarkupSurfaceHostFacet({
-      module: mimoTtsModuleRef,
     declaration: mimoTtsMarkupSurfaces.find((item) => item.name === "voiceDesign")!, handler: decodeMimoVoiceDesignSurface,
-    }),
-    createMarkupSurfaceHostFacet({
-      module: mimoTtsModuleRef,
-    declaration: mimoTtsMarkupSurfaces.find((item) => item.name === "voiceClone")!, handler: decodeMimoVoiceCloneSurface,
     }),
   ],
 };

--- a/packages/mimo-tts/src/index.ts
+++ b/packages/mimo-tts/src/index.ts
@@ -6,15 +6,8 @@ import { defineExactModelModule } from "@hypit/model-kit";
 import { textTypes } from "@hypit/text";
 
 export const mimoTtsModuleRef = { name: "@hypit/mimo-tts", version: "1" } as const;
-export const mimoTtsModels = [
-  "mimo-v2.5-tts",
-  "mimo-v2.5-tts-voicedesign",
-  "mimo-v2.5-tts-voiceclone",
-] as const;
+export const mimoTtsModels = ["mimo-v2.5-tts-voicedesign"] as const;
 export type MimoTtsModel = typeof mimoTtsModels[number];
-
-export const mimoPresetVoices = ["冰糖", "茉莉", "苏打", "白桦", "Mia", "Chloe", "Milo", "Dean"] as const;
-export type MimoPresetVoice = typeof mimoPresetVoices[number];
 
 // Xiaomi documents no fixed character ceiling. Service-side limits stay service-side
 // instead of becoming an invented model constraint in Author Source.
@@ -22,45 +15,19 @@ const spokenText = { kind: "text" } as const;
 const instruction = { kind: "text" } as const;
 
 function table(model: MimoTtsModel): GenerationPortTable {
-  const common = [
-    { name: "text", value: spokenText, minItems: 1, maxItems: 1 },
-  ] as const;
-  if (model === "mimo-v2.5-tts") {
-    return sealGenerationPortTable({
-      model, result: "audio",
-      ports: [
-        ...common,
-        { name: "instruction", value: instruction, minItems: 0, maxItems: 1 },
-        { name: "voice", value: { kind: "enum", values: [...mimoPresetVoices] }, minItems: 1, maxItems: 1 },
-      ],
-      requires: [],
-    });
-  }
-  if (model === "mimo-v2.5-tts-voicedesign") {
-    return sealGenerationPortTable({
-      model, result: "audio",
-      ports: [
-        ...common,
-        { name: "voiceDescription", value: instruction, minItems: 1, maxItems: 1 },
-      ],
-      requires: [],
-    });
-  }
   return sealGenerationPortTable({
-    model, result: "audio",
+    model,
+    result: "audio",
     ports: [
-      ...common,
-      { name: "instruction", value: instruction, minItems: 0, maxItems: 1 },
-      { name: "sample", value: { kind: "media", accepts: ["audio"] }, minItems: 1, maxItems: 1 },
+      { name: "text", value: spokenText, minItems: 1, maxItems: 1 },
+      { name: "voiceDescription", value: instruction, minItems: 1, maxItems: 1 },
     ],
     requires: [],
   });
 }
 
 export const mimoTtsPorts: Readonly<Record<MimoTtsModel, GenerationPortTable>> = {
-  "mimo-v2.5-tts": table("mimo-v2.5-tts"),
   "mimo-v2.5-tts-voicedesign": table("mimo-v2.5-tts-voicedesign"),
-  "mimo-v2.5-tts-voiceclone": table("mimo-v2.5-tts-voiceclone"),
 };
 
 export function sealMimoTtsRequest(
@@ -79,16 +46,12 @@ export function sealMimoTtsRequestDraft(
 
 const base = defineExactModelModule({
   module: mimoTtsModuleRef,
-  endpoints: ([
-    ["preset", "mimo-v2.5-tts", "MimoPresetTtsRequest"],
-    ["voiceDesign", "mimo-v2.5-tts-voicedesign", "MimoVoiceDesignTtsRequest"],
-    ["voiceClone", "mimo-v2.5-tts-voiceclone", "MimoVoiceCloneTtsRequest"],
-  ] as const).map(([key, model, requestTypeName]) => ({
-    key,
-    requestTypeName,
-    producerName: `request-${model}`,
-    ports: mimoTtsPorts[model],
-  })),
+  endpoints: [{
+    key: "voiceDesign",
+    requestTypeName: "MimoVoiceDesignTtsRequest",
+    producerName: "request-mimo-v2.5-tts-voicedesign",
+    ports: mimoTtsPorts["mimo-v2.5-tts-voicedesign"],
+  }],
 });
 
 export const mimoTtsEndpoints = base.endpoints;
@@ -115,95 +78,27 @@ const mimoAudioPort: readonly SurfacePortVocabulary[] = [{
   summary: "The synthesized speech, addressed as `<id>.audio`.",
 }];
 
-export const mimoTtsMarkupSurfaces = [
-  {
-    name: "preset", tag: "Preset", mode: "structured",
-    outputs: [mimoTtsEndpoints.preset.draftType],
-    vocabulary: {
-      summary: "Speaks a Text with one of the built-in MiMo voices.",
-      attributes: [
-        ...mimoSpokenAttributes,
-        {
-          name: "voice",
-          kind: "literal",
-          required: true,
-          summary: "The built-in voice that reads the speech.",
-          values: mimoPresetVoices,
-        },
-      ],
-      ports: mimoAudioPort,
-      text: "The element's own text is an optional delivery instruction; leaving it empty sends no instruction.",
-      example: `<mimo:Preset id="narration" speech={story.segment.opening.speech} voice="Chloe">
-  Warm, direct and conversational.
-</mimo:Preset>`,
-      notes: [
-        "The element accepts no child elements; only its text is read.",
-        "`speech` stays an ordinary Text edge attached at execution time, so the Frontend copies no Script words into the request draft.",
-      ],
-    },
-  },
-  {
-    name: "voiceDesign", tag: "VoiceDesign", mode: "structured",
-    outputs: [mimoTtsEndpoints.voiceDesign.draftType],
-    vocabulary: {
-      summary: "Speaks a Text with a voice the element describes in words rather than names.",
-      attributes: mimoSpokenAttributes,
-      ports: mimoAudioPort,
-      text: "The element's own text is the voice description and is required.",
-      example: `<mimo:VoiceDesign id="designed" speech={story.segment.answer.speech}>
+export const mimoTtsMarkupSurfaces = [{
+  name: "voiceDesign", tag: "VoiceDesign", mode: "structured",
+  outputs: [mimoTtsEndpoints.voiceDesign.draftType],
+  vocabulary: {
+    summary: "Speaks a Text with a voice described in natural language.",
+    attributes: mimoSpokenAttributes,
+    ports: mimoAudioPort,
+    text: "The element's own text is the voice description and is required.",
+    example: `<mimo:VoiceDesign id="designed" speech={story.segment.answer.speech}>
   A clear young woman with a grounded, confident delivery.
 </mimo:VoiceDesign>`,
-      notes: [
-        "The element accepts no child elements; only its text is read.",
-        "An empty body is refused, because this model has no voice to fall back on.",
-      ],
-    },
-  },
-  {
-    name: "voiceClone", tag: "VoiceClone", mode: "structured",
-    outputs: [
-      mimoTtsEndpoints.voiceClone.draftType,
-      ...Object.values(mimoTtsEndpoints.voiceClone.mediaBindings).map((binding) => binding.type),
+    notes: [
+      "The element accepts no child elements; only its text is read.",
+      "An empty body is refused, because this model has no voice to fall back on.",
     ],
-    vocabulary: {
-      summary: "Speaks a Text with the voice heard in one audio Artifact.",
-      attributes: [
-        ...mimoSpokenAttributes,
-        {
-          name: "sample",
-          kind: "reference",
-          required: true,
-          summary: "The audio Artifact whose voice the model reproduces.",
-          accepts: [artifactTypes.blob],
-        },
-      ],
-      ports: mimoAudioPort,
-      text: "The element's own text is an optional delivery instruction; leaving it empty sends no instruction.",
-      example: `<mimo:VoiceClone id="cloned" speech={story.segment.payoff.speech} sample={presenter.audio}>
-  Calm and restrained.
-</mimo:VoiceClone>`,
-      notes: [
-        "The element accepts no child elements; only its text is read.",
-        "An authored `sample` whose media type is not audio is refused before any Need exists.",
-      ],
-    },
   },
-] as const;
+}] as const;
 
-export const mimoTtsManifest = {
-  ...base.manifest,
-} as const;
-
+export const mimoTtsManifest = { ...base.manifest } as const;
 export const mimoTtsComponent = base.component;
-
-export const mimoTtsDefinition = {
-  ...base,
-  manifest: mimoTtsManifest,
-};
+export const mimoTtsDefinition = { ...base, manifest: mimoTtsManifest };
 
 export { createMimoTtsAudioFragment } from "./fragment.js";
-export {
-  decodeMimoPresetSurface,
-  decodeMimoVoiceCloneSurface,
-  decodeMimoVoiceDesignSurface,
-} from "./surface.js";
+export { decodeMimoVoiceDesignSurface } from "./surface.js";

--- a/packages/mimo-tts/src/surface.ts
+++ b/packages/mimo-tts/src/surface.ts
@@ -1,12 +1,6 @@
-import { artifactTypes } from "@hypit/artifact";
-import {
-  generationPort,
-  sealGenerationMediaBinding,
-} from "@hypit/generation";
-import type { GenerationMediaPort, GenerationPortValue } from "@hypit/generation";
-import { exactModelMediaInputNames, exactModelTextInputName } from "@hypit/model-kit";
-import type { ExactModelMediaInput, ExactModelTextInput } from "@hypit/model-kit";
 import type { CanonicalValue } from "@hypit/protocol";
+import { exactModelTextInputName } from "@hypit/model-kit";
+import type { ExactModelTextInput } from "@hypit/model-kit";
 import { textTypes, verifyText } from "@hypit/text";
 import type {
   StructuredElement,
@@ -16,23 +10,17 @@ import type {
 } from "@hypit/markup";
 
 import { createMimoTtsAudioFragment } from "./fragment.js";
-import {
-  mimoPresetVoices,
-  mimoTtsEndpoints,
-  sealMimoTtsRequestDraft,
-} from "./index.js";
-import type { MimoPresetVoice, MimoTtsModel } from "./index.js";
+import { mimoTtsEndpoints, sealMimoTtsRequestDraft } from "./index.js";
 
 function sameType(left: SurfaceResolvedReference["type"], right: SurfaceResolvedReference["type"]): boolean {
   return left.module.name === right.module.name && left.module.version === right.module.version && left.name === right.name;
 }
 
-function attributes(element: StructuredElement, required: readonly string[], optional: readonly string[] = []): void {
-  const allowed = new Set([...required, ...optional]);
+function attributes(element: StructuredElement, required: readonly string[]): void {
+  const allowed = new Set(required);
   const unknown = Object.keys(element.attributes).filter((name) => !allowed.has(name));
   if (unknown.length > 0 || required.some((name) => element.attributes[name] === undefined)) {
-    throw new Error(`${element.name} requires ${required.join(", ")}`
-      + (optional.length === 0 ? "" : `; optional: ${optional.join(", ")}`));
+    throw new Error(`${element.name} requires ${required.join(", ")}`);
   }
 }
 
@@ -64,9 +52,7 @@ function resolved(
 }
 
 function speechText(reference: SurfaceResolvedReference, subject: string): SurfaceResolvedReference {
-  if (!sameType(reference.type, textTypes.text)) {
-    throw new Error(`${subject} must reference Text`);
-  }
+  if (!sameType(reference.type, textTypes.text)) throw new Error(`${subject} must reference Text`);
   const value = reference.record?.value;
   if (value !== undefined) {
     if (value.kind !== "inline") throw new Error(`${subject} has an invalid authored Text value`);
@@ -75,18 +61,7 @@ function speechText(reference: SurfaceResolvedReference, subject: string): Surfa
   return reference;
 }
 
-function sample(reference: SurfaceResolvedReference, subject: string): SurfaceResolvedReference {
-  if (!sameType(reference.type, artifactTypes.blob)) {
-    throw new Error(`${subject} must reference an audio BlobArtifact`);
-  }
-  const value = reference.record?.value;
-  if (value !== undefined && (value.kind !== "blob" || !value.mediaType.startsWith("audio/"))) {
-    throw new Error(`${subject} must be audio media`);
-  }
-  return reference;
-}
-
-function body(element: StructuredElement, required: boolean): string | undefined {
+function body(element: StructuredElement): string {
   if (element.children.some((child) => child.kind === "element")) {
     throw new Error(`${element.name} accepts instruction text only`);
   }
@@ -97,117 +72,38 @@ function body(element: StructuredElement, required: boolean): string | undefined
   const indents = lines.filter((line) => line.trim()).map((line) => /^\s*/u.exec(line)?.[0].length ?? 0);
   const indent = indents.length === 0 ? 0 : Math.min(...indents);
   const value = lines.map((line) => line.slice(indent).trimEnd()).join("\n").trim();
-  if (value.length === 0) {
-    if (required) throw new Error(`${element.name} requires a voice description in its body`);
-    return undefined;
-  }
+  if (value.length === 0) throw new Error(`${element.name} requires a voice description in its body`);
   return value;
 }
 
-function output(
-  element: StructuredElement,
-  endpoint: (typeof mimoTtsEndpoints)[keyof typeof mimoTtsEndpoints],
-  draft: ReturnType<typeof sealMimoTtsRequestDraft>,
-  text: readonly { readonly input: ExactModelTextInput; readonly source: SurfaceResolvedReference }[],
-  media: readonly { readonly input: ExactModelMediaInput; readonly source: SurfaceResolvedReference }[] = [],
-) {
+export const decodeMimoVoiceDesignSurface: StructuredSurfaceHandler = ({ element, resolveReference }) => {
+  attributes(element, ["id", "speech"]);
   const id = stringAttribute(element, "id");
+  const speech = speechText(resolved(element, "speech", resolveReference), `${element.name}.speech`);
+  const endpoint = mimoTtsEndpoints.voiceDesign;
   const draftId = `${id}.draft`;
-  const records: Array<{
-    readonly id: string;
-    readonly type: SurfaceResolvedReference["type"];
-    readonly value: { readonly kind: "inline"; readonly value: CanonicalValue };
-    readonly range: StructuredElement["range"];
-  }> = [{
-    id: draftId,
-    type: endpoint.draftType,
-    value: { kind: "inline", value: draft as unknown as CanonicalValue },
-    range: element.range,
-  }];
-  const inputs: Record<string, SurfaceResolvedReference["ref"] | { readonly kind: "record"; readonly id: string }> = {
-    draft: { kind: "record", id: draftId },
-  };
-  for (const item of text) inputs[exactModelTextInputName(item.input.name)] = item.source.ref;
-  for (const item of media) {
-    const binding = endpoint.mediaBindings[item.input.port];
-    if (binding === undefined) throw new Error(`${endpoint.ports.model} has no media port ${item.input.port}`);
-    const port = generationPort(endpoint.ports, item.input.port);
-    if (port.value.kind !== "media") throw new Error(`${endpoint.ports.model} port ${item.input.port} is not media`);
-    const names = exactModelMediaInputNames(item.input.name);
-    const bindingId = `${id}.${item.input.name}.binding`;
-    records.push({
-      id: bindingId,
-      type: binding.type,
-      value: {
-        kind: "inline",
-        value: sealGenerationMediaBinding(port as GenerationMediaPort, { role: "audio" }) as unknown as CanonicalValue,
-      },
-      range: element.range,
-    });
-    inputs[names.binding] = { kind: "record", id: bindingId };
-    inputs[names.artifact] = item.source.ref;
-  }
-  const fragment = createMimoTtsAudioFragment(
-    endpoint,
-    media.map((item) => item.input),
-    text.map((item) => item.input),
-  );
+  const draft = sealMimoTtsRequestDraft("mimo-v2.5-tts-voicedesign", {
+    voiceDescription: [body(element)],
+  });
+  const textInput: ExactModelTextInput = { name: "speech", port: "text" };
+  const fragment = createMimoTtsAudioFragment(endpoint, [], [textInput]);
   return {
-    records,
+    records: [{
+      id: draftId,
+      type: endpoint.draftType,
+      value: { kind: "inline", value: draft as unknown as CanonicalValue },
+      range: element.range,
+    }],
     components: [{
       id,
       fragment: fragment.id,
-      inputs,
+      inputs: {
+        draft: { kind: "record", id: draftId },
+        [exactModelTextInputName(textInput.name)]: speech.ref,
+      },
       outputs: { audio: `${id}.audio` },
       range: element.range,
     }],
     fragments: [fragment],
   };
-}
-
-function speechInput(
-  element: StructuredElement,
-  resolveReference: (path: string) => SurfaceResolvedReference | undefined,
-) {
-  return {
-    input: { name: "speech", port: "text" },
-    source: speechText(resolved(element, "speech", resolveReference), `${element.name}.speech`),
-  } as const;
-}
-
-export const decodeMimoPresetSurface: StructuredSurfaceHandler = ({ element, resolveReference }) => {
-  attributes(element, ["id", "speech", "voice"]);
-  const voice = stringAttribute(element, "voice") as MimoPresetVoice;
-  if (!mimoPresetVoices.includes(voice)) throw new Error(`${element.name}.voice is not a MiMo preset voice`);
-  const instruction = body(element, false);
-  const ports: Record<string, readonly GenerationPortValue[]> = { voice: [voice] };
-  if (instruction !== undefined) ports.instruction = [instruction];
-  return output(
-    element,
-    mimoTtsEndpoints.preset,
-    sealMimoTtsRequestDraft("mimo-v2.5-tts", ports),
-    [speechInput(element, resolveReference)],
-  );
-};
-
-export const decodeMimoVoiceDesignSurface: StructuredSurfaceHandler = ({ element, resolveReference }) => {
-  attributes(element, ["id", "speech"]);
-  return output(element, mimoTtsEndpoints.voiceDesign, sealMimoTtsRequestDraft("mimo-v2.5-tts-voicedesign", {
-    voiceDescription: [body(element, true)!],
-  }), [speechInput(element, resolveReference)]);
-};
-
-export const decodeMimoVoiceCloneSurface: StructuredSurfaceHandler = ({ element, resolveReference }) => {
-  attributes(element, ["id", "speech", "sample"]);
-  const instruction = body(element, false);
-  const source = sample(resolved(element, "sample", resolveReference), `${element.name}.sample`);
-  const ports: Record<string, readonly GenerationPortValue[]> = {};
-  if (instruction !== undefined) ports.instruction = [instruction];
-  return output(
-    element,
-    mimoTtsEndpoints.voiceClone,
-    sealMimoTtsRequestDraft("mimo-v2.5-tts-voiceclone", ports),
-    [speechInput(element, resolveReference)],
-    [{ input: { name: "sample", port: "sample" }, source }],
-  );
 };

--- a/packages/mimo-tts/test/mimo-tts.test.ts
+++ b/packages/mimo-tts/test/mimo-tts.test.ts
@@ -1,20 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { fixtureDigest } from "../../../test/fixture-digest.js";
 
-import { artifactTypes } from "@hypit/artifact";
 import { generationProducers, generationTypes } from "@hypit/generation";
-import { sealText, textTypes } from "@hypit/text";
 import { parseStructuredElement } from "@hypit/markup";
 import type { SurfaceResolvedReference } from "@hypit/markup";
+import { sealText, textTypes } from "@hypit/text";
 
 import mimoNodePackage from "../src/activation.js";
 import {
-  decodeMimoPresetSurface,
-  decodeMimoVoiceCloneSurface,
   decodeMimoVoiceDesignSurface,
   mimoTtsEndpoints,
   mimoTtsMarkupSurfaces,
+  mimoTtsModels,
   mimoTtsPorts,
   sealMimoTtsRequest,
 } from "../src/index.js";
@@ -23,106 +20,60 @@ function parsed(source: string) {
   return parseStructuredElement({ name: "mimo.svml", text: source }, 0).element;
 }
 
-function authored(path: string, type: SurfaceResolvedReference["type"], value: unknown): SurfaceResolvedReference {
-  return {
-    path,
-    ref: { kind: "record", id: path },
-    type,
-    record: {
-      id: path,
-      type,
-      value: type.name === artifactTypes.blob.name
-        ? value as never
-        : { kind: "inline", value: value as never },
-    },
-  };
-}
-
 const speech = sealText("Exact authored words stay exact.");
-const sample = { kind: "blob" as const, digest: fixtureDigest("voice-sample"), size: 4, mediaType: "audio/wav" };
-const refs = new Map<string, SurfaceResolvedReference>([
-  ["story.segment.opening.speech", authored("story.segment.opening.speech", textTypes.text, speech)],
-  ["voice", authored("voice", artifactTypes.blob, sample)],
-]);
+const reference: SurfaceResolvedReference = {
+  path: "story.segment.opening.speech",
+  ref: { kind: "record", id: "story.segment.opening.speech" },
+  type: textTypes.text,
+  record: {
+    id: "story.segment.opening.speech",
+    type: textTypes.text,
+    value: { kind: "inline", value: speech },
+  },
+};
 const context = (source: string) => ({
   sourceName: "mimo.svml",
   element: parsed(source),
-  resolveReference: (path: string) => refs.get(path),
+  resolveReference: (path: string) => path === reference.path ? reference : undefined,
   resolveAsset: () => { throw new Error("no asset"); },
 });
 
-test("MiMo declares three audio models without Provider facts", () => {
-  assert.deepEqual(Object.values(mimoTtsPorts).map((ports) => ports.result), ["audio", "audio", "audio"]);
-  assert.deepEqual(Object.values(mimoTtsEndpoints).map((endpoint) => endpoint.returns), [
-    generationTypes.audioSet,
-    generationTypes.audioSet,
-    generationTypes.audioSet,
-  ]);
+test("MiMo declares only the VoiceDesign audio model without Provider facts", () => {
+  assert.deepEqual(mimoTtsModels, ["mimo-v2.5-tts-voicedesign"]);
+  assert.deepEqual(Object.values(mimoTtsPorts).map((ports) => ports.result), ["audio"]);
+  assert.deepEqual(Object.values(mimoTtsEndpoints).map((endpoint) => endpoint.returns), [generationTypes.audioSet]);
   assert.equal(JSON.stringify(mimoTtsPorts).includes("xiaomimimo.com"), false);
-  assert.equal(mimoTtsPorts["mimo-v2.5-tts"].ports.find((port) => port.name === "text")?.value.kind, "text");
-  assert.equal("maxChars" in mimoTtsPorts["mimo-v2.5-tts"].ports[0]!.value, false);
   assert.throws(() => sealMimoTtsRequest("mimo-v2.5-tts-voicedesign", {
     text: ["Do not rewrite me."],
   }), /voiceDescription is required/u);
 });
 
-test("one installed author package contributes all three Surfaces without a Runtime Provider", () => {
+test("the installed author package contributes only VoiceDesign", () => {
   assert.equal(mimoNodePackage.format, "hypit.node-package@1");
   assert.equal(mimoNodePackage.modules[0]?.manifest.version, "1");
-  assert.deepEqual(mimoTtsMarkupSurfaces.map((surface) => surface.name),
-    ["preset", "voiceDesign", "voiceClone"]);
+  assert.deepEqual(mimoTtsMarkupSurfaces.map((surface) => surface.name), ["voiceDesign"]);
   assert.equal(JSON.stringify(mimoNodePackage).includes("MIMO_API_KEY"), false);
 });
 
-test("the three author Surfaces are separate components with one ordinary audio output", async () => {
-  const results = await Promise.all([
-    decodeMimoPresetSurface(context(`<mimo:Preset id="preset" speech={story.segment.opening.speech} voice="Chloe">
-      Warm, restrained delivery.
-    </mimo:Preset>`)),
-    decodeMimoVoiceDesignSurface(context(`<mimo:VoiceDesign id="designed" speech={story.segment.opening.speech}>
-      A clear, confident young woman with a grounded conversational tone.
-    </mimo:VoiceDesign>`)),
-    decodeMimoVoiceCloneSurface(context(`<mimo:VoiceClone id="cloned" speech={story.segment.opening.speech} sample={voice}>
-      Calm and direct.
-    </mimo:VoiceClone>`)),
+test("VoiceDesign produces one ordinary audio output", async () => {
+  const result = await decodeMimoVoiceDesignSurface(context(`<mimo:VoiceDesign id="designed" speech={story.segment.opening.speech}>
+    A clear, confident young woman with a grounded conversational tone.
+  </mimo:VoiceDesign>`));
+  assert.equal(result.components.length, 1);
+  assert.deepEqual(Object.keys(result.components[0]!.outputs), ["audio"]);
+  assert.deepEqual(result.fragments[0]!.operations.map((operation) => operation.producer.name), [
+    "bind-request-mimo-v2.5-tts-voicedesign-text-text",
+    "finalize-request-mimo-v2.5-tts-voicedesign",
+    "request-mimo-v2.5-tts-voicedesign",
+    generationProducers.primaryAudio.name,
   ]);
-  for (const [index, result] of results.entries()) {
-    assert.equal(result.components.length, 1);
-    assert.deepEqual(Object.keys(result.components[0]!.outputs), ["audio"]);
-    assert.deepEqual(result.fragments[0]!.operations.map((operation) => operation.producer.name), index === 2
-      ? [
-          "bind-request-mimo-v2.5-tts-voiceclone-text-text",
-          "bind-request-mimo-v2.5-tts-voiceclone-sample",
-          "finalize-request-mimo-v2.5-tts-voiceclone",
-          "request-mimo-v2.5-tts-voiceclone",
-          generationProducers.primaryAudio.name,
-        ]
-      : [
-          index === 0
-            ? "bind-request-mimo-v2.5-tts-text-text"
-            : "bind-request-mimo-v2.5-tts-voicedesign-text-text",
-          index === 0 ? "finalize-request-mimo-v2.5-tts" : "finalize-request-mimo-v2.5-tts-voicedesign",
-          index === 0 ? "request-mimo-v2.5-tts" : "request-mimo-v2.5-tts-voicedesign",
-          generationProducers.primaryAudio.name,
-        ]);
-    assert.equal(result.records[0]!.value.kind, "inline");
-    const request = result.records[0]!.value.kind === "inline"
-      ? result.records[0]!.value.value as Record<string, unknown> : {};
-    assert.equal((request.ports as Record<string, unknown[]>).text, undefined);
-    assert.deepEqual(result.components[0]!.inputs["speech:text"], {
-      kind: "record",
-      id: "story.segment.opening.speech",
-    });
-    assert.equal(JSON.stringify(request).includes("optimize_text_preview"), false);
-  }
-});
-
-test("voice clone refuses a non-audio sample before any Need exists", async () => {
-  const wrong = { ...sample, mediaType: "video/mp4" };
-  const invalid = new Map(refs);
-  invalid.set("voice", authored("voice", artifactTypes.blob, wrong));
-  assert.throws(() => decodeMimoVoiceCloneSurface({
-    ...context('<mimo:VoiceClone id="bad" speech={story.segment.opening.speech} sample={voice}/>'),
-    resolveReference: (path) => invalid.get(path),
-  }), /must be audio/u);
+  assert.equal(result.records[0]!.value.kind, "inline");
+  const request = result.records[0]!.value.kind === "inline"
+    ? result.records[0]!.value.value as Record<string, unknown> : {};
+  assert.equal((request.ports as Record<string, unknown[]>).text, undefined);
+  assert.deepEqual(result.components[0]!.inputs["speech:text"], {
+    kind: "record",
+    id: "story.segment.opening.speech",
+  });
+  assert.equal(JSON.stringify(request).includes("optimize_text_preview"), false);
 });

--- a/packages/provider-hypihub/README.md
+++ b/packages/provider-hypihub/README.md
@@ -40,7 +40,5 @@ Artifacts are uploaded automatically through `POST /v1/files`, then their return
 URLs are used in image and video requests. Uploads are deduplicated by Artifact digest within one
 Runtime operation. Embedded callers may override that transport with `publicAssetUrl`.
 
-HypiHub audio capabilities are disabled by default because a HypiHub OAuth grant may not include the MiMo
-audio models. Set `audio: true` only when that key explicitly has them enabled. The usual setup keeps
-official `@hypit/provider-xiaomi-mimo` as the audio endpoint, so one Runtime uses HypiHub for
-image/video and official MiMo for audio.
+HypiHub exposes MiMo VoiceDesign by default. Set `audio: false` only when the user explicitly selects
+another VoiceDesign Provider. Hypit does not expose MiMo preset-voice or voice-cloning models.

--- a/packages/provider-hypihub/src/provider.ts
+++ b/packages/provider-hypihub/src/provider.ts
@@ -21,7 +21,7 @@ export type CreateHypiHubProviderOptions = {
   readonly defaultConcurrency?: number;
   readonly pollIntervalMs?: number;
   readonly requestTimeoutMs?: number;
-  /** Expose HypiHub's MiMo audio capabilities. Disable when official MiMo owns audio. */
+  /** Expose HypiHub VoiceDesign. Defaults to enabled; set false only for an explicit alternate Provider. */
   readonly audio?: boolean;
   readonly fetch?: typeof globalThis.fetch;
   /** Overrides the default POST /v1/files upload for referenced artifacts. */
@@ -255,10 +255,7 @@ export function createHypiHubProvider(options: CreateHypiHubProviderOptions = {}
     credentials: { apiKey: options.apiKey ?? credentialRef("os", "hypihub.oauth") }, credentialInputs: { apiKey: { label: "HypiHub login" } }, defaultConcurrency: options.defaultConcurrency ?? 10,
     capabilities: [
       ...hypiHubRoutes
-      // HypiHub OAuth grants do not necessarily include the MiMo audio models. Keep
-      // official Xiaomi MiMo as the safe default; opting into HypiHub audio is
-      // an explicit Runtime decision for a key that actually has those models.
-      .filter((route) => options.audio === true || route.media !== "audio")
+      .filter((route) => options.audio !== false || route.media !== "audio")
       .map((route) => route.media === "audio"
         ? { capability: route.capability, returns: route.returns, lifecycle: "immediate" as const, handler: audioEndpoint, lane: route.capability.name }
         : { capability: route.capability, returns: route.returns, lifecycle: "asynchronous" as const, endpoint: asyncEndpoint, lane: route.capability.name }),

--- a/packages/provider-hypihub/test/provider.test.ts
+++ b/packages/provider-hypihub/test/provider.test.ts
@@ -30,7 +30,7 @@ async function endpointFor(request: Need, fetch: typeof globalThis.fetch): Promi
   return resolution.registration.endpoint;
 }
 
-test("HypiHub keeps MiMo VoiceDesign audio opt-in so official MiMo can own the default audio routes", async () => {
+test("HypiHub exposes VoiceDesign by default and permits an explicit alternate audio Provider", async () => {
   const registry = new EndpointRegistry();
   await createHypiHubProvider({ fetch: async () => { throw new Error("audio must not call fetch"); } }).install(registry);
   assert.equal(registry.resolve({
@@ -39,17 +39,17 @@ test("HypiHub keeps MiMo VoiceDesign audio opt-in so official MiMo can own the d
     returns: mimoTtsEndpoints.voiceDesign.returns,
     constraints: { ports: {} },
     result: "record:hypihub-audio-default",
-  }).status, "missing");
+  }).status, "resolved");
 
-  const optedIn = new EndpointRegistry();
-  await createHypiHubProvider({ audio: true, fetch: async () => { throw new Error("not reached"); } }).install(optedIn);
-  assert.equal(optedIn.resolve({
+  const optedOut = new EndpointRegistry();
+  await createHypiHubProvider({ audio: false, fetch: async () => { throw new Error("not reached"); } }).install(optedOut);
+  assert.equal(optedOut.resolve({
     id: "need:hypihub-audio-opt-in",
     capability: mimoTtsEndpoints.voiceDesign.capability,
     returns: mimoTtsEndpoints.voiceDesign.returns,
     constraints: { ports: {} },
     result: "record:hypihub-audio-opt-in",
-  }).status, "resolved");
+  }).status, "missing");
 });
 
 test("HypiHub uploads referenced Artifacts once, submits their HTTPS URLs, and persists the result", async () => {

--- a/packages/provider-xiaomi-mimo/README.md
+++ b/packages/provider-xiaomi-mimo/README.md
@@ -1,11 +1,10 @@
 # `@hypit/provider-xiaomi-mimo`
 
-Immediate Runtime Endpoint for Xiaomi's official MiMo V2.5 TTS API.
+Immediate Runtime Endpoint for Xiaomi's official MiMo V2.5 VoiceDesign API.
 
 This package owns the `chat/completions` wire shape, `api-key` credential, timeout, response bounds,
-voice-sample data URI conversion and ArtifactStore ingestion. It does not import
-`@hypit/mimo-tts`: capabilities and model port names are bound as versioned data, keeping the
-three exact model contracts independent from this particular service.
+and ArtifactStore ingestion. It does not import `@hypit/mimo-tts`: the VoiceDesign capability and
+port names are bound as versioned data, keeping the exact model contract independent from this service.
 
 Runtime Profile example:
 

--- a/packages/provider-xiaomi-mimo/src/activation.ts
+++ b/packages/provider-xiaomi-mimo/src/activation.ts
@@ -16,7 +16,7 @@ const adapter = createRuntimeEndpointAdapterFacet({
     const config = runtimeConfigObject(context.config, "Xiaomi MiMo");
     runtimeConfigExact(config, [
       "apiBaseUrl", "apiKey", "defaultConcurrency", "requestTimeoutMs",
-      "maxResponseBytes", "maxVoiceSampleBase64Bytes",
+      "maxResponseBytes",
     ], "Xiaomi MiMo");
     const apiBaseUrl = runtimeConfigString(config.apiBaseUrl, "Xiaomi MiMo apiBaseUrl");
     if (apiBaseUrl !== undefined) {
@@ -30,10 +30,6 @@ const adapter = createRuntimeEndpointAdapterFacet({
     const defaultConcurrency = runtimeConfigPositiveInteger(config.defaultConcurrency, "Xiaomi MiMo defaultConcurrency");
     const requestTimeoutMs = runtimeConfigPositiveInteger(config.requestTimeoutMs, "Xiaomi MiMo requestTimeoutMs");
     const maxResponseBytes = runtimeConfigPositiveInteger(config.maxResponseBytes, "Xiaomi MiMo maxResponseBytes");
-    const maxVoiceSampleBase64Bytes = runtimeConfigPositiveInteger(
-      config.maxVoiceSampleBase64Bytes,
-      "Xiaomi MiMo maxVoiceSampleBase64Bytes",
-    );
     return {
       endpoint: createXiaomiMimoProvider({
         instance: context.instance,
@@ -43,7 +39,6 @@ const adapter = createRuntimeEndpointAdapterFacet({
         ...(defaultConcurrency === undefined ? {} : { defaultConcurrency }),
         ...(requestTimeoutMs === undefined ? {} : { requestTimeoutMs }),
         ...(maxResponseBytes === undefined ? {} : { maxResponseBytes }),
-        ...(maxVoiceSampleBase64Bytes === undefined ? {} : { maxVoiceSampleBase64Bytes }),
       }),
     };
   },

--- a/packages/provider-xiaomi-mimo/src/provider.ts
+++ b/packages/provider-xiaomi-mimo/src/provider.ts
@@ -4,7 +4,7 @@ import {
   generationTypes,
   sealGeneratedAudioSet,
 } from "@hypit/generation";
-import type { GenerationMediaValue, GenerationRequest } from "@hypit/generation";
+import type { GenerationRequest } from "@hypit/generation";
 import { canonicalize } from "@hypit/protocol";
 import type { CanonicalValue, CapabilityRef } from "@hypit/protocol";
 import { credentialRef } from "@hypit/runtime";
@@ -12,11 +12,7 @@ import type { CredentialRef } from "@hypit/runtime";
 
 export const xiaomiMimoProviderModuleRef = { name: "@hypit/provider-xiaomi-mimo", version: "1" } as const;
 const mimoModelModule = { name: "@hypit/mimo-tts", version: "1" } as const;
-const modelNames = [
-  "mimo-v2.5-tts",
-  "mimo-v2.5-tts-voicedesign",
-  "mimo-v2.5-tts-voiceclone",
-] as const;
+const modelNames = ["mimo-v2.5-tts-voicedesign"] as const;
 type Model = typeof modelNames[number];
 
 const capabilities = Object.fromEntries(modelNames.map((name) => [name, {
@@ -34,7 +30,6 @@ export type CreateXiaomiMimoProviderOptions = {
   readonly defaultConcurrency?: number;
   readonly requestTimeoutMs?: number;
   readonly maxResponseBytes?: number;
-  readonly maxVoiceSampleBase64Bytes?: number;
   readonly fetch?: Fetch;
 };
 
@@ -57,11 +52,7 @@ function normalizeBaseUrl(value: string): string {
 function request(value: CanonicalValue, model: Model): GenerationRequest {
   const result = value as unknown as GenerationRequest;
   assert(result.ports !== null && typeof result.ports === "object", "Xiaomi MiMo request has no ports");
-  const allowed = model === "mimo-v2.5-tts"
-    ? new Set(["text", "instruction", "voice"])
-    : model === "mimo-v2.5-tts-voicedesign"
-      ? new Set(["text", "voiceDescription"])
-      : new Set(["text", "instruction", "sample"]);
+  const allowed = new Set(["text", "voiceDescription"]);
   assert(Object.keys(result.ports).every((name) => allowed.has(name)),
     `${model} request contains an unsupported port`);
   return result;
@@ -81,32 +72,6 @@ function credential(context: EndpointInvocationContext): string {
   const value = context.credentials.apiKey?.secret;
   assert(value !== undefined && value.length > 0, "Xiaomi MiMo API key is unavailable");
   return value;
-}
-
-async function readVoiceSample(
-  context: EndpointInvocationContext,
-  req: GenerationRequest,
-  maxBase64Bytes: number,
-): Promise<string> {
-  const values = req.ports.sample;
-  assert(values?.length === 1, "MiMo voice clone requires exactly one sample");
-  const value = values[0] as GenerationMediaValue;
-  assert(value.role === "audio", "MiMo voice clone sample must be audio");
-  const supported = new Set(["audio/mpeg", "audio/mp3", "audio/wav", "audio/x-wav"]);
-  assert(supported.has(value.artifact.mediaType), "Xiaomi MiMo accepts only MP3 or WAV voice samples");
-  const encodedSize = 4 * Math.ceil(value.artifact.size / 3);
-  assert(encodedSize <= maxBase64Bytes,
-    `MiMo voice sample exceeds the configured ${maxBase64Bytes}-byte Base64 limit`);
-  const bytes = await context.artifacts.get(value.artifact.digest);
-  assert(bytes !== undefined, `MiMo voice sample ${value.artifact.digest} is unavailable`);
-  assert(bytes.byteLength === value.artifact.size, "MiMo voice sample size differs from its BlobRef");
-  const mediaType = value.artifact.mediaType === "audio/x-wav"
-    ? "audio/wav"
-    : value.artifact.mediaType === "audio/mp3" ? "audio/mpeg" : value.artifact.mediaType;
-  const encoded = Buffer.from(bytes).toString("base64");
-  assert(Buffer.byteLength(encoded, "utf8") <= maxBase64Bytes,
-    `MiMo voice sample exceeds the configured ${maxBase64Bytes}-byte Base64 limit`);
-  return `data:${mediaType};base64,${encoded}`;
 }
 
 function parseAudio(text: string, maxAudioBytes: number): Uint8Array {
@@ -162,10 +127,6 @@ export function createXiaomiMimoProvider(options: CreateXiaomiMimoProviderOption
   const apiBaseUrl = normalizeBaseUrl(options.apiBaseUrl ?? "https://api.xiaomimimo.com/v1");
   const requestTimeoutMs = positiveInteger(options.requestTimeoutMs ?? 180_000, "requestTimeoutMs");
   const maxResponseBytes = positiveInteger(options.maxResponseBytes ?? 64 * 1024 * 1024, "maxResponseBytes");
-  const maxVoiceSampleBase64Bytes = positiveInteger(
-    options.maxVoiceSampleBase64Bytes ?? 10_000_000,
-    "maxVoiceSampleBase64Bytes",
-  );
   const fetcher = options.fetch ?? globalThis.fetch;
   const endpointCapabilities = modelNames.map((model) => ({
     capability: capabilities[model],
@@ -174,19 +135,10 @@ export function createXiaomiMimoProvider(options: CreateXiaomiMimoProviderOption
     handler: async (context: EndpointInvocationContext) => {
       const req = request(context.need.constraints, model);
       const text = scalar(req, model, "text")!;
-      const messages: Array<{ role: "user" | "assistant"; content: string }> = [];
+      const messages: Array<{ role: "user" | "assistant"; content: string }> = [
+        { role: "user", content: scalar(req, model, "voiceDescription")! },
+      ];
       const audio: Record<string, CanonicalValue> = { format: "wav" };
-      if (model === "mimo-v2.5-tts") {
-        const instruction = scalar(req, model, "instruction", false);
-        if (instruction !== undefined) messages.push({ role: "user", content: instruction });
-        audio.voice = scalar(req, model, "voice")!;
-      } else if (model === "mimo-v2.5-tts-voicedesign") {
-        messages.push({ role: "user", content: scalar(req, model, "voiceDescription")! });
-      } else {
-        const instruction = scalar(req, model, "instruction", false);
-        if (instruction !== undefined) messages.push({ role: "user", content: instruction });
-        audio.voice = await readVoiceSample(context, req, maxVoiceSampleBase64Bytes);
-      }
       messages.push({ role: "assistant", content: text });
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(new Error("Xiaomi MiMo request timed out")), requestTimeoutMs);

--- a/packages/provider-xiaomi-mimo/test/provider.test.ts
+++ b/packages/provider-xiaomi-mimo/test/provider.test.ts
@@ -7,105 +7,56 @@ import { mimoTtsEndpoints, sealMimoTtsRequest } from "@hypit/mimo-tts";
 import type { CanonicalValue, Need } from "@hypit/protocol";
 import { createXiaomiMimoProvider } from "@hypit/provider-xiaomi-mimo";
 
-function need(
-  endpoint: (typeof mimoTtsEndpoints)[keyof typeof mimoTtsEndpoints],
-  constraints: CanonicalValue,
-  id: string,
-): Need {
+function need(constraints: CanonicalValue): Need {
   return {
-    id: `need:${id}`,
-    capability: endpoint.capability,
-    returns: endpoint.returns,
+    id: "need:mimo-voicedesign",
+    capability: mimoTtsEndpoints.voiceDesign.capability,
+    returns: mimoTtsEndpoints.voiceDesign.returns,
     constraints,
-    result: `record:${id}`,
+    result: "record:mimo-voicedesign",
   };
 }
 
-async function invoke(request: Need, artifacts: MemoryArtifactStore, fetch: typeof globalThis.fetch) {
+test("the official Provider maps only the VoiceDesign contract", async () => {
+  const artifacts = new MemoryArtifactStore();
   const provider = createXiaomiMimoProvider({
-    fetch,
+    fetch: async (input, init) => {
+      assert.equal(String(input), "https://api.xiaomimimo.com/v1/chat/completions");
+      assert.equal(new Headers(init?.headers).get("api-key"), "test-key");
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      assert.equal(body.model, "mimo-v2.5-tts-voicedesign");
+      assert.deepEqual(body.audio, { format: "wav" });
+      assert.deepEqual(body.messages, [
+        { role: "user", content: "A clear, grounded female voice." },
+        { role: "assistant", content: "Keep every authored word." },
+      ]);
+      return Response.json({ choices: [{ message: { audio: { data: Buffer.from([9, 8, 7]).toString("base64") } } }] });
+    },
   });
   const registry = new EndpointRegistry();
   await provider.install(registry);
+  const request = need(sealMimoTtsRequest("mimo-v2.5-tts-voicedesign", {
+    text: ["Keep every authored word."],
+    voiceDescription: ["A clear, grounded female voice."],
+  }) as unknown as CanonicalValue);
   const resolution = registry.resolve(request);
   assert.equal(resolution.status, "resolved");
   assert.equal(resolution.registration.kind, "immediate");
-  return await resolution.registration.handler({
-    command: { kind: "fulfill-need", id: `command:${request.id}`, need: request },
+  const result = await resolution.registration.handler({
+    command: { kind: "fulfill-need", id: "command:mimo-voicedesign", need: request },
     need: request,
     artifacts,
     credentials: { apiKey: { secret: "test-key" } },
   });
-}
-
-function audioResponse(bytes: Uint8Array) {
-  return Response.json({ choices: [{ message: { audio: { data: Buffer.from(bytes).toString("base64") } } }] });
-}
-
-test("the official Provider maps all three model contracts without owning them", async () => {
-  const artifacts = new MemoryArtifactStore();
-  const sample = await artifacts.put(new Uint8Array([1, 2, 3, 4]), "audio/wav");
-  const cases = [
-    {
-      endpoint: mimoTtsEndpoints.preset,
-      request: sealMimoTtsRequest("mimo-v2.5-tts", {
-        text: ["Keep every authored word."], instruction: ["Warm and concise."], voice: ["Chloe"],
-      }),
-      assertBody(body: Record<string, unknown>) {
-        assert.deepEqual(body.audio, { format: "wav", voice: "Chloe" });
-        assert.equal((body.messages as unknown[]).length, 2);
-      },
-    },
-    {
-      endpoint: mimoTtsEndpoints.voiceDesign,
-      request: sealMimoTtsRequest("mimo-v2.5-tts-voicedesign", {
-        text: ["Keep every authored word."], voiceDescription: ["A clear, grounded female voice."],
-      }),
-      assertBody(body: Record<string, unknown>) {
-        assert.deepEqual(body.audio, { format: "wav" });
-        assert.equal((body.messages as unknown[]).length, 2);
-      },
-    },
-    {
-      endpoint: mimoTtsEndpoints.voiceClone,
-      request: sealMimoTtsRequest("mimo-v2.5-tts-voiceclone", {
-        text: ["Keep every authored word."], sample: [{ role: "audio", artifact: sample }],
-      }),
-      assertBody(body: Record<string, unknown>) {
-        assert.match((body.audio as Record<string, string>).voice!, /^data:audio\/wav;base64,/u);
-        assert.equal((body.messages as unknown[]).length, 1);
-      },
-    },
-  ];
-  for (const [index, item] of cases.entries()) {
-    let calls = 0;
-    const result = await invoke(
-      need(item.endpoint, item.request as unknown as CanonicalValue, String(index)),
-      artifacts,
-      async (input, init) => {
-        calls += 1;
-        assert.equal(String(input), "https://api.xiaomimimo.com/v1/chat/completions");
-        assert.equal(new Headers(init?.headers).get("api-key"), "test-key");
-        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
-        assert.equal(body.model, item.endpoint.capability.name);
-        assert.equal((body.messages as Array<Record<string, unknown>>).at(-1)?.role, "assistant");
-        assert.equal((body.messages as Array<Record<string, unknown>>).at(-1)?.content, "Keep every authored word.");
-        assert.equal("optimize_text_preview" in (body.audio as Record<string, unknown>), false);
-        item.assertBody(body);
-        return audioResponse(new Uint8Array([9, 8, 7, index]));
-      },
-    );
-    assert.equal(calls, 1);
-    assert.equal(result.value.kind, "inline");
-    const set = result.value.kind === "inline" ? result.value.value as Record<string, unknown> : {};
-    const audios = set.audios as Array<{ mediaType: string; digest: string }>;
-    assert.equal(audios[0]?.mediaType, "audio/wav");
-    assert.equal(await artifacts.has(audios[0]!.digest as `sha256:${string}`), true);
-  }
+  assert.equal(result.value.kind, "inline");
+  const set = result.value.kind === "inline" ? result.value.value as Record<string, unknown> : {};
+  const audios = set.audios as Array<{ mediaType: string; digest: string }>;
+  assert.equal(audios[0]?.mediaType, "audio/wav");
+  assert.equal(await artifacts.has(audios[0]!.digest as `sha256:${string}`), true);
 });
 
 test("Provider configuration owns credentials and queue policy, not model semantics", () => {
   const provider = createXiaomiMimoProvider({ defaultConcurrency: 3 });
-  assert.equal(provider.offers.length, 3);
-  assert.ok(provider.offers.every((binding) => binding.returns.name === generationTypes.audioSet.name));
+  assert.equal(provider.offers.length, 1);
+  assert.equal(provider.offers[0]?.returns.name, generationTypes.audioSet.name);
 });

--- a/projects/hypihub-provider-smoke/hypit.runtime.json
+++ b/projects/hypihub-provider-smoke/hypit.runtime.json
@@ -15,18 +15,7 @@
             "apiKey": { "store": "env", "key": "HYPIHUB_API_KEY" },
             "defaultConcurrency": 8,
             "pollIntervalMs": 5000,
-            "requestTimeoutMs": 120000,
-            "audio": false
-          }
-        },
-        "xiaomi-mimo.smoke": {
-          "use": "@hypit/provider-xiaomi-mimo",
-          "pool": "xiaomi-mimo.smoke",
-          "config": {
-            "apiBaseUrl": "https://api.xiaomimimo.com/v1",
-            "apiKey": { "store": "env", "key": "MIMO_API_KEY" },
-            "defaultConcurrency": 2,
-            "requestTimeoutMs": 180000
+            "requestTimeoutMs": 120000
           }
         }
       }

--- a/projects/hypihub-provider-smoke/main.svml
+++ b/projects/hypihub-provider-smoke/main.svml
@@ -87,6 +87,4 @@
   </gemini:Generate>
 
   <mimo:VoiceDesign id="mimo-voice" speech={speech}>A clear, warm narrator with a lightly playful delivery.</mimo:VoiceDesign>
-  <mimo:Preset id="mimo-preset" speech={speech} voice="Chloe"/>
-  <mimo:VoiceClone id="mimo-clone" speech={speech} sample={reference-audio}/>
 </svml>


### PR DESCRIPTION
## Summary
- remove MiMo preset TTS and VoiceClone surfaces and provider routes
- keep VoiceDesign as the only MiMo capability
- enable HypiHub VoiceDesign by default and make HypiHub the default paid provider in the skill
- require OAuth login before every HypiHub-backed API boundary

## Validation
- pnpm check
- 15 related provider/package tests
- Hypit skill validation
- HypiHub smoke source check