### PR TITLE
fix: preserve Gemini media formats when preparing

### DIFF
--- a/packages/media-execution/src/execute.ts
+++ b/packages/media-execution/src/execute.ts
@@ -111,20 +111,20 @@ export async function executePrepareMedia(env: MediaExecutionEnvironment, constr
     const work = await mkdtemp(join(tmpdir(), "hypit-media-prepare-"));
     try {
       const input = join(work, "source.bin");
-      const output = join(work, "prepared.webp");
+      const output = join(work, "prepared.png");
       await writeFile(input, source);
-      await runProcess({ executable: env.ffmpegPath, argv: ["-y", "-i", input, "-frames:v", "1", "-vf", "scale='min(2048,iw)':-2", "-c:v", "libwebp", "-q:v", "75", output], timeoutMs: env.processTimeoutMs, maxStdoutBytes: 64 * 1024 });
-      return artifactResult(await env.artifacts.putFile(output, "image/webp"));
+      await runProcess({ executable: env.ffmpegPath, argv: ["-y", "-i", input, "-frames:v", "1", "-vf", "scale='min(2048,iw)':-2", "-c:v", "png", output], timeoutMs: env.processTimeoutMs, maxStdoutBytes: 64 * 1024 });
+      return artifactResult(await env.artifacts.putFile(output, "image/png"));
     } finally { await rm(work, { recursive: true, force: true }).catch(() => {}); }
   }
   if (need.source.mediaType.startsWith("audio/")) {
     const work = await mkdtemp(join(tmpdir(), "hypit-media-prepare-"));
     try {
       const input = join(work, "source.bin");
-      const output = join(work, "prepared.m4a");
+      const output = join(work, "prepared.mp3");
       await writeFile(input, source);
-      await runProcess({ executable: env.ffmpegPath, argv: ["-y", "-i", input, "-vn", "-c:a", "aac", "-b:a", "96k", "-movflags", "+faststart", output], timeoutMs: env.processTimeoutMs, maxStdoutBytes: 64 * 1024 });
-      return artifactResult(await env.artifacts.putFile(output, "audio/mp4"));
+      await runProcess({ executable: env.ffmpegPath, argv: ["-y", "-i", input, "-vn", "-c:a", "libmp3lame", "-b:a", "96k", output], timeoutMs: env.processTimeoutMs, maxStdoutBytes: 64 * 1024 });
+      return artifactResult(await env.artifacts.putFile(output, "audio/mpeg"));
     } finally { await rm(work, { recursive: true, force: true }).catch(() => {}); }
   }
   if (need.source.mediaType.startsWith("video/")) {

--- a/packages/media-execution/src/toolchain.ts
+++ b/packages/media-execution/src/toolchain.ts
@@ -4,7 +4,7 @@ export type MediaToolchainState =
   | { readonly state: "ready"; readonly ffprobeVersion: string; readonly ffmpegVersion?: string }
   | { readonly state: "down" | "mismatch"; readonly detail: string };
 
-const REQUIRED_ENCODERS = ["aac", "libx264", "pcm_s16le"] as const;
+const REQUIRED_ENCODERS = ["aac", "libmp3lame", "libx264", "pcm_s16le", "png"] as const;
 const REQUIRED_FILTERS = [
   "aformat", "amix", "aresample", "asetpts", "atempo", "atrim",
   "loop", "pad", "scale", "select", "setpts", "setsar", "trim",


### PR DESCRIPTION
Preserve caller media formats during implicit Gemini preparation.

- Images remain image/png; only resolution is reduced with lossless PNG encoding.
- Audio remains audio/mpeg; only MP3 bitrate is reduced.
- Video remains video/mp4; resolution and bitrate/CRF are reduced.
- No caller or graph API changes.

Validation: pnpm check and targeted existing tests pass.