### PR TITLE
config: set HypiHub concurrency to 3 and polling to 10s

### DIFF
--- a/examples/interview/hypit.runtime.json
+++ b/examples/interview/hypit.runtime.json
@@ -18,7 +18,8 @@
           "config": {
             "baseUrl": "https://hypit.ai",
             "apiKey": { "store": "os", "key": "hypihub.oauth" },
-            "defaultConcurrency": 4,
+            "defaultConcurrency": 3,
+            "pollIntervalMs": 10000,
             "requestTimeoutMs": 120000
           }
         },

--- a/examples/podcast/hypit.runtime.json
+++ b/examples/podcast/hypit.runtime.json
@@ -19,7 +19,8 @@
           "config": {
             "baseUrl": "https://hypit.ai",
             "apiKey": { "store": "os", "key": "hypihub.oauth" },
-            "defaultConcurrency": 4,
+            "defaultConcurrency": 3,
+            "pollIntervalMs": 10000,
             "requestTimeoutMs": 120000
           }
         },

--- a/examples/ranking-football/hypit.runtime.json
+++ b/examples/ranking-football/hypit.runtime.json
@@ -18,7 +18,8 @@
           "config": {
             "baseUrl": "https://hypit.ai",
             "apiKey": { "store": "os", "key": "hypihub.oauth" },
-            "defaultConcurrency": 4,
+            "defaultConcurrency": 3,
+            "pollIntervalMs": 10000,
             "requestTimeoutMs": 120000
           }
         },

--- a/examples/ranking-football/reference-banana-from-swap/hypit.runtime.json
+++ b/examples/ranking-football/reference-banana-from-swap/hypit.runtime.json
@@ -18,7 +18,8 @@
           "config": {
             "baseUrl": "https://hypit.ai",
             "apiKey": { "store": "os", "key": "hypihub.oauth" },
-            "defaultConcurrency": 4,
+            "defaultConcurrency": 3,
+            "pollIntervalMs": 10000,
             "requestTimeoutMs": 120000
           }
         },

--- a/examples/ranking-football/reference-banana/hypit.runtime.json
+++ b/examples/ranking-football/reference-banana/hypit.runtime.json
@@ -18,7 +18,8 @@
           "config": {
             "baseUrl": "https://hypit.ai",
             "apiKey": { "store": "os", "key": "hypihub.oauth" },
-            "defaultConcurrency": 4,
+            "defaultConcurrency": 3,
+            "pollIntervalMs": 10000,
             "requestTimeoutMs": 120000
           }
         },

--- a/examples/ranking-football/swap-effect-banana-reference-sync/hypit.runtime.json
+++ b/examples/ranking-football/swap-effect-banana-reference-sync/hypit.runtime.json
@@ -18,7 +18,8 @@
           "config": {
             "baseUrl": "https://hypit.ai",
             "apiKey": { "store": "os", "key": "hypihub.oauth" },
-            "defaultConcurrency": 4,
+            "defaultConcurrency": 3,
+            "pollIntervalMs": 10000,
             "requestTimeoutMs": 120000
           }
         },

--- a/examples/ranking-football/swap-effect-banana/hypit.runtime.json
+++ b/examples/ranking-football/swap-effect-banana/hypit.runtime.json
@@ -18,7 +18,8 @@
           "config": {
             "baseUrl": "https://hypit.ai",
             "apiKey": { "store": "os", "key": "hypihub.oauth" },
-            "defaultConcurrency": 4,
+            "defaultConcurrency": 3,
+            "pollIntervalMs": 10000,
             "requestTimeoutMs": 120000
           }
         },


### PR DESCRIPTION
将所有示例 Runtime Profile 中 HypiHub Endpoint 的显式配置统一为：\n\n- defaultConcurrency: 3\n- pollIntervalMs: 10000 (10 秒)\n\nProvider 代码默认值本身已经是这两个值；本 PR 修正会覆盖默认值的示例配置。已通过 TypeScript 检查。