### PR TITLE
docs: sync quickstart with Hypit skill

### DIFF
--- a/docs/guide/develop.md
+++ b/docs/guide/develop.md
@@ -11,12 +11,14 @@ description: Getting started with Hypit development.
 |---|---|---|
 | Node.js | 22+ | everything |
 | pnpm | 10.33.x | workspace management; selected by the root `packageManager` field |
-| Python | 3.10–3.13 | local WhisperX and OpenCV Managed Programs |
+| Python | 3.10–3.13 (OpenCV: 3.13) | local WhisperX and OpenCV Managed Programs |
 | uv | latest | Python environment management |
 | ffmpeg / ffprobe | recent stable | media processing |
 | Chrome / Chromium | managed by HyperFrames | local HyperFrames rendering |
 
-Node.js and pnpm are the only hard requirements. The rest are needed only for live Builds.
+Node.js and pnpm are the only hard requirements for repository development. Python/uv are needed
+when working with the managed WhisperX or OpenCV services; ffmpeg/ffprobe and a browser are needed
+for media or visual-rendering tests and live Builds.
 
 ## Daily workflow
 
@@ -41,7 +43,7 @@ hypit/
 ├── packages/              workspace packages
 ├── docs/                  VitePress documentation site
 ├── examples/              runnable example sources
