### PR TITLE
fix(hypihub): configure eight-file upload concurrency

### DIFF
--- a/packages/provider-hypihub/README.md
+++ b/packages/provider-hypihub/README.md
@@ -43,7 +43,16 @@ for every valid non-empty media file, including files compressed by the tool bef
 are uploaded concurrently through short-lived signed URLs, so media bytes do not make an extra trip
 through the HypiHub application server. A failed part alone is retried with a fresh signed URL.
 
-The server owns the part size, concurrency, and URL lifetime. Clients do not need to duplicate that
+Whole-file uploads default to **8 concurrent files** per origin/credential in a Node process,
+shared across Provider and Gemini uploader instances. Set `uploadConcurrency` (integer 1..64)
+in the Provider runtime configuration, `createHypiHubProvider`, or
+`createHypiHubGeminiGenerator` to change it. Extra files wait locally. If outstanding calls
+sharing a credential specify different limits, the lowest limit controls new starts until
+those calls finish; running uploads are allowed to drain. Separate processes still share
+the server's account session limit, which defaults to 64. These are configurable protection
+limits, not a claim about sustained network throughput.
+
+The server owns the part size, per-file part concurrency, and URL lifetime. Clients do not need to duplicate that
 policy. `uploadPartTimeoutMs` (default five minutes) and `uploadPartAttempts` (default three) only
 control client retry behavior. Signed S3 URLs are never included in Provider error messages. Uploads remain deduplicated by Artifact digest within one
 Runtime operation. Embedded callers may override the entire transport with `publicAssetUrl`.

