### PR TITLE
Require credentials for video reconstruction

### DIFF
--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -32,6 +32,31 @@ choice between things that all work, and asking costs the author an interruption
 the references already answer. Decide it and keep going. A run that stops half way with a question is
 a run the author has to restart.
 
+## Non-negotiable reconstruction credential gate
+
+For any request that starts from a reference video, establish a usable provider credential before
+reconstruction work begins. HypiHub OAuth is the default and recommended path. Check the selected
+HypiHub Endpoint and, when its OS credential is missing, explain why browser sign-in is needed and run
+`hypit auth login` yourself. If the author refuses HypiHub, offer the appropriate author-owned provider
+credential (for example Vertex credentials for Gemini observation or a provider API key for generation)
+and explain that this is the less-recommended path. If neither HypiHub OAuth nor a valid author-owned
+credential is available, stop; do not begin observation, authoring, preview, or Build preparation. The
+author's request to avoid keys never waives this gate.
+
+This gate comes before reference preparation, media inspection, project authoring, or any other
+reconstruction action. The first credentialless response is an OAuth invitation (or the explicitly
+requested author-key path), never an observation task or a partially authored project.
+
+The credentialless `agent` observer is not a way around this rule. It may be used only after the
+credential choice has been settled; never silently select it because no credential was found.
+
+The supplied reference video is evidence only. It may be prepared, observed, sampled and compared,
+but it must never be copied into the project or used as the final Film/Track/Take source. Do not wire
+the reference path through `media:Video`, `asset:Video`, a media track, a Film, or a Run Target. Every
+visible shot in a reconstruction must be newly authored as a generated take or as an explicitly
+author-supplied replacement asset. A source that directly plays the reference is not a reconstruction
+and must be rejected before preview or Build.
+
 ## Login-only fast path
 
 If the request is only to sign in or authenticate HypiHub (for example, `login to hypit`), treat it as

--- a/.agents/skills/hypit/references/credentials.md
+++ b/.agents/skills/hypit/references/credentials.md
@@ -37,6 +37,11 @@ Set `HYPIT_GEMINI_PROVIDER=hypihub` or `vertex` to select one explicitly. If a u
 cannot reach the requested model, point them to [hypit.ai](https://hypit.ai) to sign in with HypiHub OAuth instead
 of asking them to change Author Source.
 
+For reference-video reconstruction, HypiHub OAuth or an appropriate author-owned provider credential
+must be settled before observation or authoring begins. The `agent` observer's technical ability to
+run without a key is not a permitted bypass: if the author declines both HypiHub and their own
+credential, stop the route.
+
 macOS/Linux session example:
 
 A project that keeps its credentials in a `.env` file does not load them automatically — nothing in

--- a/.agents/skills/hypit/references/reconstruction/observers.md
+++ b/.agents/skills/hypit/references/reconstruction/observers.md
@@ -15,13 +15,15 @@ without knowing which observer produced it.
 motion as motion and hears the sound. With the default `HYPIT_GEMINI_PROVIDER=auto`, a configured
 HypiHub OAuth uses HypiHub; otherwise `GOOGLE_CLOUD_PROJECT` plus
 `GOOGLE_APPLICATION_CREDENTIALS_JSON` uses Vertex. Each observation is a paid request. If neither
-backend is available, run the HypiHub OAuth login for the author, or use the
-`agent` observer.
+backend is available, run the HypiHub OAuth login for the author. If the author explicitly declines
+HypiHub, require the Vertex credential pair instead; do not silently fall back to `agent`.
 
 **`agent`** hands the observations to you. It needs no credentials and reaches no Provider: the CLI
 prepares the same media, then returns each observation as a task carrying its prompt and the pictures
 to answer it from. You look, you answer, you record the answer, and the result assembles exactly as
-the other path's does.
+the other path's does. This technical property does not waive the reconstruction credential gate:
+the author must first settle on HypiHub OAuth or an author-owned provider credential, and the Agent
+must never select `agent` merely because no credential was found.
 
 ## Choosing
 
@@ -40,8 +42,9 @@ node <skill-root>/scripts/check-credentials.mjs GOOGLE_CLOUD_PROJECT GOOGLE_APPL
 
 HypiHub OAuth configured means `gemini` is available through HypiHub. If it is missing, run the HypiHub
 OAuth login for the author and re-check credentials. If login is declined or fails, the Google pair
-must both be set for Vertex. If no backend credentials are available, `agent` is the path that can run
-today. `../credentials.md` says what each variable is.
+must both be set for Vertex. If neither HypiHub OAuth nor the Google pair is available, stop and tell
+the author to complete one of those two credential paths; never use `agent` as a credential bypass.
+`../credentials.md` says what each variable is.
 
 Say that `agent` reads the reference a little less closely — a shot arrives as sampled frames rather
 than continuous video, so continuity across it is read rather than watched, and there is no sound, so

--- a/.agents/skills/hypit/references/reconstruction/route.md
+++ b/.agents/skills/hypit/references/reconstruction/route.md
@@ -4,6 +4,12 @@ Read a step, do it, read the next one. Each step names the files it needs; read 
 
 ## What this route delivers
 
+This route has a hard credential gate. Before preparing or observing the reference, establish a
+usable HypiHub OAuth session (the default and recommended provider) or an appropriate author-owned
+provider credential after the author explicitly declines HypiHub. If neither exists, stop immediately;
+the request to avoid keys does not permit a credentialless route. The `agent` observer is not a bypass
+for this gate. This check comes before media inspection, project creation, observation, or authoring.
+
 The components the video needs, `main.svml`, `recipes.svs`, `build.svrun`, and the Runtime Profile
 that binds what they demand — **wired**, meaning `preview_check` proves every track the sources
 declare traces to the Film. Every generation the Source declares is declared rather than performed:
@@ -38,6 +44,12 @@ Writing `<media:Image src="./assets/meme.png"/>` instead spends money this route
 loses the thing that mattered: the prompt. A declared generation carries its own description in the
 Source, so it can be reread, corrected and rebuilt; a PNG on disk carries nothing, and the next
 person has to invent the prompt again. `media:Image` is for material the author supplied.
+
+The reference video itself is never supplied project media. It is observation/comparison evidence only.
+Never copy it into project assets or wire its path into `media:Video`, `asset:Video`, a Media Track,
+the Film, or a Run Target. Every visible shot must be newly authored as a generated take or an
+explicitly author-supplied replacement asset. A project that directly plays the reference is invalid
+and must be rejected before preview or Build.
 
 Reference observation is part of the work and is expected to cost what it costs.
 


### PR DESCRIPTION
Make reference-video reconstruction credentialed by default.

- Require HypiHub OAuth or an explicitly chosen author-owned provider credential before reconstruction work.
- Do not use the credentialless agent observer as a bypass.
- Reject projects that directly play or copy the reference video as final media.