-├── services/              Python services (whisperx, image-opencv)
+├── services/              managed services and deployment adapters (whisperx, image-opencv, yt-dlp, media-lambda)
 ├── test/                  repository boundary tests and shared fixtures
 ├── package.json           root workspace manifest
 ├── pnpm-workspace.yaml    workspace: [packages/*]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -64,20 +64,18 @@ You can add constraints such as audience, duration, language, tone, brand colors
 or aspect ratio. The Agent turns the brief into a complete plan and fills in production details from
 the information you provide.
 
-## 3. Provide credentials when the Agent asks
+## 3. Configure credentials
 
 <video controls playsInline preload="metadata" width="100%" src="./quickstart/videos/provide_credentials_when_the_agent_asks.mp4"></video>
 
-After you describe the video, the Agent checks which models and services the project needs. If a
-required credential is missing, it will ask you for it and explain what it is used for. You have two
-options:
+After you describe the video, the Agent checks which models and services the project needs. Hypit
+uses HypiHub OAuth by default for hosted models. If that credential is missing, tell the Agent to
+sign in to HypiHub; the Agent runs the login command, opens the browser flow and stores the session
+in the secure OS credential store. The login itself does not submit a paid generation.
 
-1. **Use Hypit's recommended Hypit.ai OAuth login.** Tell the Agent to log in through hypit.ai. This
-   single OAuth flow covers all models that Hypit provides through its hosted service, so you do not
-   need to collect separate keys for each model.
-2. **Use your own provider keys.** You can tell the Agent which models to use and provide API keys
-   from the corresponding providers. The Agent will request only the keys needed for this project
-   and will not ask for unrelated credentials.
+Only if you explicitly choose an author-owned Provider should you configure its API key instead. The
+Agent requests only the credentials declared by the selected Runtime Profile; it does not silently
+switch Providers because one credential is unavailable.
 
 Never paste a secret into a public document or commit it to Git. The Agent stores credentials using
 the configured secure credential store.
@@ -87,8 +85,9 @@ the configured secure credential store.
 <video controls playsInline preload="metadata" width="100%" src="./quickstart/videos/let_the_agent_do_the_production_work.mp4"></video>
 
 Once you submit the brief, the Agent works through the project automatically without requiring you to
-write source code. It does not ask questions during production; wait for the Studio mock. The exact
-sequence depends on the video, but it generally includes:
+write source code. It normally proceeds to the Studio mock, but may ask a focused clarification when
+the reference or brief does not establish an important editorial detail. The exact sequence depends
+on the video, but it generally includes:
 
 1. **Breaking the request into shots.** The Agent identifies the spoken sections, visual beats,
    transitions, captions, B-roll opportunities and any persistent elements such as a ranking board.
@@ -105,6 +104,8 @@ sequence depends on the video, but it generally includes:
    to design the package interface yourself.
 6. **Creating the source and checking it.** The Agent writes the SVML/SVS source, creates the needed
    Run configuration, compiles the graph, and fixes type or layout problems it finds.
+   It also selects the project Runtime Profile and starts the local Runtime before any managed
+   capability is used.
 7. **Comparing against a mock.** It produces mock media for unbuilt generations, renders the complete
    composition in Studio, compares what it sees with the reference or brief, and repairs issues such
    as incorrect timing, hierarchy, cropping, captions or visual density.
@@ -142,10 +143,11 @@ Only after you explicitly approve the mock should you ask for the paid Build:
 The mock is approved. Submit the paid Build and create the final video.
 ```
 
-The Agent summarizes the selected models, expected external work and estimated cost before it starts.
-It then submits the Build, follows its progress and reports any provider or runtime issue in plain
-language. A paid Build is the step that performs the real generation, media processing and final
-rendering; the earlier mock does not silently trigger those billable operations.
+The Agent summarizes every selected Provider, credential source, expected external work and estimated
+cost before it starts, then waits for your approval. It submits the Build only after approval, follows
+its progress and reports any Provider or Runtime issue in plain language. A paid Build is the step that
+performs the real generation, media processing and final rendering; the earlier mock does not silently
+trigger those billable operations.
 
 ## 7. Review the paid result
 

--- a/docs/quickstart/run.md
+++ b/docs/quickstart/run.md
@@ -207,7 +207,8 @@ change installed packages. See [Runtime](../guide/runtime.md) for the Profile sc
 `check` and `plan` never make live Provider requests. A graph-only `plan` without a selected Runtime
 needs no deployment credentials; with a selected Runtime, its cheap preflight checks that demanded
 credential references are present. Before `doctor` or a paid/external `build`, configure only the
-variables referenced by the selected Runtime Profile:
+credentials referenced by the selected Runtime Profile. For the default HypiHub route, use OAuth;
+it stores the session in the OS credential store and does not require exporting `HYPIHUB_API_KEY`:
 
 | Variable | Provider/use |
 |---|---|
@@ -215,7 +216,10 @@ variables referenced by the selected Runtime Profile:
 | `KIE_API_KEY` | Explicit KIE Provider only |
 | `MIMO_API_KEY` | Xiaomi MiMo VoiceDesign, only when the official Endpoint is explicitly selected |
 
-Run only the lines for the Endpoints in your Profile. In macOS/Linux shells:
+The environment-variable examples below are only for an explicitly selected API-key credential
+fallback or for a Provider that declares an environment store. Do not set them when using HypiHub
+OAuth unless your Runtime Profile explicitly references that environment variable. In macOS/Linux
+shells:
 
 ```bash
 read -r -s HYPIHUB_API_KEY

--- a/docs/zh/guide/develop.md
+++ b/docs/zh/guide/develop.md
@@ -11,12 +11,13 @@ description: 开始 Hypit 开发工作。
 |---|---|---|
 | Node.js | 22+ | 所有工作 |
 | pnpm | 10.33.x | workspace 管理；由根目录 `packageManager` 字段选择 |
-| Python | 3.10–3.13 | 本地 WhisperX 与 OpenCV Managed Program |
+| Python | 3.10–3.13（OpenCV：3.13） | 本地 WhisperX 与 OpenCV Managed Program |
 | uv | latest | Python 环境管理 |
 | ffmpeg / ffprobe | 较新的稳定版 | 媒体处理 |
 | Chrome / Chromium | 由 HyperFrames 管理 | 本地 HyperFrames 渲染 |
 
-只有 Node.js 与 pnpm 是硬性要求。其余都只在跑真实 Builds 时才需要。
+对于仓库开发，只有 Node.js 与 pnpm 是硬性要求。处理 Managed WhisperX 或 OpenCV 服务时需要
+Python/uv；运行媒体或视觉渲染测试以及真实 Build 时还需要 ffmpeg/ffprobe 和浏览器。
 
 ## 日常工作流
 
@@ -41,7 +42,7 @@ hypit/
 ├── packages/              workspace packages
 ├── docs/                  VitePress documentation site
 ├── examples/              runnable example sources
-├── services/              Python 服务 (whisperx, image-opencv)
+├── services/              Managed 服务与部署适配器（whisperx、image-opencv、yt-dlp、media-lambda）
 ├── test/                  repository boundary tests and shared fixtures
 ├── package.json           root workspace manifest
 ├── pnpm-workspace.yaml    workspace: [packages/*]

--- a/docs/zh/quickstart.md
+++ b/docs/zh/quickstart.md
@@ -53,14 +53,13 @@ npx skills add hypit-ai/hypit -g
 
 你还可以补充目标受众、时长、语言、语气、品牌色、主持人、发布平台或画幅比例等要求。Agent 会把 brief 转换成完整计划，并自行补全制作所需的细节。
 
-## 3. 按 Agent 提示提供凭据
+## 3. 配置凭据
 
 <video controls playsInline preload="metadata" width="100%" src="../quickstart/videos/provide_credentials_when_the_agent_asks.mp4"></video>
 
-在你描述视频之后，Agent 会检查项目需要哪些模型和服务。如果缺少必要凭据，Agent 会向你询问，并说明该凭据的用途。你可以选择两种方式：
+在你描述视频之后，Agent 会检查项目需要哪些模型和服务。对于 Hypit 托管模型，Hypit 默认使用 HypiHub OAuth。如果缺少该凭据，请告诉 Agent 登录 HypiHub；Agent 会自己运行登录命令、打开浏览器流程，并把会话保存到系统安全凭据存储中。登录本身不会提交付费生成任务。
 
-1. **使用 Hypit 推荐的 hypit.ai OAuth 登录。** 告诉 Agent 通过 hypit.ai 登录。一次 OAuth 登录即可覆盖 Hypit 托管服务提供的所有模型，不需要为每个模型分别收集 key。
-2. **使用你自己的 Provider key。** 你可以直接和 Agent 约定要使用哪些模型，并提供相应 Provider 的 API key。Agent 只会索取当前项目需要的 key，不会询问无关凭据。
+只有在你明确选择自有 Provider 时，才配置它的 API key。Agent 只会请求所选 Runtime Profile 声明的凭据；某个凭据不可用时，不会悄悄切换到其他 Provider。
 
 不要把密钥粘贴到公开文档中，也不要提交到 Git。Agent 会使用已配置的安全凭据存储来保存这些凭据。
 
@@ -68,14 +67,14 @@ npx skills add hypit-ai/hypit -g
 
 <video controls playsInline preload="metadata" width="100%" src="../quickstart/videos/let_the_agent_do_the_production_work.mp4"></video>
 
-收到 brief 后，Agent 会在不要求你编写源码的情况下自动推进项目。制作过程中不会询问任何问题，你只需等待 Studio mock。具体顺序会因视频而不同，但通常包括：
+收到 brief 后，Agent 会在不要求你编写源码的情况下自动推进项目。通常会直接推进到 Studio mock；但如果参考视频或 brief 没有明确重要的剪辑细节，Agent 可能会提出一个聚焦的澄清问题。具体顺序会因视频而不同，但通常包括：
 
 1. **拆分镜头。** Agent 识别口播段落、视觉节拍、转场、字幕、B-roll 机会，以及 ranking 板等需要持续保持的元素。
 2. **分析参考视频或 brief。** 复刻路线会使用 Gemini 和可用的媒体工具检查节奏、构图、文字、说话人和视觉连续性；原创路线则根据你的描述和确定的创作方向回答同样的问题。
 3. **自行确定细节。** Agent 会根据参考视频、brief 和观察结果自动确定时机、语言、产品位置和主持人处理方式。
 4. **读取现有 package 声明。** 在自行发明实现之前，Agent 会检查项目和 Hypit 官方 package 中已有的组件。如果已有合适的字幕、ranking、主持人、B-roll 或渲染组件，就直接复用。
 5. **必要时编写新 package。** 如果确实缺少所需的视觉行为，Agent 会创建一个足够小、可复用的新组件，并记录它的使用方式。你不需要自行设计 package 接口。
-6. **编写并检查源码。** Agent 会写出 SVML/SVS 源码，创建所需的 Run 配置，编译视频图，并修复发现的类型或布局问题。
+6. **编写并检查源码。** Agent 会写出 SVML/SVS 源码，创建所需的 Run 配置，编译视频图，并修复发现的类型或布局问题。使用任何 Managed capability 之前，Agent 还会选择项目 Runtime Profile 并启动本地 Runtime。
 7. **与 mock 对比。** 对尚未真正生成的素材使用 mock，随后在 Studio 中渲染完整构图；Agent 会把看到的结果与参考视频或 brief 对比，修复时机、层级、裁切、字幕和画面密度等问题。
 8. **按照要求完成修改。** 基础视频确定后，Agent 会根据你的要求完成定制，例如更换画面中的人物，或替换成你的产品，然后检查修改后的结果。
 
@@ -103,7 +102,7 @@ Agent 会修改源码、重新检查并返回更新后的 mock。
 mock 没有问题。请提交付费 Build 并生成最终视频。
 ```
 
-开始之前，Agent 会向你总结将使用的模型、预计执行的外部工作和预估费用。随后它会提交 Build、跟踪进度，并用书面化的语言报告 Provider 或 Runtime 问题。付费 Build 才会执行真实的素材生成、媒体处理和最终渲染；之前的 mock 不会自动触发这些计费操作。
+开始之前，Agent 会向你总结所有选定的 Provider、凭据来源、预计执行的外部工作和预估费用，并等待你的确认。确认后它才会提交 Build、跟踪进度，并用书面化的语言报告 Provider 或 Runtime 问题。付费 Build 才会执行真实的素材生成、媒体处理和最终渲染；之前的 mock 不会自动触发这些计费操作。
 
 ## 7. 查看付费 Build 的结果
 

--- a/docs/zh/quickstart/run.md
+++ b/docs/zh/quickstart/run.md
@@ -181,7 +181,8 @@ hypit paths
 
 `check` 与 `plan` 不会请求在线 Provider。没有所选 Runtime 的 `plan` 只看图，不需要部署
 凭据；有 Runtime 时，便宜预检会检查本次 Plan 所需凭据是否存在。在运行 `doctor` 或付费/
-外部 `build` 之前，只配置当前 Runtime Profile 实际引用的环境变量：
+外部 `build` 之前，只配置当前 Runtime Profile 实际引用的凭据。默认的 HypiHub 路径使用
+OAuth；会话保存在系统凭据存储中，不需要导出 `HYPIHUB_API_KEY`：
 
 | 变量 | Provider / 用途 |
 |---|---|
@@ -189,7 +190,9 @@ hypit paths
 | `KIE_API_KEY` | 仅在显式选择 KIE Provider 时使用 |
 | `MIMO_API_KEY` | Xiaomi MiMo VoiceDesign；只有明确选择官方 Endpoint 时才需要 |
 
-只执行 Profile 中所选 Endpoint 对应的行。在 macOS/Linux Shell 中：
+下面的环境变量示例只适用于显式选择的 API key 凭据回退路径，或声明了环境变量存储的
+Provider。使用 HypiHub OAuth 时不要设置这些变量，除非 Runtime Profile 明确引用了对应的
+环境变量。在 macOS/Linux Shell 中：
 
 ```bash
 read -r -s HYPIHUB_API_KEY


### PR DESCRIPTION
同步英文和中文 Quickstart、Run、Develop 文档与当前 Hypit skill 行为。\n\n- 修正 HypiHub OAuth 默认流程与凭据说明\n- 说明 Agent 可能提出聚焦澄清问题\n- 明确付费 Build 前的 Provider/费用确认\n- 补充 Runtime 启动、Python 版本和服务目录信息\n- 文档构建已验证