### PR TITLE
fix(runtime): pass the hidden-console script as one encoded command

### DIFF
--- a/packages/runtime-local/src/programs.ts
+++ b/packages/runtime-local/src/programs.ts
@@ -161,10 +161,15 @@ function windowsCommandLine(args: readonly string[]): string {
 /**
  * Windows: a console of its own, hidden, so the launching console's destruction does not take it.
  *
- * The script is fed on stdin rather than as a command-line argument, so no quoting of ours crosses a
- * shell boundary. `Start-Process` refuses to send both streams to one file, so the error stream gets
- * its own beside the log; `-PassThru` reports the new process, which is the pid everything after this
- * waits on and stores.
+ * The script travels as one `-EncodedCommand` blob, so no quoting of ours crosses a shell boundary.
+ * Feeding it on stdin instead looks equivalent and is not: `-Command -` parses what it reads a
+ * statement at a time, so an argument holding a newline — `node -e` with a real script in it — ends
+ * the statement early and PowerShell exits having run nothing, with no process id and nothing on
+ * stderr to say why. Base64 has no line structure to trip over.
+ *
+ * `Start-Process` refuses to send both streams to one file, so the error stream gets its own beside
+ * the log; `-PassThru` reports the new process, which is the pid everything after this waits on and
+ * stores.
  */
 export async function startWithOwnConsole(
   start: ManagedProgramCommand,
@@ -189,9 +194,10 @@ export async function startWithOwnConsole(
   ].filter((line) => line.length > 0).join("\n");
 
   const shell = await new Promise<{ readonly out: string; readonly err: string }>((settle) => {
-    const child = spawn("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", "-"], {
+    const encoded = Buffer.from(script, "utf16le").toString("base64");
+    const child = spawn("powershell.exe", ["-NoProfile", "-NonInteractive", "-EncodedCommand", encoded], {
       windowsHide: true,
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
     let out = "";
     let err = "";
@@ -209,7 +215,6 @@ export async function startWithOwnConsole(
     // for the pipe to drain is what settles this, and `close` still settles it first when it comes.
     child.on("exit", () => { setTimeout(done, 250).unref(); });
     child.on("close", done);
-    child.stdin.end(script, "utf8");
   });
   const pid = Number(shell.out);
   if (Number.isSafeInteger(pid) && pid > 0) return { pid };


### PR DESCRIPTION
Regression from #186, found by running `pnpm test` locally while CI is down for billing.

## What broke

#186 routed the Worker through `startWithOwnConsole`, which feeds its PowerShell script on stdin via
`-Command -`. That parses what it reads a statement at a time, so an argument containing a real
newline ends the statement early. PowerShell then exits having run nothing — no process id, and
nothing on stderr to say why, so the only symptom is:

```
Runtime Worker process did not start: Start-Process reported no process id
```

Managed Programs are only ever handed single-line arguments, so the helper never showed this. The
Worker's real arguments are single-line too, but `ensureRuntimeProcess` accepts any
`RuntimeWorkerLaunch`, and `node -e <script>` is the ordinary shape for a stand-in worker — which is
exactly what `packages/runtime-local/test/worker-process.test.ts` passes it.

## The fix

Send the script as one `-EncodedCommand` blob. This keeps the property that made stdin attractive —
no quoting of ours crosses a shell boundary — and base64 has no line structure to end a statement
early. stdin is no longer used, so it is closed.

## Verification

- `packages/runtime-local/test/worker-process.test.ts` fails on `main`, passes here.
- Full suite: 682 tests, 674 pass, 7 skipped, 1 unrelated flake (`browser-capture` asserts a
  recording ran longer than 0.3 s and measured 0.29185 s under full-suite load; it passes 3/3 in
  isolation).
- `pnpm check` clean.

Both were run on Windows, where this code path lives.
