### PR TITLE
fix: extend HypiHub request timeout to 300 seconds

### DIFF
--- a/packages/provider-hypihub/src/gemini.ts
+++ b/packages/provider-hypihub/src/gemini.ts
@@ -71,7 +71,7 @@ export function createHypiHubGeminiGenerator(options: HypiHubGeminiGeneratorOpti
     .replace(/\/(?:v1beta|v1)\/?$/iu, "")
     .replace(/\/$/u, "");
   const model = options.model?.trim() || "gemini-3.1-pro";
-  const timeout = options.requestTimeoutMs ?? 120_000;
+  const timeout = options.requestTimeoutMs ?? 300_000;
   const maxRateLimitRetries = options.maxRateLimitRetries ?? 3;
   assert(Number.isSafeInteger(maxRateLimitRetries) && maxRateLimitRetries >= 0,
     "HypiHub Gemini maxRateLimitRetries must be a non-negative integer");

--- a/packages/provider-hypihub/src/provider.ts
+++ b/packages/provider-hypihub/src/provider.ts
@@ -233,7 +233,7 @@ function endpoint(client: HypiHubClient, pollIntervalMs: number, maxOperationMs:
 }
 
 export function createHypiHubProvider(options: CreateHypiHubProviderOptions = {}) {
-  const client = new HypiHubClient({ baseUrl: apiBaseUrl(options.baseUrl ?? "https://hypit.ai/v1"), timeout: options.requestTimeoutMs ?? 30_000, fetcher: options.fetch ?? globalThis.fetch });
+  const client = new HypiHubClient({ baseUrl: apiBaseUrl(options.baseUrl ?? "https://hypit.ai/v1"), timeout: options.requestTimeoutMs ?? 300_000, fetcher: options.fetch ?? globalThis.fetch });
   const asyncEndpoint = endpoint(client, options.pollIntervalMs ?? 10_000, 20 * 60_000, options.publicAssetUrl);
   const audioEndpoint: ImmediateEndpointHandler = async (context) => {
     try {


### PR DESCRIPTION
Increase HypiHub Provider and Gemini request timeout defaults to 300 seconds. This keeps existing runtime JSON and explicit requestTimeoutMs overrides compatible while allowing large media uploads and long Gemini requests more time.