--- a/packages/provider-hypihub/src/activation.ts
+++ b/packages/provider-hypihub/src/activation.ts
@@ -15,7 +15,7 @@ const adapter = createRuntimeEndpointAdapterFacet({
   activate(context) {
     if (context.pool === undefined) throw new Error("HypiHub Provider Pool is required");
     const config = runtimeConfigObject(context.config, "HypiHub");
-    runtimeConfigExact(config, ["baseUrl", "apiKey", "defaultConcurrency", "pollIntervalMs", "requestTimeoutMs", "audio", "whisperxModel"], "HypiHub");
+    runtimeConfigExact(config, ["baseUrl", "apiKey", "defaultConcurrency", "pollIntervalMs", "requestTimeoutMs", "uploadConcurrency", "audio", "whisperxModel"], "HypiHub");
     const baseUrl = runtimeConfigString(config.baseUrl, "HypiHub baseUrl");
     if (baseUrl !== undefined) {
       const url = new URL(baseUrl);
@@ -27,6 +27,7 @@ const adapter = createRuntimeEndpointAdapterFacet({
     if (apiKey === undefined) throw new Error("HypiHub apiKey CredentialRef is required");
     const defaultConcurrency = runtimeConfigPositiveInteger(config.defaultConcurrency, "HypiHub defaultConcurrency");
     const pollIntervalMs = runtimeConfigPositiveInteger(config.pollIntervalMs, "HypiHub pollIntervalMs");
+    const uploadConcurrency = runtimeConfigPositiveInteger(config.uploadConcurrency, "HypiHub uploadConcurrency");
     const requestTimeoutMs = runtimeConfigPositiveInteger(config.requestTimeoutMs, "HypiHub requestTimeoutMs");
     const audio = runtimeConfigBoolean(config.audio, "HypiHub audio");
     const whisperxModel = runtimeConfigString(config.whisperxModel, "HypiHub whisperxModel");
@@ -39,6 +40,7 @@ const adapter = createRuntimeEndpointAdapterFacet({
         ...(defaultConcurrency === undefined ? {} : { defaultConcurrency }),
         ...(pollIntervalMs === undefined ? {} : { pollIntervalMs }),
         ...(requestTimeoutMs === undefined ? {} : { requestTimeoutMs }),
+        ...(uploadConcurrency === undefined ? {} : { uploadConcurrency }),
         ...(audio === undefined ? {} : { audio }),
         ...(whisperxModel === undefined ? {} : { whisperxModel }),
       }),

--- a/packages/provider-hypihub/src/gemini.ts
+++ b/packages/provider-hypihub/src/gemini.ts
@@ -11,6 +11,8 @@ export type HypiHubGeminiGeneratorOptions = {
   readonly model?: string;
   readonly baseUrl?: string;
   readonly requestTimeoutMs?: number;
+  /** Whole file upload concurrency per origin/credential. Defaults to 8; range 1..64. */
+  readonly uploadConcurrency?: number;
   /** Timeout for one direct S3 multipart PUT. Defaults to five minutes. */
   readonly uploadPartTimeoutMs?: number;
   /** Attempts per direct S3 part. Defaults to three. */
@@ -91,6 +93,7 @@ export function createHypiHubGeminiGenerator(options: HypiHubGeminiGeneratorOpti
   const uploader = new HypiHubUploader({
     baseUrl,
     requestTimeoutMs: timeout,
+    ...(options.uploadConcurrency === undefined ? {} : { uploadConcurrency: options.uploadConcurrency }),
     ...(options.uploadPartTimeoutMs === undefined ? {} : { uploadPartTimeoutMs: options.uploadPartTimeoutMs }),
     ...(options.uploadPartAttempts === undefined ? {} : { uploadPartAttempts: options.uploadPartAttempts }),
     fetch: fetcher,

--- a/packages/provider-hypihub/src/provider.ts
+++ b/packages/provider-hypihub/src/provider.ts
@@ -28,6 +28,8 @@ export type CreateHypiHubProviderOptions = {
   readonly defaultConcurrency?: number;
   readonly pollIntervalMs?: number;
   readonly requestTimeoutMs?: number;
+  /** Whole file upload concurrency per origin/credential. Defaults to 8; range 1..64. */
+  readonly uploadConcurrency?: number;
   /** Timeout for one S3 multipart PUT. Defaults to five minutes. */
   readonly uploadPartTimeoutMs?: number;
   /** Attempts per S3 part; only a failed part is retried. Defaults to three. */
@@ -104,7 +106,7 @@ class HypiHubClient {
   readonly timeout: number;
   readonly fetcher: typeof globalThis.fetch;
   readonly uploader: HypiHubUploader;
-  constructor(options: { readonly baseUrl: string; readonly timeout: number; readonly uploadPartTimeout: number; readonly uploadPartAttempts: number; readonly fetcher: typeof globalThis.fetch }) {
+  constructor(options: { readonly baseUrl: string; readonly timeout: number; readonly uploadPartTimeout: number; readonly uploadPartAttempts: number; readonly uploadConcurrency: number; readonly fetcher: typeof globalThis.fetch }) {
     this.baseUrl = options.baseUrl.replace(/\/$/u, ""); this.timeout = options.timeout;
     this.fetcher = options.fetcher;
     this.uploader = new HypiHubUploader({
@@ -112,6 +114,7 @@ class HypiHubClient {
       requestTimeoutMs: this.timeout,
       uploadPartTimeoutMs: options.uploadPartTimeout,
       uploadPartAttempts: options.uploadPartAttempts,
+      uploadConcurrency: options.uploadConcurrency,
       fetch: this.fetcher,
     });
   }
@@ -265,7 +268,7 @@ export function createHypiHubProvider(options: CreateHypiHubProviderOptions = {}
     "HypiHub uploadPartTimeoutMs must be a positive integer");
   const client = new HypiHubClient({
     baseUrl: apiBaseUrl(options.baseUrl ?? "https://hypit.ai/v1"), timeout: options.requestTimeoutMs ?? 300_000,
-    uploadPartTimeout, uploadPartAttempts,
+    uploadPartTimeout, uploadPartAttempts, uploadConcurrency: options.uploadConcurrency ?? 8,
     fetcher: options.fetch ?? globalThis.fetch,
   });
   const apiKey = options.apiKey ?? credentialRef("os", "hypihub.oauth");
@@ -286,6 +289,7 @@ export function createHypiHubProvider(options: CreateHypiHubProviderOptions = {}
       model: context.need.capability.name,
       ...(options.baseUrl === undefined ? {} : { baseUrl: options.baseUrl }),
       ...(options.requestTimeoutMs === undefined ? {} : { requestTimeoutMs: options.requestTimeoutMs }),
+      ...(options.uploadConcurrency === undefined ? {} : { uploadConcurrency: options.uploadConcurrency }),
       ...(options.uploadPartTimeoutMs === undefined ? {} : { uploadPartTimeoutMs: options.uploadPartTimeoutMs }),
       ...(options.uploadPartAttempts === undefined ? {} : { uploadPartAttempts: options.uploadPartAttempts }),
       ...(options.fetch === undefined ? {} : { fetch: options.fetch }),

--- a/packages/provider-hypihub/src/upload.ts
+++ b/packages/provider-hypihub/src/upload.ts
@@ -55,6 +55,8 @@ class HypiHubHTTPError extends Error {
 export type HypiHubUploaderOptions = {
   readonly baseUrl: string;
   readonly requestTimeoutMs: number;
+  /** Whole files per origin/credential in this process. Defaults to 8; range 1..64. */
+  readonly uploadConcurrency?: number;
   readonly uploadPartTimeoutMs?: number;
   readonly uploadPartAttempts?: number;
   readonly fetch: typeof globalThis.fetch;
@@ -91,17 +93,29 @@ function assertHTTPS(value: string, subject: string): void {
 
 // A provider can upload references from several operations/uploader instances.
 // Bound whole file sessions, independently of each file's S3 part concurrency.
-const uploadGates = new Map<string, { active: number; waiting: (() => void)[] }>();
-async function acquireUploadSlot(origin: string, auth: UploadAuth): Promise<() => void> {
+type UploadGate = { active: number; limits: Map<number, number>; waiting: (() => void)[] };
+const uploadGates = new Map<string, UploadGate>();
+function drainUploadGate(gate: UploadGate): void {
+  const limit = Math.min(...gate.limits.keys());
+  while (gate.active < limit && gate.waiting.length > 0) {
+    gate.active += 1;
+    gate.waiting.shift()!();
+  }
+}
+async function acquireUploadSlot(origin: string, auth: UploadAuth, limit: number): Promise<() => void> {
   const key = `${origin}:${createHash("sha256").update(await uploadToken(auth)).digest("hex")}`;
   let gate = uploadGates.get(key);
-  if (gate === undefined) { gate = { active: 0, waiting: [] }; uploadGates.set(key, gate); }
-  if (gate.active < 2) gate.active += 1;
-  else await new Promise<void>((resolve) => gate.waiting.push(resolve));
+  if (gate === undefined) { gate = { active: 0, limits: new Map(), waiting: [] }; uploadGates.set(key, gate); }
+  // Instances sharing a credential share capacity. The strictest outstanding
+  // caller wins; a lower limit drains existing work without cancelling it.
+  gate.limits.set(limit, (gate.limits.get(limit) ?? 0) + 1);
+  await new Promise<void>((resolve) => { gate.waiting.push(resolve); drainUploadGate(gate); });
   return () => {
-    const next = gate.waiting.shift();
-    if (next !== undefined) next();
-    else { gate.active -= 1; if (gate.active === 0) uploadGates.delete(key); }
+    gate.active -= 1;
+    const remaining = (gate.limits.get(limit) ?? 1) - 1;
+    if (remaining === 0) gate.limits.delete(limit); else gate.limits.set(limit, remaining);
+    drainUploadGate(gate);
+    if (gate.active === 0 && gate.waiting.length === 0) uploadGates.delete(key);
   };
 }
 
@@ -109,6 +123,7 @@ async function acquireUploadSlot(origin: string, auth: UploadAuth): Promise<() =
 export class HypiHubUploader {
   readonly baseUrl: string;
   readonly requestTimeout: number;
+  readonly uploadConcurrency: number;
   readonly uploadPartTimeout: number;
   readonly uploadPartAttempts: number;
   readonly fetcher: typeof globalThis.fetch;
@@ -117,6 +132,8 @@ export class HypiHubUploader {
   constructor(options: HypiHubUploaderOptions) {
     this.baseUrl = apiBaseUrl(options.baseUrl);
     this.requestTimeout = requiredInteger(options.requestTimeoutMs, "HypiHub upload request timeout");
+    this.uploadConcurrency = requiredInteger(options.uploadConcurrency ?? 8, "HypiHub uploadConcurrency");
+    assert(this.uploadConcurrency <= 64, "HypiHub uploadConcurrency must be within 1..64");
     this.uploadPartTimeout = requiredInteger(options.uploadPartTimeoutMs ?? 5 * 60_000,
       "HypiHub upload part timeout");
     this.uploadPartAttempts = requiredInteger(options.uploadPartAttempts ?? 3,
@@ -348,7 +365,7 @@ export class HypiHubUploader {
   }
 
   async upload(input: HypiHubUploadInput, auth: UploadAuth): Promise<string> {
-    const release = await acquireUploadSlot(this.baseUrl, auth);
+    const release = await acquireUploadSlot(this.baseUrl, auth, this.uploadConcurrency);
     try { return await this.uploadWithSlot(input, auth); }
     finally { release(); }
   }

--- a/packages/provider-hypihub/test/gemini.test.ts
+++ b/packages/provider-hypihub/test/gemini.test.ts
@@ -3,6 +3,31 @@ import test from "node:test";
 
 import { createHypiHubGeminiGenerator } from "../src/gemini.js";
 
+test("Gemini honors configured concurrency while uploading a batch of unique references", async () => {
+  let active = 0; let peak = 0; let created = 0;
+  let release!: () => void;
+  const barrier = new Promise<void>((resolve) => { release = resolve; });
+  const generate = createHypiHubGeminiGenerator({ apiKey: "gemini-capacity-test", uploadConcurrency: 3, logger: () => {}, fetch: async (resource, init) => {
+    const url = String(resource);
+    if (url.endsWith("/files/uploads")) {
+      created += 1; active += 1; peak = Math.max(peak, active);
+      return Response.json({ upload_mode: "s3_multipart", upload_id: `up_${created}`, part_size: 16, part_count: 1, concurrency: 4 });
+    }
+    if (url.endsWith("/parts")) {
+      const body = JSON.parse(String(init?.body)) as { parts: { checksum_sha256: string }[] };
+      return Response.json({ parts: [{ part_number: 1, url: "https://s3.test/part", headers: { "content-length": "1", "x-amz-checksum-sha256": body.parts[0]!.checksum_sha256 } }] });
+    }
+    if (url === "https://s3.test/part") return new Response(null, { headers: { etag: "etag" } });
+    if (url.endsWith("/complete")) { await barrier; active -= 1; return Response.json({ url: "https://hub.test/files/ref" }); }
+    assert.equal(active, 0); assert.equal(created, 12);
+    return Response.json({ candidates: [{ content: { parts: [{ text: "OK" }] } }] });
+  } });
+  const result = generate({ instruction: "inspect", parts: Array.from({ length: 12 }, (_, i) => ({ inlineData: { mimeType: "image/png", data: Buffer.from([i]).toString("base64") } })) });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(created, 3);
+  release(); assert.equal(await result, "OK"); assert.equal(peak, 3);
+});
+
 test("HypiHub Gemini uses native wire format for text, image and video parts", async () => {
   let seenUrl = "";
   let seenBody: Record<string, unknown> | undefined;

--- a/packages/provider-hypihub/test/upload.test.ts
+++ b/packages/provider-hypihub/test/upload.test.ts
@@ -22,7 +22,7 @@ function fixture(hook: (url: string, init: RequestInit, calls: string[]) => Resp
     if (init.method === "DELETE") return new Response(null, { status: 204 });
     throw new Error(`unexpected request ${url}`);
   };
-  const uploader = () => new HypiHubUploader({ baseUrl: "https://hub.test", requestTimeoutMs: 5000, uploadPartAttempts: 1, fetch: fetcher, logger: (message) => logs.push(message) });
+  const uploader = (uploadConcurrency?: number) => new HypiHubUploader({ ...(uploadConcurrency === undefined ? {} : { uploadConcurrency }), baseUrl: "https://hub.test", requestTimeoutMs: 5000, uploadPartAttempts: 1, fetch: fetcher, logger: (message) => logs.push(message) });
   return { uploader, calls, logs };
 }
 
@@ -105,12 +105,12 @@ test("file concurrency is shared across uploader instances for the same origin a
       return Response.json({ url: "https://hub.test/files/result" });
     }
   });
-  const uploads = Array.from({ length: 6 }, () => f.uploader().upload(input, "test-key"));
+  const uploads = Array.from({ length: 50 }, () => f.uploader().upload(input, "test-key"));
   await new Promise<void>((resolve) => setImmediate(resolve));
-  assert.equal(nextId, 2);
+  assert.equal(nextId, 8);
   release();
   await Promise.all(uploads);
-  assert.equal(nextId, 6); assert.equal(maximum, 2); assert.equal(active, 0);
+  assert.equal(nextId, 50); assert.equal(maximum, 8); assert.equal(active, 0);
 });
 
 test("cancellation waits for other in-flight part workers to settle", async () => {
@@ -133,4 +133,80 @@ test("invalid negotiated policy still cancels its known upload session", async (
     ? Response.json({ upload_mode: "s3_multipart", upload_id: "up_test", part_size: 0 }) : undefined);
   await assert.rejects(f.uploader().upload(input, "test-key"), /part size/u);
   assert.equal(f.calls.filter((c) => c.startsWith("DELETE")).length, 1);
+});
+
+test("configured file concurrency controls batches and releases capacity after failures", async () => {
+  for (const limit of [1, 4, 16]) {
+    let active = 0; let maximum = 0; let created = 0;
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => { release = resolve; });
+    const f = fixture(async (url, init) => {
+      if (url.endsWith("/files/uploads")) {
+        active += 1; maximum = Math.max(maximum, active); created += 1;
+        return Response.json({ upload_mode: "s3_multipart", upload_id: `up_${created}`, part_size: 16, part_count: 1, concurrency: 4 });
+      }
+      if (url.endsWith("/complete")) { await barrier; throw new Error("completion unavailable"); }
+      if (init.method === "DELETE") { active -= 1; return new Response(null, { status: 204 }); }
+    });
+    // A terminal response avoids retry sleeps; all files must still drain.
+    const original = f.uploader(limit).fetcher;
+    const uploader = new HypiHubUploader({ baseUrl: "https://hub.test", requestTimeoutMs: 5000, uploadConcurrency: limit, logger: () => {}, fetch: async (resource, init) => {
+      try { return await original(resource, init); }
+      catch { return Response.json({ error: { code: "invalid_completion" } }, { status: 400 }); }
+    } });
+    const pending = Array.from({ length: 50 }, () => uploader.upload(input, `configured-${limit}`));
+    const settled = Promise.allSettled(pending);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(created, limit);
+    release();
+    assert((await settled).every((r) => r.status === "rejected"));
+    assert.equal(created, 50); assert.equal(maximum, limit); assert.equal(active, 0);
+  }
+});
+
+test("the strictest outstanding instance limit is shared and disappears when it drains", async () => {
+  let active = 0; let created = 0; let phaseMaximum = 0;
+  let release!: () => void;
+  const barrier = new Promise<void>((resolve) => { release = resolve; });
+  const f = fixture(async (url) => {
+    if (url.endsWith("/files/uploads")) {
+      active += 1; phaseMaximum = Math.max(phaseMaximum, active); created += 1;
+      return Response.json({ upload_mode: "s3_multipart", upload_id: `up_${created}`, part_size: 16, part_count: 1, concurrency: 4 });
+    }
+    if (url.endsWith("/complete")) { await barrier; active -= 1; return Response.json({ url: "https://hub.test/files/result" }); }
+  });
+  const low = f.uploader(2); const high = f.uploader(8);
+  const pending = [low.upload(input, "mixed-limit"), low.upload(input, "mixed-limit"), ...Array.from({ length: 12 }, () => high.upload(input, "mixed-limit"))];
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(created, 2);
+  release(); await Promise.all(pending);
+  assert.equal(active, 0); assert.equal(phaseMaximum, 8);
+});
+
+test("file and part concurrency remain separate for a multipart batch", async () => {
+  let puts = 0; let peakPuts = 0; let creates = 0;
+  let release!: () => void;
+  const barrier = new Promise<void>((resolve) => { release = resolve; });
+  const f = fixture(async (url) => {
+    if (url.endsWith("/files/uploads")) {
+      creates += 1;
+      return Response.json({ upload_mode: "s3_multipart", upload_id: `up_${creates}`, part_size: 1, part_count: 4, concurrency: 4 });
+    }
+    if (url.startsWith("https://s3.test/")) {
+      puts += 1; peakPuts = Math.max(peakPuts, puts);
+      await barrier; puts -= 1;
+      return new Response(null, { headers: { etag: "etag" } });
+    }
+  });
+  const pending = Array.from({ length: 12 }, () => f.uploader().upload(input, "multipart-batch"));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(creates, 8); assert.equal(puts, 32);
+  release(); await Promise.all(pending);
+  assert.equal(creates, 12); assert.equal(puts, 0); assert.equal(peakPuts, 32);
+});
+
+test("invalid uploadConcurrency is rejected before network activity", () => {
+  const f = fixture();
+  for (const value of [0, -1, 1.5, 65, NaN]) assert.throws(() => f.uploader(value), /uploadConcurrency/u);
+  assert.equal(f.calls.length, 0);
 });


### PR DESCRIPTION
Whole-file uploads were fixed at two across uploader instances, causing batches of mostly single-part references to queue unnecessarily. Default to eight and expose uploadConcurrency (1..64) through Provider runtime configuration, programmatic Provider, and Gemini options.

Keep a shared origin/credential queue. The strictest outstanding caller limit governs new starts, and draining those callers restores the remaining configuration. File concurrency remains separate from server-negotiated part concurrency; retain cancellation and retry recovery.

Validation: 31 provider-hypihub tests pass, including 50-file batches, configured limits, shared instances, failure draining, 12 multipart files with independent file/part limits, and Gemini option propagation. Full pnpm check passes. These mocked transport tests verify scheduling, not real S3 throughput. Server companion: hypit-ai/hypihub#25.
