### PR TITLE
feat(tts): add Fish Audio voice design and voice clone as the defaults

### DIFF
--- a/packages/provider-hypihub/README.md
+++ b/packages/provider-hypihub/README.md
@@ -95,10 +95,13 @@ generation, alignment, Voice Design, and Voice Clone through the same mechanism;
 the Provider does not maintain a second list of billing formulas or calculate a request total.
 
 HypiHub declares every `@hypit/tts` capability together with every other capability it serves; it
-never hides one. Voice Design (MiMo `mimo-v2.5-tts-voicedesign` and ElevenLabs `eleven_ttv_v3`)
-maps to `POST /v1/audio/speech` with `input` and `voice_description` and produces an accepted
-voice-reference Resource; each returned preview becomes one member of the audio set. Voice Clone
-uses that reference to produce independent speech. Hypit does not expose preset voices. When another
+never hides one. Voice Design (Fish Audio `voice-design-1` → `fishaudio/voice-design-1`, MiMo
+`mimo-v2.5-tts-voicedesign` and ElevenLabs `eleven_ttv_v3`) maps to `POST /v1/audio/speech` with
+`input` and `voice_description` and produces an accepted voice-reference Resource; each returned
+preview becomes one member of the audio set. Voice Clone (Fish Audio `voice-clone` →
+`fishaudio/voice-clone`, MiMo `mimo-v2.5-tts-voiceclone`) sends `input`, `reference_audio` and an
+optional `prompt`; the Fish Audio route also sends the constant `voice_description` title the
+service requires for its transient voice. Hypit does not expose preset voices. When another
 selected Endpoint offers the same capability (a local WhisperX or the official MiMo
 Provider), the Runtime Profile's `bindings` say which Endpoint serves it.
 

--- a/packages/provider-hypihub/src/mapping.ts
+++ b/packages/provider-hypihub/src/mapping.ts
@@ -27,11 +27,21 @@ const seedance = (name: string, model: string): GenerationWireMapping => ({
   },
 });
 
-const voiceDesign = (model: string): GenerationWireMapping => ({
-  capability: { module: TTS, name: model }, result: "audio", routes: [{ model }],
+const voiceDesign = (name: string, model = name): GenerationWireMapping => ({
+  capability: { module: TTS, name }, result: "audio", routes: [{ model }],
   fields: {
     text: { as: "value", field: "input" },
     voiceDescription: { as: "value", field: "voice_description" },
+  },
+});
+
+const voiceClone = (name: string, model = name, constants?: GenerationWireMapping["constants"]): GenerationWireMapping => ({
+  capability: { module: TTS, name }, result: "audio", routes: [{ model }],
+  ...(constants === undefined ? {} : { constants }),
+  fields: {
+    text: { as: "value", field: "input" },
+    instruction: { as: "value", field: "prompt" },
+    voiceReference: { as: "urlArray", field: "reference_audio" },
   },
 });
 
@@ -125,16 +135,12 @@ export const hypiHubMappings: readonly GenerationWireMapping[] = [
       images: { as: "itemObject", field: "reference_images", urlKey: "url", fieldKeys: {} },
     },
   },
+  voiceDesign("voice-design-1", "fishaudio/voice-design-1"),
   voiceDesign("mimo-v2.5-tts-voicedesign"),
   voiceDesign("eleven_ttv_v3"),
-  {
-    capability: { module: TTS, name: "mimo-v2.5-tts-voiceclone" }, result: "audio", routes: [{ model: "mimo-v2.5-tts-voiceclone" }],
-    fields: {
-      text: { as: "value", field: "input" },
-      instruction: { as: "value", field: "prompt" },
-      voiceReference: { as: "urlArray", field: "reference_audio" },
-    },
-  },
+  // Fish Audio names its transient cloned voice; the title has no authored meaning.
+  voiceClone("voice-clone", "fishaudio/voice-clone", { voice_description: "reference" }),
+  voiceClone("mimo-v2.5-tts-voiceclone"),
 ];
 
 function capabilityKey(ref: CapabilityRef): string {

--- a/packages/provider-hypihub/test/provider.test.ts
+++ b/packages/provider-hypihub/test/provider.test.ts
@@ -274,9 +274,10 @@ test("HypiHub declares every TTS capability; who serves them is the Profile's bi
     }],
   });
   await other.install(registry);
