### PR TITLE
fix(provider-hypihub): lower default request pressure

### DIFF
--- a/packages/provider-hypihub/README.md
+++ b/packages/provider-hypihub/README.md
@@ -23,7 +23,8 @@ Runtime Profile example:
       "config": {
         "baseUrl": "https://hypit.ai",
         "apiKey": { "store": "os", "key": "hypihub.oauth" },
-        "defaultConcurrency": 10
+        "defaultConcurrency": 3,
+        "pollIntervalMs": 10000
       }
     }
   }

--- a/packages/provider-hypihub/src/provider.ts
+++ b/packages/provider-hypihub/src/provider.ts
@@ -222,7 +222,7 @@ function endpoint(client: HypiHubClient, pollIntervalMs: number, maxOperationMs:
 
 export function createHypiHubProvider(options: CreateHypiHubProviderOptions = {}) {
   const client = new HypiHubClient({ baseUrl: apiBaseUrl(options.baseUrl ?? "https://hypit.ai/v1"), timeout: options.requestTimeoutMs ?? 30_000, fetcher: options.fetch ?? globalThis.fetch });
-  const asyncEndpoint = endpoint(client, options.pollIntervalMs ?? 5_000, 20 * 60_000, options.publicAssetUrl);
+  const asyncEndpoint = endpoint(client, options.pollIntervalMs ?? 10_000, 20 * 60_000, options.publicAssetUrl);
   const audioEndpoint: ImmediateEndpointHandler = async (context) => {
     try {
       return await synthesizeAudio(client, context, options.publicAssetUrl);
@@ -252,7 +252,7 @@ export function createHypiHubProvider(options: CreateHypiHubProviderOptions = {}
   };
   return defineEndpointPackage({
     module: hypiHubProviderModuleRef, facet: "gateway", instance: options.instance ?? "hypihub.default", pool: options.pool ?? options.instance ?? "hypihub.default",
-    credentials: { apiKey: options.apiKey ?? credentialRef("os", "hypihub.oauth") }, credentialInputs: { apiKey: { label: "HypiHub login" } }, defaultConcurrency: options.defaultConcurrency ?? 10,
+    credentials: { apiKey: options.apiKey ?? credentialRef("os", "hypihub.oauth") }, credentialInputs: { apiKey: { label: "HypiHub login" } }, defaultConcurrency: options.defaultConcurrency ?? 3,
     capabilities: [
       ...hypiHubRoutes
       .filter((route) => options.audio !== false || route.media !== "audio")


### PR DESCRIPTION
Lower provider-hypihub defaults to 3 concurrent operations and 10-second async polling to stay below HypiHub request/concurrency limits. Update the README example. No new tests.