### PR TITLE
Fix Hypit Skill reference paths

### DIFF
--- a/.agents/skills/hypit/references/brief-intake.md
+++ b/.agents/skills/hypit/references/brief-intake.md
@@ -30,7 +30,7 @@ for the high-impact decisions the request leaves unresolved. Never turn an examp
 a hard-coded type-specific questionnaire; an opening provocation is evidence of that author's Hook,
 not a rule for a purported format.
 
-After the intent comparison, use `../playbooks/index.md` to determine whether a format playbook
+After the intent comparison, use `playbooks/index.md` to determine whether a format playbook
 matches the requested program. Read the matching format playbook completely, including its craft
 notes and footer, and then read every additional craft file that footer names. The match is based on
 the recovered intent and the user's goal, never on an example directory name, component count or a

--- a/.agents/skills/hypit/references/playbooks/craft/b-roll.md
+++ b/.agents/skills/hypit/references/playbooks/craft/b-roll.md
@@ -9,7 +9,7 @@ program audio.
 
 A reference may cover the whole frame with the same speaker in a second location while their voice
 continues: the picture cuts away to the person whose voice is heard, shown silent in another setting.
-This is B-roll, and the base stays the primary take. `continuity.md` owns the rule — the picture that
+This is B-roll, and the base stays the primary take. `../../reconstruction/continuity.md` owns the rule — the picture that
 shows the speaker saying the words is the base, whoever else fills the frame. Author the second
 location exactly like any other B-roll: vendor `broll-v1.svs`, one shot per beat, placed over the
 Script Selection with `during=`.

--- a/.agents/skills/hypit/references/preview.md
+++ b/.agents/skills/hypit/references/preview.md
@@ -5,7 +5,7 @@ preview checks (and optionally render for artifact integrity), but never calls a
 `revision/route.md` for that route.
 
 `preview_check` and `render_element` advance the project's `.hypit/route-state.json` only after their
-success predicates hold. After a new turn or interruption, read `../recovery.md`, reconcile the state,
+success predicates hold. After a new turn or interruption, read `recovery.md`, reconcile the state,
 and resume from its `next_action`; do not rely on chat history.
 
 Before preview, the command repeats `validate_local_author_packages` and `validate_script_cues`; a

--- a/.agents/skills/hypit/references/quickstart.md
+++ b/.agents/skills/hypit/references/quickstart.md
@@ -39,6 +39,6 @@ accepted Records, retrieve Artifacts, and declare any reuse explicitly in a new 
 
 Both production routes expose current progress in `.hypit/route-state.json` and preserve each
 execution under `.hypit/routes/<route-id>/`; after an interruption, follow
-`references/recovery.md` and reconcile before resuming. Before `preview_check`, run
+`recovery.md` and reconcile before resuming. Before `preview_check`, run
 `inspect_svml_vocabulary --run`, `validate_local_author_packages --run` and
 `validate_script_cues --run`; the preview and final checks repeat these gates.

--- a/.agents/skills/hypit/references/reconstruction/observers.md
+++ b/.agents/skills/hypit/references/reconstruction/observers.md
@@ -26,7 +26,7 @@ must never select `agent` merely because no credential was found.
 ## Choosing
 
 Before `prepare_reference`, inspect the selected Runtime Profile and report what this machine actually
-holds. Credential setup should already be complete from `environment.md`; if it is not, return to that
+holds. Credential setup should already be complete from `../environment.md`; if it is not, return to that
 gate and complete HypiHub OAuth (or the explicitly requested author-owned key) before proceeding:
 
 ```text


### PR DESCRIPTION
Repair five broken relative references in the Hypit Skill documentation. No behavior or UI changes.