### PR TITLE
fix: keep the Worker alive and let fetch cross volumes on Windows

### DIFF
--- a/packages/runtime-local/src/programs.ts
+++ b/packages/runtime-local/src/programs.ts
@@ -166,7 +166,7 @@ function windowsCommandLine(args: readonly string[]): string {
  * its own beside the log; `-PassThru` reports the new process, which is the pid everything after this
  * waits on and stores.
  */
-async function startWithOwnConsole(
+export async function startWithOwnConsole(
   start: ManagedProgramCommand,
   root: string,
   logPath: string,

--- a/packages/runtime-local/src/worker-process.ts
+++ b/packages/runtime-local/src/worker-process.ts
@@ -6,6 +6,7 @@ import { dirname, join, resolve } from "node:path";
 import { canonicalStringify } from "@hypit/protocol";
 
 import { processAlive, stopProcessTree } from "./process-control.js";
+import { startWithOwnConsole } from "./programs.js";
 
 export type RuntimeWorkerLaunch = {
   readonly command: string;
@@ -215,26 +216,42 @@ export async function ensureRuntimeProcess(
     await rm(location.ready, { force: true });
     await rotateLog(location.log);
     const log = await open(location.log, "a");
-    let child;
+    const workerArgs = [
+      ...launch.args,
+      "_worker",
+      absolute,
+      "--ready-file",
+      location.ready,
+      "--worker-owner",
+      owner,
+      ...(launch.workerArgs ?? []),
+    ];
+    let child: { readonly pid?: number | undefined; readonly unref?: (() => unknown) | undefined };
     try {
-      child = spawn(launch.command, [
-        ...launch.args,
-        "_worker",
-        absolute,
-        "--ready-file",
-        location.ready,
-        "--worker-owner",
-        owner,
-        ...(launch.workerArgs ?? []),
-      ], {
-        cwd: process.cwd(),
-        // See the managed program start in `programs.ts`: on Windows, detaching costs the console and
-        // every console descendant then gets a window of its own.
-        detached: process.platform !== "win32",
-        windowsHide: true,
-        stdio: ["ignore", log.fd, log.fd],
-        env: process.env,
-      });
+      // Outliving this CLI process is the point, and what grants it differs by platform. Windows
+      // ties a process to the console it inherits, so a plain child died with the command that
+      // started it and its Builds then sat at `0/n steps` with an empty Worker log. `programs.ts`
+      // explains why a hidden console of its own is the combination neither spawn option reaches.
+      if (process.platform === "win32") {
+        const started = await startWithOwnConsole(
+          { command: launch.command, args: workerArgs, cwd: process.cwd() },
+          process.cwd(),
+          location.log,
+        );
+        if (started.pid === undefined) {
+          const refusal = started.detail === undefined ? "" : `: ${started.detail}`;
+          throw new Error(`Runtime Worker process did not start${refusal}`);
+        }
+        child = { pid: started.pid };
+      } else {
+        child = spawn(launch.command, workerArgs, {
+          cwd: process.cwd(),
+          detached: true,
+          windowsHide: true,
+          stdio: ["ignore", log.fd, log.fd],
+          env: process.env,
+        });
+      }
       if (child.pid === undefined) throw new Error("Runtime Worker process has no pid");
       const startedAt = Date.now();
       await writeFile(location.pid, JSON.stringify({
@@ -244,7 +261,7 @@ export async function ensureRuntimeProcess(
         pid: child.pid,
         startedAt,
       } satisfies ProcessRecord), "utf8");
-      child.unref();
+      child.unref?.();
       try {
         const ready = await waitForReady(absolute, dataRoot, owner, timeoutMs);
         if (ready.configuration === "changed") {

--- a/packages/yt-dlp/src/download.ts
+++ b/packages/yt-dlp/src/download.ts
@@ -12,7 +12,7 @@
  */
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, readdir, rename, rm } from "node:fs/promises";
+import { copyFile, mkdtemp, readdir, rename, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -88,7 +88,16 @@ export async function downloadVideo(url: string, target: string): Promise<void> 
     const finished = (await readdir(work)).filter((name) => !name.endsWith(".part"));
     const [file] = finished.sort();
     if (file === undefined) throw new Error(`yt-dlp reported success for ${url} but wrote no file`);
-    await rename(join(work, file), target);
+    const staged = join(work, file);
+    try {
+      await rename(staged, target);
+    } catch (cause) {
+      // Staging lives in the OS temp directory, which is often on a different volume from the
+      // project. A rename cannot cross volumes, so copy the bytes over instead; the staging
+      // directory is removed either way.
+      if ((cause as NodeJS.ErrnoException).code !== "EXDEV") throw cause;
+      await copyFile(staged, target);
+    }
   } finally {
     await rm(work, { recursive: true, force: true });
   }


### PR DESCRIPTION
Two Windows-only defects hit while producing a video on this platform. Both are small and
independent; each is its own commit.

## The Worker died with the shell that started it

Windows ties a process's lifetime to the console it is attached to, and the Worker inherited the
launching CLI's. When that command exited, its console was destroyed and every process on it was
terminated — so a submitted Build sat at `0/n steps` with an empty Worker log and no error anywhere
to read. `hypit runtime status` reported `stopped` immediately after `runtime up` reported `running`.

`programs.ts` had already solved exactly this for Managed Programs, and its comment explains why
neither `spawn` option reaches the needed combination: `detached` on Windows means DETACHED_PROCESS,
which is no console at all, and then the first console grandchild allocates a fresh visible one.
`Start-Process -WindowStyle Hidden` creates a console of its own and hides it.

This exports that existing `startWithOwnConsole` helper and uses it for the Worker. POSIX keeps
`detached: true`, which is what grants it its own session there.

## `media fetch` failed with EXDEV

Staging is an `mkdtemp` directory in the OS temp location, routinely on a different volume from the
project. A rename cannot cross volumes, so the video downloaded in full and then failed:

```
EXDEV: cross-device link not permitted, rename
'C:\Users\...\Temp\hypit-fetch-XXXX\video.mp4' -> 'D:\...\reference.mp4'
```

Falls back to copying the bytes when rename reports EXDEV. Any other rename failure still
propagates, and the staging directory is removed either way.

## Verification

- `runtime up` in one shell, then `runtime status` from a separate command: Worker `running`
  (previously `stopped`).
- `media fetch` with temp on `C:` and the destination on `D:`: succeeds, video and audio together.
- `tsc -p tsconfig.json --noEmit` is clean on all three touched files. The repository's pre-existing
  error count is unchanged.

No behaviour change on POSIX. No new tests.
