### PR TITLE
Enforce complete environment setup and checkout sync

### DIFF
--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -62,18 +62,23 @@ This gate comes before reference preparation, media inspection, project authorin
 reconstruction action. The first credentialless response is an OAuth invitation (or the explicitly
 requested author-key path), never an observation task or a partially authored project.
 
-## Non-negotiable WhisperX gate
+## Non-negotiable environment gate
 
 For every video-production route — original authoring, reconstruction, revision, and variant work —
-WhisperX must be installed and healthy before the route advances beyond environment setup. Select a
-Runtime Profile with the local WhisperX Endpoint, run `hypit runtime up`, and verify that the service
-reports `Ready whisperx` (or an equivalent successful health check). Do this before reading or
-preparing a reference, inspecting examples or vocabulary, freezing a brief, writing Source, previewing,
-or building. Installation, model setup, or the health probe may never be skipped, replaced by another
-transcriber, deferred until later, or worked around because the user asks to proceed. If WhisperX is
-not installed, still installing, unhealthy, or its health check cannot be confirmed, stop at the
-environment stage and repair it first. The login-only authentication path is the sole exception
-because it is not video production.
+read `references/environment.md` completely and finish its environment setup before doing anything
+else in the route. This is a hard prerequisite, not documentation to consult later. The completed
+environment must include a selected Hypit Distribution, an explicit project boundary, the project's
+Runtime Profile, resolved credentials for the capabilities the route will use, and every selected
+managed program installed and healthy. Run the required `hypit runtime up` provisioning and health
+checks; WhisperX must report `Ready whisperx` (or an equivalent successful probe). Do this before
+inspecting media or examples, preparing a reference, choosing an observer, freezing a brief, reading
+vocabulary, writing Source, previewing, or building.
+
+Do not skip, replace, defer, or partially complete any environment step, and do not proceed because
+the user asks to bypass it. If Distribution selection, project setup, credential resolution, Runtime
+Profile selection, program installation, or any health check is incomplete or cannot be confirmed,
+stop at the environment stage and repair it first. The login-only authentication path is the sole
+exception because it is not video production.
 
 The credentialless `agent` observer is not a way around this rule. It may be used only after the
 credential choice has been settled; never silently select it because no credential was found.

--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -13,18 +13,29 @@ description: Produce a complete video program from a description or reference vi
 
 ## Session initialization
 
-When this Skill is loaded for the first time in a new conversation, refresh the installed Hypit Skill
-from the repository before entering any production route:
+When this Skill is loaded for the first time in a new conversation, synchronize the complete Hypit
+repository before entering any production route. If the selected Distribution is a Hypit contributor
+checkout, update that checkout first:
+
+```bash
+git pull --ff-only origin main
+```
+
+This is a whole-repository update: it refreshes the CLI, packages, services, examples, docs and Skill
+source together. Do not treat an installed Skill update as a substitute for pulling the checkout.
+After the checkout is current, refresh the installed global Skill as well:
 
 ```bash
 npx --yes skills update hypit --global --yes
 ```
 
-Run this refresh once per conversation, do not repeat it for later turns, and then continue with the
-current request using the refreshed Skill. This is a Skill update only; it does not update the Hypit
-Distribution, install packages, inspect a project, or make any provider request. If the refresh cannot
-complete because the network or Skills CLI is unavailable, report that the latest Skill could not be
-confirmed before proceeding; never pretend the local copy is current.
+Run the repository pull and installed Skill refresh once per conversation, do not repeat them for later
+turns, and then continue with the current request using the current checkout and refreshed Skill. Do
+not reset or overwrite local changes: if `git pull --ff-only origin main` cannot fast-forward, stop and
+report the sync conflict. If no contributor checkout is selected, there is no local repository to pull;
+still run the global Skill refresh and report that only the installed Skill was updated. If either
+operation cannot complete because the network or CLI is unavailable, report that the latest state could
+not be confirmed before proceeding; never pretend the repository is current.
 
 **Run the route to the end without stopping.** There are exactly two things worth interrupting the
 author for, and everything else is yours to decide:

--- a/.agents/skills/hypit/references/environment.md
+++ b/.agents/skills/hypit/references/environment.md
@@ -15,11 +15,20 @@ Hypit has three different lifetimes. Never collapse them into one directory.
 An ordinary user does not clone the repository and does not run pnpm, Corepack, `npm link`, or a
 service's `uv sync` by hand. A clone is only a contributor checkout.
 
