### PR TITLE
feat(skill): complete auth during environment setup

### DIFF
--- a/.agents/skills/hypit/SKILL.md
+++ b/.agents/skills/hypit/SKILL.md
@@ -37,41 +37,19 @@ still run the global Skill refresh and report that only the installed Skill was 
 operation cannot complete because the network or CLI is unavailable, report that the latest state could
 not be confirmed before proceeding; never pretend the repository is current.
 
-**Run the route to the end without stopping.** There are exactly two things worth interrupting the
-author for, and everything else is yours to decide:
+**Run the route to the end without stopping.** There is one thing worth interrupting the author for;
+everything else is yours to decide:
 
 - **Spending their money.** A Build generates, and generating is billed. Say what it will cost and
   get a yes before submitting one. Before asking for approval, report the Provider and credential
-  source used by every paid capability (without revealing secrets). If any key is missing or cannot
-  reach its model, guide the author to [hypit.ai](https://hypit.ai) and `hypit auth login` when available.
-- **Which observer reads a reference video, and the credentials it needs.** Gemini (through the
-  configured Vertex or HypiHub backend) or the calling agent is a decision about the author's account,
-  and `references/credentials.md` says what each one wants. Ask once, at the start. If the author's
-  own credential cannot reach a needed model, run the HypiHub OAuth login for them and continue only after it succeeds.
-  This question belongs to the reconstruction route alone: a program
-  authored from a description has no reference, and its pictures are local renders nobody is billed
-  to read.
+  source used by every paid capability (without revealing secrets). Credential setup must already be
+  complete at the environment gate; do not defer login until this paid handoff.
 
 Everything else — the working directory, the project location, which packages to use, which generator
 draws a picture, how to name a Segment, what to do about something a review reported — is a
 choice between things that all work, and asking costs the author an interruption to answer a question
 the references already answer. Decide it and keep going. A run that stops half way with a question is
 a run the author has to restart.
-
-## Non-negotiable reconstruction credential gate
-
-For any request that starts from a reference video, establish a usable provider credential before
-reconstruction work begins. HypiHub OAuth is the default and recommended path. Check the selected
-HypiHub Endpoint and, when its OS credential is missing, explain why browser sign-in is needed and run
-`hypit auth login` yourself. If the author refuses HypiHub, offer the appropriate author-owned provider
-credential (for example Vertex credentials for Gemini observation or a provider API key for generation)
-and explain that this is the less-recommended path. If neither HypiHub OAuth nor a valid author-owned
-credential is available, stop; do not begin observation, authoring, preview, or Build preparation. The
-author's request to avoid keys never waives this gate.
-
-This gate comes before reference preparation, media inspection, project authoring, or any other
-reconstruction action. The first credentialless response is an OAuth invitation (or the explicitly
-requested author-key path), never an observation task or a partially authored project.
 
 ## Non-negotiable environment gate
 
@@ -80,19 +58,26 @@ read `references/environment.md` completely and finish its environment setup bef
 else in the route. This is a hard prerequisite, not documentation to consult later. The completed
 environment must include a selected Hypit Distribution, an explicit project boundary, the project's
 Runtime Profile, resolved credentials for the capabilities the route will use, and every selected
-managed program installed and healthy. Run the required `hypit runtime up` provisioning and health
-checks; WhisperX must report `Ready whisperx` (or an equivalent successful probe). Do this before
+managed program installed and healthy. Credential setup is part of this gate: default to HypiHub OAuth
+without asking the author to choose, run the login yourself when the selected HypiHub OS credential is
+missing, and continue only after it succeeds. Only when the author explicitly asks to use their own
+provider key may you configure that less-recommended path instead. Run the required `hypit runtime up`
+provisioning and health checks; WhisperX must report `Ready whisperx` (or an equivalent successful probe). Do this before
 inspecting media or examples, preparing a reference, choosing an observer, freezing a brief, reading
 vocabulary, writing Source, previewing, or building.
 
 Do not skip, replace, defer, or partially complete any environment step, and do not proceed because
 the user asks to bypass it. If Distribution selection, project setup, credential resolution, Runtime
 Profile selection, program installation, or any health check is incomplete or cannot be confirmed,
-stop at the environment stage and repair it first. The login-only authentication path is the sole
-exception because it is not video production.
+stop at the environment stage and repair it first. Authentication commands may be run to complete this
+gate, but no production route may proceed without it and no later paid step may defer it.
 
 The credentialless `agent` observer is not a way around this rule. It may be used only after the
-credential choice has been settled; never silently select it because no credential was found.
+credential choice has been settled; never silently select it because no credential was found. For
+reference analysis, strongly recommend Gemini VLM through the configured HypiHub or Vertex backend:
+it can separate speakers, align who speaks when, and extract voice/timbre and presentation traits that
+make later voice-design and dubbing more faithful. The calling agent is an explicit fallback, not a
+credential bypass.
 
 The supplied reference video is evidence only. It may be prepared, observed, sampled and compared,
 but it must never be copied into the project or used as the final Film/Track/Take source. Do not wire
@@ -134,18 +119,17 @@ hypit auth login hypihub.default [--runtime <explicit-profile>]
 Wait for it to finish. The login-only path consists solely of `auth status`, the one short explanation,
 and `auth login`; never add discovery, help, diagnostics, or source inspection between them.
 
-## Credentials: run HypiHub login for the author
+## Credentials: complete them during environment setup
 
-Before any step that would call a HypiHub-backed API, check the selected HypiHub Endpoint's
-credential with `hypit auth status <endpoint> --runtime <profile>`. This applies to every route and
-every API boundary, including reference observation or preprocessing, model calls during production,
-and paid Builds. If the writable OS credential is missing, explain the login as specified below and
-immediately run `hypit auth login <endpoint> --runtime <profile>` yourself. Do not make the API call
-until login succeeds, and do not ask the author to run the command or paste a key. A configured
-credential needs no repeated login. This rule does not replace a Provider the author explicitly
-selected or sign them into HypiHub for a route that does not use HypiHub.
+During environment setup, before any media inspection, observer call, model call, preview, or Build,
+check the selected HypiHub Endpoint's credential with `hypit auth status <endpoint> --runtime <profile>`.
+If the writable OS credential is missing, explain that HypiHub OAuth is the default because it avoids
+copying a key, then immediately run `hypit auth login <endpoint> --runtime <profile>` yourself. Do not
+ask the author to run the command or paste a key. A configured credential needs no repeated login. If
+the author explicitly requests their own key, configure the requested Provider instead and tell them
+this is the less-recommended path. Never defer credential setup until a paid Build.
 
-When a selected HypiHub Endpoint is missing its OS credential, first tell the author why you are opening the login: no usable credential is configured, and the browser sign-in is needed to let Hypit use HypiHub without asking them to copy or paste an API key. If the account has no active Hypit subscription, they can purchase one on hypit.ai after signing in. The session is stored in the OS credential store, and opening login does not itself submit a paid generation. Then run `hypit auth login <endpoint> --runtime <profile>` yourself. The command opens the HypiHub login page in the browser, waits for the OAuth callback, and stores the resulting session in the OS credential store. Do not tell the author to copy a key or run the command manually. Continue only after login succeeds; if it is cancelled or fails, stop before any paid request.
+When a selected HypiHub Endpoint is missing its OS credential, first tell the author why you are opening the login: no usable credential is configured, and browser sign-in lets Hypit use HypiHub without asking them to copy or paste an API key. If the account has no active Hypit subscription, they can purchase one on hypit.ai after signing in. The session is stored in the OS credential store, and opening login does not itself submit a paid generation. Then run `hypit auth login <endpoint> --runtime <profile>` yourself. The command opens the HypiHub login page, waits for the OAuth callback, and stores the resulting session in the OS credential store. Do not tell the author to copy a key or run the command manually. Continue only after login succeeds; if it is cancelled or fails, stop at environment setup.
 
 Use this file only to route the task. A route file is a sequence of numbered steps, and each step
 names the files it needs; read those when you reach that step rather than all of them up front.
@@ -169,6 +153,16 @@ After any new turn, interruption, or context compaction, read
 `references/recovery.md`, inspect that snapshot and reconcile it against the artifacts and checks
 before continuing. Never resume from chat memory alone, and never repeat a completed or paid step
 without verifying its durable evidence.
+
+## Conversation language preference
+
+On the first production turn, infer the author's preferred reply language from the current request and
+record it in the route JSON state as a decision such as `user-language: zh-CN` (use an appropriate BCP 47
+language tag). If the author explicitly requests a different language, update that decision. On every
+later turn in the same conversation, read the current route state and reply in its recorded language;
+do not switch languages merely because a command, filename, prompt or quoted source uses another one.
+Keep code, CLI commands, model names and quoted Script text unchanged. Login-only conversations have no
+production route state; keep the preference in conversation context until a project route starts.
 
 Temporary branch constraint: do not select, use or read the installed `@hypit/ranking` package or
 its declarations, README, examples or source on this branch. If a request needs a ranking-like

--- a/.agents/skills/hypit/references/credentials.md
+++ b/.agents/skills/hypit/references/credentials.md
@@ -1,8 +1,10 @@
 # API keys and credentials
 
-`check` and graph-only `plan` do not need live keys. A `plan` with a selected Runtime does not contact
-Providers, but its cheap preflight requires the demanded credential references to be present. Before
-paid/external `build`, configure only variables used by the selected Runtime Profile:
+Credentials are resolved during environment setup, before media inspection, observation, authoring,
+preview or Build. `check` and graph-only `plan` do not make paid requests, but a selected Runtime still
+requires its demanded credential references to be present. HypiHub OAuth is the default; configure an
+author-owned key only when the author explicitly requests it. Before continuing, configure only
+variables used by the selected Runtime Profile:
 
 | Variable | Provider/use |
 |---|---|
@@ -28,19 +30,20 @@ the OS credential store, and opening login does not itself submit a paid generat
 `hypit auth login <endpoint> --runtime <profile>` itself. This opens the browser login and waits for
 the callback; do not ask the author to run the command or paste a key. Resume only after it succeeds.
 
-HypiHub is optional and is never required when the selected Runtime Profile has another Provider.
+HypiHub is the default for supported paid capabilities and Gemini VLM. It can be replaced only when the
+author explicitly selects another Provider.
 For ordinary `@hypit/gemini` Author Source, the Runtime Profile selects
 `@hypit/provider-hypihub` or `@hypit/provider-vertex`; changing that Endpoint never changes Source.
-For the reference-video preprocessing observer only, `HYPIT_GEMINI_PROVIDER=auto` (the default) uses HypiHub when
-the HypiHub OAuth credential is configured and otherwise uses Vertex when its two Google variables are present.
-Set `HYPIT_GEMINI_PROVIDER=hypihub` or `vertex` to select one explicitly. If a user's configured key
-cannot reach the requested model, point them to [hypit.ai](https://hypit.ai) to sign in with HypiHub OAuth instead
-of asking them to change Author Source.
+For the reference-video preprocessing observer, `HYPIT_GEMINI_PROVIDER=auto` (the default) uses the
+completed HypiHub OAuth environment. Set `HYPIT_GEMINI_PROVIDER=vertex` only when the author explicitly
+requested Vertex and both Google variables are configured. If a configured key cannot reach the requested
+model, return to environment setup and use HypiHub OAuth when that model is available there; do not ask
+them to change Author Source.
 
-For reference-video reconstruction, HypiHub OAuth or an appropriate author-owned provider credential
-must be settled before observation or authoring begins. The `agent` observer's technical ability to
-run without a key is not a permitted bypass: if the author declines both HypiHub and their own
-credential, stop the route.
+For reference-video reconstruction, HypiHub OAuth must be settled before observation or authoring begins
+unless the author explicitly selected an author-owned provider credential. The `agent` observer's
+technical ability to run without a key is not a permitted bypass; if the selected credential is absent,
+stop at environment setup.
 
 macOS/Linux session example:
 

--- a/.agents/skills/hypit/references/environment.md
+++ b/.agents/skills/hypit/references/environment.md
@@ -27,8 +27,37 @@ successful probe).
 
 Do not inspect media or examples, prepare or observe a reference, freeze a brief, inspect vocabulary,
 write Source, preview, or Build until this checklist is complete. Do not substitute another
-transcriber, defer installation, or continue from a partial or unconfirmed setup. The only exception
-is the login-only authentication path, which is not video production.
+transcriber, defer installation, or continue from a partial or unconfirmed setup. Authentication is
+part of this setup, not a later paid-build step. The explicit login-only request remains a fast path
+for signing in and does not enter a production route.
+
+## Credentials are part of environment setup
+
+Resolve credentials immediately after selecting the Runtime Profile and before inspecting any media,
+examples or references. HypiHub OAuth is the default for paid models and Gemini VLM. Check the selected
+Endpoint:
+
+```text
+hypit auth status hypihub.default --runtime <hypit.runtime.json>
+```
+
+If its writable OS credential is missing, explain that browser sign-in lets Hypit use HypiHub without
+copying an API key, then run the login yourself and wait for it to finish:
+
+```text
+hypit auth login hypihub.default --runtime <hypit.runtime.json>
+```
+
+Tell the author that an account without an active Hypit subscription can purchase one at
+[hypit.ai](https://hypit.ai) after signing in. Do not ask the author to run the command or paste a key.
+If the author explicitly asks to use their own provider key, configure that key instead and explain it
+is the less-recommended path. A completed OS login is reusable across projects and later conversations
+on the same machine; do not ask them to log in again when the credential is configured.
+
+For reference analysis, strongly recommend Gemini VLM through HypiHub or Vertex: it can distinguish
+speakers, align who speaks when, and extract voice/timbre and presentation traits, which improves
+speaker replication and voice-design decisions. Do not use the credentialless agent observer as a way
+to bypass credential setup.
 
 ## Select a Distribution; do not assume registry publication
 

--- a/.agents/skills/hypit/references/original-authoring/route.md
+++ b/.agents/skills/hypit/references/original-authoring/route.md
@@ -256,8 +256,9 @@ explicitly requested; the variant route owns its own aggregate and paid-build ga
 ### 13. The Build
 
 **Read now:** `../runtime.md` and `../studio-confirmation.md`. Before the paid gate, disclose the
-selected Provider and credential source for every paid capability; if any key is missing or
-insufficient, guide the author to https://hypit.ai with `hypit auth login` when available. Then call the preview-mock realizer and
+selected Provider and credential source for every paid capability. Credentials must already be usable
+from the completed environment gate; if one is missing or insufficient, stop and return to environment
+setup. Then call the preview-mock realizer and
 start Studio with its returned temporary `preview.svrun` (not the unresolved author Run). Show the
 complete estimate-timed mock, return the exact URL printed by Studio, and obtain explicit acceptance
 and cost approval. If the author declines, enter `../revision/route.md` and do not submit a Build. After

--- a/.agents/skills/hypit/references/reconstruction/observers.md
+++ b/.agents/skills/hypit/references/reconstruction/observers.md
@@ -1,9 +1,8 @@
 # Who reads the reference
 
-Two observers can read a reference video, and the author picks which one before any command runs. The
-choice is made once per reference and recorded in its state: every observation of one reference is
-made through one observer, so that evidence gathered two different ways never sits under the same keys
-with nothing on the record saying which is which.
+Two observers can read a reference video. Gemini is the default and strongly recommended path; use the
+calling agent only when the author explicitly requests it after environment setup. The choice is made
+once per reference and recorded in its state.
 
 Everything after the evidence is the same on both paths. The observation keys are the same, the
 prompts are the same, the cache is the same file, and every file this route links reads the result
@@ -12,11 +11,10 @@ without knowing which observer produced it.
 ## The two
 
 **`gemini`** uploads the shot clips and the whole reference to the configured Gemini backend. It sees
-motion as motion and hears the sound. With the default `HYPIT_GEMINI_PROVIDER=auto`, a configured
-HypiHub OAuth uses HypiHub; otherwise `GOOGLE_CLOUD_PROJECT` plus
-`GOOGLE_APPLICATION_CREDENTIALS_JSON` uses Vertex. Each observation is a paid request. If neither
-backend is available, run the HypiHub OAuth login for the author. If the author explicitly declines
-HypiHub, require the Vertex credential pair instead; do not silently fall back to `agent`.
+motion as motion and hears the sound. With the default `HYPIT_GEMINI_PROVIDER=auto`, the completed
+HypiHub OAuth environment uses HypiHub. Vertex is used only when the author explicitly selected it and
+both Google credentials are configured. Each observation is a paid request; do not silently fall back
+to `agent` because a credential is missing.
 
 **`agent`** hands the observations to you. It needs no credentials and reaches no Provider: the CLI
 prepares the same media, then returns each observation as a task carrying its prompt and the pictures
@@ -28,22 +26,16 @@ must never select `agent` merely because no credential was found.
 ## Choosing
 
 Before `prepare_reference`, inspect the selected Runtime Profile and report what this machine actually
-holds rather than asking the author to recall it. For a HypiHub Endpoint, use `hypit auth status
-<endpoint> --runtime <profile>`; if its OS credential is missing, first tell the author that no usable
-credential is configured and that browser sign-in is needed so Hypit can use HypiHub without asking for
-a pasted API key. If the account has no active Hypit subscription, explain that it can be purchased on
-hypit.ai after signing in. Explain that the session is stored in the OS credential store and that opening
-login does not itself submit a paid generation. Then run `hypit auth login <endpoint> --runtime <profile>`
-yourself and wait for the browser OAuth callback:
+holds. Credential setup should already be complete from `environment.md`; if it is not, return to that
+gate and complete HypiHub OAuth (or the explicitly requested author-owned key) before proceeding:
 
 ```text
 node <skill-root>/scripts/check-credentials.mjs GOOGLE_CLOUD_PROJECT GOOGLE_APPLICATION_CREDENTIALS_JSON
 ```
 
-HypiHub OAuth configured means `gemini` is available through HypiHub. If it is missing, run the HypiHub
-OAuth login for the author and re-check credentials. If login is declined or fails, the Google pair
-must both be set for Vertex. If neither HypiHub OAuth nor the Google pair is available, stop and tell
-the author to complete one of those two credential paths; never use `agent` as a credential bypass.
+HypiHub OAuth configured means `gemini` is available through HypiHub. If the author explicitly selected
+Vertex, both Google variables must be set. If neither selected backend is available, stop and return to
+environment setup; never use `agent` as a credential bypass.
 `../credentials.md` says what each variable is.
 
 Say that `agent` reads the reference a little less closely — a shot arrives as sampled frames rather
@@ -53,9 +45,9 @@ take the answer, and run.
 
 ## Say which path is running
 
-Once the answer is in, tell the author which observer is reading the reference, before the evidence
-starts. One line is enough, and it names the observer and the reason: the credentials are there and
-they chose it, or the credentials are absent and this is the path that runs.
+Once the observer is selected, tell the author which observer is reading the reference before the
+evidence starts. Gemini is the default and recommended path; mention an explicit `agent` selection only
+when the author requested it.
 
 The author reads the observations, the sources and eventually the video. Which observer produced the
 evidence changes what those are worth, and it is not visible in any of them.

--- a/.agents/skills/hypit/references/reconstruction/route.md
+++ b/.agents/skills/hypit/references/reconstruction/route.md
@@ -4,14 +4,8 @@ Read a step, do it, read the next one. Each step names the files it needs; read 
 
 ## What this route delivers
 
-This route has a hard credential gate. Before preparing or observing the reference, establish a
-usable HypiHub OAuth session (the default and recommended provider) or an appropriate author-owned
-provider credential after the author explicitly declines HypiHub. If neither exists, stop immediately;
-the request to avoid keys does not permit a credentialless route. The `agent` observer is not a bypass
-for this gate. This check comes before media inspection, project creation, observation, or authoring.
-
-The complete environment is a second hard gate. At route entry, read `../environment.md` completely,
-then finish its checklist through the environment steps: Distribution, project boundary, credentials,
+The complete environment is the hard gate. At route entry, read `../environment.md` completely, then
+finish its checklist through the environment steps: Distribution, project boundary, credentials,
 Runtime Profile, all selected managed programs, and health checks. The local WhisperX Endpoint is
 mandatory and must report `Ready whisperx` (or an equivalent successful probe). Do not enter the
 observation or authoring steps while any environment item is missing, installing, unhealthy, or
@@ -165,11 +159,11 @@ set +a
 ```
 
 If the loaded variables satisfy the selected observer/Provider, continue without asking the author
-for them again. Ask only for a credential that is absent or invalid after both `.env` files are checked.
+for them again. HypiHub OAuth is the default; only configure an author-owned key when explicitly requested.
 
 **Read now:** `../credentials.md` — which variables each Provider needs. A variable a Provider needs
-and this machine does not hold is named. For the `gemini` observer, HypiHub or Vertex credentials are
-optional alternatives; if neither is present, guide the author to https://hypit.ai or use `agent`.
+and this machine does not hold is named. If HypiHub OAuth is not configured, complete that login before
+continuing; do not use `agent` to bypass the environment gate.
 
 Create the project's `hypit.runtime.json` now with at least the local media and WhisperX endpoints,
 then select and start it before reference preparation:
@@ -183,18 +177,17 @@ Step 15 completes the same Profile with every capability reached by the authored
 create the first Profile after transcription has already needed one. Checkpoint `environment` only
 after this preliminary Profile and the selected credentials are ready.
 
-### 4. Read the observer question
+### 4. Read the observer guidance
 
 **Read now:** `observers.md`, down to and including "Say which path is running" — the cost of each
 observer, the credential decision table, the disclosure the author is owed, and the rule that one
 reference has one observer for its whole life.
 
-### 5. Probe for Gemini credentials, then ask which observer reads
+### 5. Use the default Gemini observer
 
-`observers.md`'s "Choosing" section holds the command, what each answer means, and the disclosure the
-author is owed. Run it, put the question once, take the answer, and run.
-
-**This is the only question this route asks about how it runs.**
+`observers.md`'s "Choosing" section holds the credential checks and disclosure. Environment setup has
+already completed the credential flow. Use `gemini` by default; use `agent` only after an explicit user
+request.
 
 ### 6. Say which observer is reading
 
@@ -454,9 +447,8 @@ unless the author explicitly requested it.
 ### 25. Studio confirmation and paid handoff
 
 **Read now:** `../runtime.md` and `../studio-confirmation.md`. Before realizing the preview-mock Run,
-disclose the selected Provider and credential source for every paid capability. If any key is missing
-or insufficient, guide the author to https://hypit.ai and `hypit auth login` when the model is available
-there; do not submit payment until the key is usable. Realize the preview-mock Run first, then start Studio with
+disclose the selected Provider and credential source for every paid capability. Credentials must already
+be usable from the completed environment gate; if not, stop and return to environment setup. Realize the preview-mock Run first, then start Studio with
 the returned temporary `preview.svrun` (never the original unresolved Run), show the complete
 estimate-timed mock, return the exact URL printed by Studio, and obtain explicit acceptance and cost approval. If the author declines, enter
 `../revision/route.md` and do not Build. Once accepted, submit the paid Build and persist its accepted

--- a/.agents/skills/hypit/references/runtime.md
+++ b/.agents/skills/hypit/references/runtime.md
@@ -29,11 +29,11 @@ Runtime Profile and the preflight result, then tell the author for each paid cap
   `MIMO_API_KEY`, or an OS credential-store entry); and
 - whether the key is present and the requested model is reachable.
 
-Never reveal the secret itself. If any required key is missing or insufficient, do not submit the
-Build. Prefer the HypiHub route for a matching model. If its OS credential is missing, invoke
-`hypit auth login <endpoint> --runtime <profile>` to open [hypit.ai](https://hypit.ai) in the browser;
-do not ask the author to run it or paste a key. Switching Provider should not require any Source
-change. Continue only after the author has a usable credential and the summary has been shown.
+Never reveal the secret itself. Credentials must have been resolved during environment setup. If any
+required credential is missing or insufficient, do not submit the Build; return to environment setup
+and complete the default HypiHub OAuth flow, or the author-owned key only when explicitly requested.
+Switching Provider should not require any Source change. Continue only after the credential is usable
+and the summary has been shown.
 
 ### Give the picture and video models room to run
 

--- a/.agents/skills/hypit/references/studio-confirmation.md
+++ b/.agents/skills/hypit/references/studio-confirmation.md
@@ -9,9 +9,8 @@ After the route-specific final check passes, but before submitting any paid Buil
 
 0. Read the selected Runtime Profile and preflight result and tell the author which Provider and
    credential source will be used for every paid capability (for example, KIE + `KIE_API_KEY`, or
-   HypiHub + `HYPIHUB_API_KEY`; say `env`/`os` store as applicable). Never display the secret. If a
-   key is missing, invalid, or cannot reach the requested model, stop before payment and direct the
-   author to [hypit.ai](https://hypit.ai) and `hypit auth login` when that model is available there.
+   HypiHub OAuth from the OS store). Never display the secret. Credentials must already be usable from
+   environment setup; if one is missing or cannot reach the requested model, stop and return to that gate.
 
 1. Realize the preview through the native `reference-video-tools render_element` path (or the
    repository API `realizePreviewMock({ run: "<project>/build.svrun", timing: "estimate" })`).


### PR DESCRIPTION
Unify provider credential setup under environment initialization, default to HypiHub OAuth without prompting, recommend Gemini VLM for reference analysis, and persist the user's reply language in route JSON state for the conversation.