-  assert.equal(registry.resolve(needs[0]!).status, "ambiguous");
+  const mimoDesign = needs.find((item) => item.id === "need:hypihub-voiceDesign")!;
+  assert.equal(registry.resolve(mimoDesign).status, "ambiguous");
   registry.bind(ttsEndpoints.voiceDesign.capability, "mimo.official");
-  const resolved = registry.resolve(needs[0]!);
+  const resolved = registry.resolve(mimoDesign);
   assert.equal(resolved.status, "resolved");
   assert.equal(resolved.status === "resolved" ? resolved.registration.id : undefined, "mimo.official");
 });

--- a/packages/tts/README.md
+++ b/packages/tts/README.md
@@ -2,13 +2,14 @@
 
 Exact model contracts and author Surfaces for voice design and voice clone speech synthesis.
 
-The package owns two distinct speech operations:
+The package owns two distinct speech operations, each served by exact models chosen with the
+`model` attribute:
 
 - Voice Design creates an ordinary audio voice reference from a natural-language description and a
-  short authored speech sample. Two exact models serve it: ElevenLabs `eleven_ttv_v3` (the
-  default) and Xiaomi `mimo-v2.5-tts-voicedesign`, chosen with the `model` attribute;
-- Voice Clone (`mimo-v2.5-tts-voiceclone`) uses one accepted audio voice reference to create
-  independent speech.
+  short authored speech sample: Fish Audio `voice-design-1` (`fish`, the default), Xiaomi
+  `mimo-v2.5-tts-voicedesign` (`mimo`) and ElevenLabs `eleven_ttv_v3` (`eleven`);
+- Voice Clone uses one accepted audio voice reference to create independent speech: Fish Audio
+  `voice-clone` (`fish`, the default) and Xiaomi `mimo-v2.5-tts-voiceclone` (`mimo`).
 
 It contains no API URL, credential, retry, queue or vendor wire encoding. Those belong to a Runtime
 Endpoint such as `@hypit/provider-hypihub` or `@hypit/provider-xiaomi-mimo`. Every model returns the
@@ -32,6 +33,7 @@ whichever model designed it.
 
 Official API references:
 
+- Fish Audio: <https://docs.fish.audio/>
 - Xiaomi MiMo: <https://mimo.mi.com/docs/zh-CN/quick-start/usage-guide/audio/speech-synthesis-v2.5>
 - ElevenLabs Voice Design: <https://elevenlabs.io/docs/api-reference/text-to-voice/design>
 

--- a/packages/tts/src/index.ts
+++ b/packages/tts/src/index.ts
@@ -7,8 +7,10 @@ import { textTypes } from "@hypit/text";
 
 export const ttsModuleRef = { name: "@hypit/tts", version: "1" } as const;
 export const ttsModels = [
+  "voice-design-1",
   "mimo-v2.5-tts-voicedesign",
   "eleven_ttv_v3",
+  "voice-clone",
   "mimo-v2.5-tts-voiceclone",
 ] as const;
 export type TtsModel = typeof ttsModels[number];