-WhisperX is a mandatory environment prerequisite for every video-production route. Before any route
-advances beyond environment setup, the selected Runtime Profile must include the local WhisperX
-Endpoint, `hypit runtime up` must install and start it, and its health must report `Ready whisperx` (or
-an equivalent successful probe). Do not proceed while it is missing, still installing or unhealthy;
-the only exception is the login-only authentication path, which is not video production.
+## Environment completion gate
+
+This document must be read completely before any video-production route continues. Environment setup is
+complete only when all of the following are true: a Hypit Distribution is selected; the project
+directory and its package boundary are established; credentials for every capability the route will
+use are resolved; the project's Runtime Profile is selected; `hypit runtime up` has finished installing
+and starting every selected managed program; and every required health check passes. The local
+WhisperX Endpoint is mandatory for video production and must report `Ready whisperx` (or an equivalent
+successful probe).
+
+Do not inspect media or examples, prepare or observe a reference, freeze a brief, inspect vocabulary,
+write Source, preview, or Build until this checklist is complete. Do not substitute another
+transcriber, defer installation, or continue from a partial or unconfirmed setup. The only exception
+is the login-only authentication path, which is not video production.
 
 ## Select a Distribution; do not assume registry publication
 

--- a/.agents/skills/hypit/references/environment.md
+++ b/.agents/skills/hypit/references/environment.md
@@ -166,6 +166,17 @@ may also use it as the Distribution when no installed CLI exists, as described a
 projects in this checkout live under `<checkout-root>/projects/<project-name>/`; they remain independent
 author projects and are not part of the repository workspace globs.
 
+When this checkout is the selected Distribution and the Hypit Skill is loaded for the first time in a
+new conversation, synchronize the complete repository before using it:
+
+```text
+git pull --ff-only origin main
+```
+
+This updates the CLI, packages, services, examples, docs and Skill source together. Never reset or
+overwrite local changes; a pull that cannot fast-forward is a sync conflict and blocks the route until
+it is resolved. Updating only the installed Skill does not make the contributor checkout current.
+
 A project directory carries its own `package.json` with the runtime-safe minimum
 `{ "name": "<project-name>", "version": "0.0.0", "private": true, "type": "module" }`.
 `hypit check`, `plan` and `build` locate the package root by walking

--- a/.agents/skills/hypit/references/original-authoring/route.md
+++ b/.agents/skills/hypit/references/original-authoring/route.md
@@ -26,12 +26,14 @@ If the same request also asks for many independent derivatives, finish this rout
 deterministic gate, then enter `../variant-expansion/route.md`. The base project's format, examples,
 component choices and package gaps are decided globally there before any variant agent starts.
 
-This route has a hard WhisperX gate. Before Step 3 or any brief, example, vocabulary, Source, preview,
-or Build work, select a Runtime Profile containing the local WhisperX Endpoint, run `hypit runtime up`,
-and verify `Ready whisperx` (or an equivalent successful health check). If installation or health is
-incomplete, stop at environment setup and repair it; do not substitute another transcriber or proceed
-because the user asks to bypass it. If no profile exists yet, create a minimal profile with local media
-and WhisperX endpoints, select it, and provision it before continuing; extend that same profile later.
+This route has a hard environment gate. At route entry read `../environment.md` completely and finish
+its environment steps (Distribution, project boundary, credentials, Runtime Profile, all selected
+managed programs, and health checks) before entering the brief, example, vocabulary, Source, preview,
+or Build steps. The local WhisperX Endpoint is one mandatory item and must report `Ready whisperx` (or
+an equivalent successful health check). If no profile exists yet, create a minimal profile with local
+media and WhisperX endpoints, select it, and provision it before continuing; extend that same profile
+later. Do not proceed from a partial or unconfirmed environment, substitute another transcriber, or
+continue because the user asks to bypass setup.
 
 ## Checkpoint and recovery
 
