### PR TITLE
Refresh Hypit skill on first session load

### DIFF
--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -11,6 +11,21 @@ description: Produce a complete video program from a description or reference vi
 > CLIs, Studio, runtime or repository infrastructure, ignore the video-production routes and follow
 > the repository's contributor/development instructions instead.
 
+## Session initialization
+
+When this Skill is loaded for the first time in a new conversation, refresh the installed Hypit Skill
+from the repository before entering any production route:
+
+```bash
+npx --yes skills update hypit --global --yes
+```
+
+Run this refresh once per conversation, do not repeat it for later turns, and then continue with the
+current request using the refreshed Skill. This is a Skill update only; it does not update the Hypit
+Distribution, install packages, inspect a project, or make any provider request. If the refresh cannot
+complete because the network or Skills CLI is unavailable, report that the latest Skill could not be
+confirmed before proceeding; never pretend the local copy is current.
+
 **Run the route to the end without stopping.** There are exactly two things worth interrupting the
 author for, and everything else is yours to decide:
 

--- a/.agents/skills/hypit/references/host-setup.md
+++ b/.agents/skills/hypit/references/host-setup.md
@@ -177,8 +177,7 @@ receipt, digest inventory or project-local copy.
 
 ## Update an installed Distribution
 
-Updates to an installed, published Distribution are an explicit package-manager operation, never an
-automatic mutation during authoring:
+Updates to an installed, published Distribution remain an explicit package-manager operation:
 
 ```text
 npm outdated --global hypit
@@ -187,7 +186,10 @@ npx skills update --global
 ```
 
 Use `hypit --version` to report the installed Distribution. Check npm only when the user asks about
-updates or during deliberate environment maintenance; do not add a registry request to every route.
+updates or during deliberate environment maintenance; do not add a Distribution registry request to
+every route. The Hypit Skill itself is different: its `SKILL.md` requires one
+`npx --yes skills update hypit --global --yes` refresh the first time the Skill is loaded in each new
+conversation.
 
 Do not run those npm commands for a contributor checkout; update it through its repository workflow.
 After updating Hypit, stop an idle Runtime Worker before the next Build so the next process loads the


### PR DESCRIPTION
Refresh the installed Hypit Skill once when it is first loaded in a new conversation.

- Run the documented Skills CLI update command before production routes.
- Do not repeat it on later turns.
- Keep Distribution updates explicit and separate.
- Report when the latest Skill cannot be confirmed.