### PR TITLE
Require healthy WhisperX before video routes

### DIFF
--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -62,6 +62,19 @@ This gate comes before reference preparation, media inspection, project authorin
 reconstruction action. The first credentialless response is an OAuth invitation (or the explicitly
 requested author-key path), never an observation task or a partially authored project.
 
+## Non-negotiable WhisperX gate
+
+For every video-production route — original authoring, reconstruction, revision, and variant work —
+WhisperX must be installed and healthy before the route advances beyond environment setup. Select a
+Runtime Profile with the local WhisperX Endpoint, run `hypit runtime up`, and verify that the service
+reports `Ready whisperx` (or an equivalent successful health check). Do this before reading or
+preparing a reference, inspecting examples or vocabulary, freezing a brief, writing Source, previewing,
+or building. Installation, model setup, or the health probe may never be skipped, replaced by another
+transcriber, deferred until later, or worked around because the user asks to proceed. If WhisperX is
+not installed, still installing, unhealthy, or its health check cannot be confirmed, stop at the
+environment stage and repair it first. The login-only authentication path is the sole exception
+because it is not video production.
+
 The credentialless `agent` observer is not a way around this rule. It may be used only after the
 credential choice has been settled; never silently select it because no credential was found.
 

--- a/.agents/skills/hypit/references/environment.md
+++ b/.agents/skills/hypit/references/environment.md
@@ -15,6 +15,12 @@ Hypit has three different lifetimes. Never collapse them into one directory.
 An ordinary user does not clone the repository and does not run pnpm, Corepack, `npm link`, or a
 service's `uv sync` by hand. A clone is only a contributor checkout.
 
+WhisperX is a mandatory environment prerequisite for every video-production route. Before any route
+advances beyond environment setup, the selected Runtime Profile must include the local WhisperX
+Endpoint, `hypit runtime up` must install and start it, and its health must report `Ready whisperx` (or
+an equivalent successful probe). Do not proceed while it is missing, still installing or unhealthy;
+the only exception is the login-only authentication path, which is not video production.
+
 ## Select a Distribution; do not assume registry publication
 
 The skill must be global; the skills CLI's default is project-local:

--- a/.agents/skills/hypit/references/original-authoring/route.md
+++ b/.agents/skills/hypit/references/original-authoring/route.md
@@ -26,6 +26,13 @@ If the same request also asks for many independent derivatives, finish this rout
 deterministic gate, then enter `../variant-expansion/route.md`. The base project's format, examples,
 component choices and package gaps are decided globally there before any variant agent starts.
 
+This route has a hard WhisperX gate. Before Step 3 or any brief, example, vocabulary, Source, preview,
+or Build work, select a Runtime Profile containing the local WhisperX Endpoint, run `hypit runtime up`,
+and verify `Ready whisperx` (or an equivalent successful health check). If installation or health is
+incomplete, stop at environment setup and repair it; do not substitute another transcriber or proceed
+because the user asks to bypass it. If no profile exists yet, create a minimal profile with local media
+and WhisperX endpoints, select it, and provision it before continuing; extend that same profile later.
+
 ## Checkpoint and recovery
 
 Start the project snapshot after creating the project directory:
@@ -44,7 +51,7 @@ interruption or context compaction, read `../recovery.md`, run `route_state --ac
 
 | state | update / completion predicate | recovery entry |
 | --- | --- | --- |
-| `environment` | explicit checkpoint after Distribution, project and credentials are selected | `hypit paths --json` |
+| `environment` | explicit checkpoint after Distribution, project, credentials and healthy WhisperX are ready | `hypit paths --json` / `hypit runtime up` |
 | `brief-frozen` | explicit checkpoint naming the frozen brief, audience, format and claims | return to the brief checkpoint |
 | `vocabulary-checked` | Run-scoped vocabulary inspection and the frozen `.hypit/component-fit.json` are both persisted | `inspect_svml_vocabulary --run <run>` |
 | `source-authored` | explicit checkpoint naming `main.svml` (and Recipe/Run when available) | `hypit check <run>` |

--- a/.agents/skills/hypit/references/reconstruction/evidence.md
+++ b/.agents/skills/hypit/references/reconstruction/evidence.md
@@ -55,9 +55,10 @@ to transcribe.
 `transcript` reports `status`, `transcript_ref` and `word_count`. Read the words from
 `transcript_ref`, a JSON file of passages, each with its own `words` array of
 `{ text, start_seconds, end_seconds, score }`. A machine with no WhisperX service running reports
-`status: "unavailable"` with a `reason` and prepares everything else; run `hypit runtime up` for the
-project's selected Profile and prepare again. `../host-setup.md` covers diagnosing that service when
-starting it is not enough.
+`status: "unavailable"` with a `reason`. Under the Skill's hard environment gate, do not continue from
+that result: run `hypit runtime up` for the project's selected Profile, confirm the service health, and
+prepare the reference again only after it reports ready. `../host-setup.md` covers diagnosing that
+service when starting it is not enough.
 
 When a completed preparation stage must be rerun, use one small `--redo` value:
 

--- a/.agents/skills/hypit/references/reconstruction/route.md
+++ b/.agents/skills/hypit/references/reconstruction/route.md
@@ -10,6 +10,11 @@ provider credential after the author explicitly declines HypiHub. If neither exi
 the request to avoid keys does not permit a credentialless route. The `agent` observer is not a bypass
 for this gate. This check comes before media inspection, project creation, observation, or authoring.
 
+WhisperX is a second hard gate. Before Step 4 or any later route work, the selected Runtime Profile
+must include the local WhisperX Endpoint, `hypit runtime up` must finish its installation and startup,
+and the service health must report `Ready whisperx` (or an equivalent successful probe). Do not prepare
+the reference, inspect vocabulary, or author Source while WhisperX is missing, installing or unhealthy.
+
 The components the video needs, `main.svml`, `recipes.svs`, `build.svrun`, and the Runtime Profile
 that binds what they demand — **wired**, meaning `preview_check` proves every track the sources
 declare traces to the Film. Every generation the Source declares is declared rather than performed:
@@ -95,7 +100,7 @@ of intent; files and check results remain the authority.
 
 | state | update / completion predicate | recovery entry |
 | --- | --- | --- |
-| `environment` | explicit checkpoint after Distribution, project and credentials are selected | `hypit paths --json` |
+| `environment` | explicit checkpoint after Distribution, project, credentials and healthy WhisperX are ready | `hypit paths --json` / `hypit runtime up` |
 | `reference-prepared` | checkpoint after `prepare_reference` reports ready `state.json` | `prepare_reference` or `route_state reconcile` |
 | `reference-observed` | explicit observer checkpoint; all required observation answers are complete | `observe_reference` / `record_observation` |
 | `vocabulary-checked` | Run-scoped vocabulary inspection and the frozen `.hypit/component-fit.json` are both persisted | `inspect_svml_vocabulary --run <run>` |


### PR DESCRIPTION
Make WhisperX installation and health a hard prerequisite for video production.

- Require the local WhisperX endpoint and a successful Ready whisperx health check before any route work beyond environment setup.
- Apply the gate to reconstruction and original-authoring routes.
- Do not continue from unavailable WhisperX preparation results or substitute another transcriber.