@@ -51,7 +53,7 @@ interruption or context compaction, read `../recovery.md`, run `route_state --ac
 
 | state | update / completion predicate | recovery entry |
 | --- | --- | --- |
-| `environment` | explicit checkpoint after Distribution, project, credentials and healthy WhisperX are ready | `hypit paths --json` / `hypit runtime up` |
+| `environment` | explicit checkpoint after Distribution, project, credentials, Runtime Profile, selected programs and all health checks are ready | `hypit paths --json` / `hypit runtime up` |
 | `brief-frozen` | explicit checkpoint naming the frozen brief, audience, format and claims | return to the brief checkpoint |
 | `vocabulary-checked` | Run-scoped vocabulary inspection and the frozen `.hypit/component-fit.json` are both persisted | `inspect_svml_vocabulary --run <run>` |
 | `source-authored` | explicit checkpoint naming `main.svml` (and Recipe/Run when available) | `hypit check <run>` |

--- a/.agents/skills/hypit/references/reconstruction/route.md
+++ b/.agents/skills/hypit/references/reconstruction/route.md
@@ -10,10 +10,12 @@ provider credential after the author explicitly declines HypiHub. If neither exi
 the request to avoid keys does not permit a credentialless route. The `agent` observer is not a bypass
 for this gate. This check comes before media inspection, project creation, observation, or authoring.
 
-WhisperX is a second hard gate. Before Step 4 or any later route work, the selected Runtime Profile
-must include the local WhisperX Endpoint, `hypit runtime up` must finish its installation and startup,
-and the service health must report `Ready whisperx` (or an equivalent successful probe). Do not prepare
-the reference, inspect vocabulary, or author Source while WhisperX is missing, installing or unhealthy.
+The complete environment is a second hard gate. At route entry, read `../environment.md` completely,
+then finish its checklist through the environment steps: Distribution, project boundary, credentials,
+Runtime Profile, all selected managed programs, and health checks. The local WhisperX Endpoint is
+mandatory and must report `Ready whisperx` (or an equivalent successful probe). Do not enter the
+observation or authoring steps while any environment item is missing, installing, unhealthy, or
+unconfirmed.
 
 The components the video needs, `main.svml`, `recipes.svs`, `build.svrun`, and the Runtime Profile
 that binds what they demand — **wired**, meaning `preview_check` proves every track the sources
@@ -100,7 +102,7 @@ of intent; files and check results remain the authority.
 
 | state | update / completion predicate | recovery entry |
 | --- | --- | --- |
-| `environment` | explicit checkpoint after Distribution, project, credentials and healthy WhisperX are ready | `hypit paths --json` / `hypit runtime up` |
+| `environment` | explicit checkpoint after Distribution, project, credentials, Runtime Profile, selected programs and all health checks are ready | `hypit paths --json` / `hypit runtime up` |
 | `reference-prepared` | checkpoint after `prepare_reference` reports ready `state.json` | `prepare_reference` or `route_state reconcile` |
 | `reference-observed` | explicit observer checkpoint; all required observation answers are complete | `observe_reference` / `record_observation` |
 | `vocabulary-checked` | Run-scoped vocabulary inspection and the frozen `.hypit/component-fit.json` are both persisted | `inspect_svml_vocabulary --run <run>` |

--- a/.agents/skills/hypit/references/revision/route.md
+++ b/.agents/skills/hypit/references/revision/route.md
@@ -17,6 +17,13 @@ Requests such as “move this element right” or “raise the captions” start
 Do not edit the rendered MP4, PNG, WAV, preview mock or Artifact directly. The source remains
 authoritative.
 
+Before any revision command or project inspection, read `../environment.md` completely and finish its
+environment checklist. The selected Distribution, project boundary, credentials, Runtime Profile,
+selected managed programs and their health checks must all be confirmed; the local WhisperX Endpoint
+must report `Ready whisperx` (or an equivalent successful probe). Do not begin a revision from a
+partial, installing, unhealthy or unconfirmed environment, even when the change itself appears
+deterministic or the user asks to bypass setup.
+
 ## Recovery and state
 
 Read `../../SKILL.md`, `../recovery.md`, the project's current `.hypit/revision-state.json` view, its

--- a/.agents/skills/hypit/references/variant-expansion/route.md
+++ b/.agents/skills/hypit/references/variant-expansion/route.md
@@ -10,6 +10,12 @@ The default deliverable is checked Source. Do not render, visually review or sub
 the author explicitly asks for finished videos. A Build spends money and still requires a fresh cost
 approval; context recovery is never approval to repeat it.
 
+Before discovering or copying a batch, read `../environment.md` completely and finish its environment
+checklist. The selected Distribution, project boundary, credentials, Runtime Profile, selected managed
+programs and health checks must be confirmed; the local WhisperX Endpoint must report `Ready whisperx`
+(or an equivalent successful probe). Do not treat source-only delivery or an existing completed base
+as a reason to skip this gate.
+
 ## Recovery comes first
 
 At the start of a new turn or after context compaction:


### PR DESCRIPTION
Harden the Hypit Skill environment and session initialization rules.

- Require reading and completing environment.md before video-production routes continue.
- Require Distribution, project boundary, credentials, Runtime Profile, managed programs and health checks.
- Keep WhisperX as a mandatory healthy environment item.
- On first Skill load in a new conversation, pull the complete contributor checkout from origin/main before refreshing the installed Skill.
- Do not overwrite local changes or bypass incomplete setup.