@@ -19,7 +21,7 @@ const spokenText = { kind: "text" } as const;
 const instruction = { kind: "text" } as const;
 
 function table(model: TtsModel): GenerationPortTable {
-  if (model === "mimo-v2.5-tts-voicedesign" || model === "eleven_ttv_v3") {
+  if (model === "voice-design-1" || model === "mimo-v2.5-tts-voicedesign" || model === "eleven_ttv_v3") {
     return sealGenerationPortTable({
       model,
       result: "audio",
@@ -42,11 +44,9 @@ function table(model: TtsModel): GenerationPortTable {
   });
 }
 
-export const ttsPorts: Readonly<Record<TtsModel, GenerationPortTable>> = {
-  "mimo-v2.5-tts-voicedesign": table("mimo-v2.5-tts-voicedesign"),
-  "eleven_ttv_v3": table("eleven_ttv_v3"),
-  "mimo-v2.5-tts-voiceclone": table("mimo-v2.5-tts-voiceclone"),
-};
+export const ttsPorts = Object.fromEntries(
+  ttsModels.map((model) => [model, table(model)]),
+) as Readonly<Record<TtsModel, GenerationPortTable>>;
 
 export function sealTtsRequest(
   model: TtsModel,
@@ -65,8 +65,10 @@ export function sealTtsRequestDraft(
 const base = defineExactModelModule({
   module: ttsModuleRef,
   endpoints: ([
+    ["fishVoiceDesign", "voice-design-1", "FishVoiceDesignRequest"],
     ["voiceDesign", "mimo-v2.5-tts-voicedesign", "MimoVoiceDesignRequest"],
     ["elevenVoiceDesign", "eleven_ttv_v3", "ElevenVoiceDesignRequest"],
+    ["fishVoiceClone", "voice-clone", "FishVoiceCloneRequest"],
     ["voiceClone", "mimo-v2.5-tts-voiceclone", "MimoVoiceCloneRequest"],
   ] as const).map(([key, model, requestTypeName]) => ({
     key,
@@ -78,10 +80,16 @@ const base = defineExactModelModule({
 
 export const ttsEndpoints = base.endpoints;
 export const voiceDesignEndpoints = {
+  "voice-design-1": ttsEndpoints.fishVoiceDesign,
   "mimo-v2.5-tts-voicedesign": ttsEndpoints.voiceDesign,
   "eleven_ttv_v3": ttsEndpoints.elevenVoiceDesign,
 } as const;
 export type VoiceDesignModel = keyof typeof voiceDesignEndpoints;
+export const voiceCloneEndpoints = {
+  "voice-clone": ttsEndpoints.fishVoiceClone,
+  "mimo-v2.5-tts-voiceclone": ttsEndpoints.voiceClone,
+} as const;
+export type VoiceCloneModel = keyof typeof voiceCloneEndpoints;
 
 const spokenAttributes: readonly SurfaceAttributeVocabulary[] = [
   {
@@ -123,8 +131,8 @@ export const ttsMarkupSurfaces = [
           name: "model",
           kind: "literal",
           required: false,
-          summary: "Chooses the exact voice design model; ElevenLabs when omitted.",
-          values: ["mimo", "mimo-v2.5-tts-voicedesign", "eleven", "eleven_ttv_v3"],
+          summary: "Chooses the exact voice design model; Fish Audio when omitted.",
+          values: ["fish", "voice-design-1", "mimo", "mimo-v2.5-tts-voicedesign", "eleven", "eleven_ttv_v3"],
         },
       ],
       ports: referencePort,
@@ -140,10 +148,10 @@ export const ttsMarkupSurfaces = [
   },
   {
     name: "voiceClone", tag: "VoiceClone", mode: "structured",
-    outputs: [
-      ttsEndpoints.voiceClone.draftType,
-      ...Object.values(ttsEndpoints.voiceClone.mediaBindings).map((binding) => binding.type),
-    ],
+    outputs: Object.values(voiceCloneEndpoints).flatMap((endpoint) => [
+      endpoint.draftType,
+      ...Object.values(endpoint.mediaBindings).map((binding) => binding.type),
+    ]),
     vocabulary: {
       summary: "Creates independent speech in the voice heard in one accepted audio reference.",
       attributes: [
@@ -154,6 +162,13 @@ export const ttsMarkupSurfaces = [
           required: true,
           summary: "The audio Resource carrying the voice identity to reproduce.",
           accepts: [artifactTypes.blob],
+        },
+        {
+          name: "model",
+          kind: "literal",
+          required: false,
+          summary: "Chooses the exact voice clone model; Fish Audio when omitted.",
+          values: ["fish", "voice-clone", "mimo", "mimo-v2.5-tts-voiceclone"],
         },
       ],
       ports: audioPort,

--- a/packages/tts/src/surface.ts
+++ b/packages/tts/src/surface.ts
@@ -13,8 +13,8 @@ import type {
 } from "@hypit/markup";
 
 import { createTtsAudioFragment } from "./fragment.js";
-import { ttsEndpoints, sealTtsRequestDraft, voiceDesignEndpoints } from "./index.js";
-import type { VoiceDesignModel } from "./index.js";
+import { sealTtsRequestDraft, voiceCloneEndpoints, voiceDesignEndpoints } from "./index.js";
+import type { VoiceCloneModel, VoiceDesignModel } from "./index.js";
 
 function sameType(left: SurfaceResolvedReference["type"], right: SurfaceResolvedReference["type"]): boolean {
   return left.module.name === right.module.name && left.module.version === right.module.version && left.name === right.name;
@@ -164,16 +164,26 @@ function speechInput(
   } as const;
 }
 
-function voiceDesignModel(element: StructuredElement): VoiceDesignModel {
-  const requested = element.attributes.model === undefined ? "eleven" : stringAttribute(element, "model");
-  if (requested === "mimo" || requested === "mimo-v2.5-tts-voicedesign") return "mimo-v2.5-tts-voicedesign";
-  if (requested === "eleven" || requested === "eleven_ttv_v3") return "eleven_ttv_v3";
-  throw new Error(`${element.name}.model must be mimo or eleven`);
+const voiceDesignModels: Readonly<Record<string, VoiceDesignModel>> = {
+  "fish": "voice-design-1", "voice-design-1": "voice-design-1",
+  "mimo": "mimo-v2.5-tts-voicedesign", "mimo-v2.5-tts-voicedesign": "mimo-v2.5-tts-voicedesign",
+  "eleven": "eleven_ttv_v3", "eleven_ttv_v3": "eleven_ttv_v3",
+};
+const voiceCloneModels: Readonly<Record<string, VoiceCloneModel>> = {
+  "fish": "voice-clone", "voice-clone": "voice-clone",
+  "mimo": "mimo-v2.5-tts-voiceclone", "mimo-v2.5-tts-voiceclone": "mimo-v2.5-tts-voiceclone",
+};
+
+function selectedModel<M extends string>(element: StructuredElement, models: Readonly<Record<string, M>>): M {
+  const requested = element.attributes.model === undefined ? "fish" : stringAttribute(element, "model");
+  const model = models[requested];
+  if (model === undefined) throw new Error(`${element.name}.model must be one of ${Object.keys(models).join(", ")}`);
+  return model;
 }
 
 export const decodeVoiceDesignSurface: StructuredSurfaceHandler = ({ element, resolveReference }) => {
   attributes(element, ["id", "speech"], ["model"]);
-  const model = voiceDesignModel(element);
+  const model = selectedModel(element, voiceDesignModels);
   return output(
     element,
     voiceDesignEndpoints[model],
@@ -184,14 +194,15 @@ export const decodeVoiceDesignSurface: StructuredSurfaceHandler = ({ element, re
 };
 
 export const decodeVoiceCloneSurface: StructuredSurfaceHandler = ({ element, resolveReference }) => {
-  attributes(element, ["id", "speech", "voice"]);
+  attributes(element, ["id", "speech", "voice"], ["model"]);
+  const model = selectedModel(element, voiceCloneModels);
   const instruction = body(element, false);
   const ports: Record<string, readonly GenerationPortValue[]> = {};
   if (instruction !== undefined) ports.instruction = [instruction];
   return output(
     element,
-    ttsEndpoints.voiceClone,
-    sealTtsRequestDraft("mimo-v2.5-tts-voiceclone", ports),
+    voiceCloneEndpoints[model],
+    sealTtsRequestDraft(model, ports),
     "audio",
     [speechInput(element, resolveReference)],
     [{

--- a/packages/tts/test/tts.test.ts
+++ b/packages/tts/test/tts.test.ts
@@ -53,7 +53,7 @@ const context = (source: string, voice: SurfaceResolvedReference = voiceReferenc
 });
 
 test("TTS declares the exact audio request shapes", () => {
-  assert.deepEqual(ttsModels, ["mimo-v2.5-tts-voicedesign", "eleven_ttv_v3", "mimo-v2.5-tts-voiceclone"]);
+  assert.deepEqual(ttsModels, ["voice-design-1", "mimo-v2.5-tts-voicedesign", "eleven_ttv_v3", "voice-clone", "mimo-v2.5-tts-voiceclone"]);
   assert.ok(Object.values(ttsPorts).every((ports) => ports.result === "audio"));
   assert.ok(Object.values(ttsEndpoints).every((endpoint) => endpoint.returns.name === generationTypes.audioSet.name));
   assert.throws(() => sealTtsRequest("mimo-v2.5-tts-voicedesign", {

--- a/skills/hypit/references/playbooks/craft/voice-and-performance.md
+++ b/skills/hypit/references/playbooks/craft/voice-and-performance.md
@@ -131,8 +131,9 @@ reusable voice and Voice Clone to perform the actual Segment; the casting sample
 delivery have different jobs.
 
 Use `hypit vocabulary @hypit/tts` for the installed Voice Design and Voice Clone author
-Surfaces. `<tts:VoiceDesign>` designs with ElevenLabs unless `model="mimo"` selects Xiaomi MiMo;
-either result is an ordinary audio Resource that Voice Clone and reference-audio video models accept.
+Surfaces. Both elements accept an optional `model`: Fish Audio when omitted, `mimo` for Xiaomi MiMo,
+and `eleven` for ElevenLabs Voice Design. Every result is an ordinary audio Resource that Voice Clone
+and reference-audio video models accept, whichever model produced it.
 The Source chooses those model semantics; the Runtime Profile independently chooses the
 Endpoint that can perform them.
 


### PR DESCRIPTION
## Summary

- Add `voice-design-1` and `voice-clone` to `@hypit/tts`, sharing the existing voice design / voice clone port tables, Surface decoders and HypiHub `/audio/speech` route with the MiMo models.
- `<tts:VoiceDesign>` and `<tts:VoiceClone>` both take an optional `model`: `fish` (default), `mimo`, and `eleven` for design. Sources that omit `model` now use Fish Audio for both operations.
- `provider-hypihub`: maps to `fishaudio/voice-design-1` and `fishaudio/voice-clone` through the shared `voiceDesign` / `voiceClone` mapping factories. The clone route sends the constant `voice_description` title the service requires (`missing_title` otherwise). `provider.ts` and `routes.ts` are unchanged.
- READMEs and the voice playbook describe the model choice.

## Verification

- `pnpm run check` passes; tts, provider-hypihub and provider-xiaomi-mimo suites pass (43 tests).
- `hypit check` passes on the three examples; `hypit plan` on the podcast example resolves VoiceDesign to `@hypit/tts#voice-design-1`.
- Live run through `createHypiHubProvider` with the stored OAuth credential: `voice-design-1` returned one 5.1 s WAV preview (450 KB) in 8.7 s; that preview was uploaded through the Provider transport and fed to `voice-clone` with an authored instruction, which returned a 4.1 s MP3 (66 KB) in 15.2 s.
